### PR TITLE
add inventory plugin

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -340,6 +340,24 @@ function inject(bot) {
       }
     }
   });
+
+  bot.interact = function(entity, leftClick) {
+    if (!leftClick) {
+      leftClick = true;
+    }
+    var target;
+    if (typeof entity === 'number') {
+      target = entity;
+    } else {
+      target = entity.id;
+    }
+    bot.client.write(0x07, {
+      user: bot.entity.id,
+      target: target,
+      leftClick: leftClick
+    });
+  };
+
 }
 
 function degreesToRadians(degrees) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,25 +1,11 @@
 module.exports = inject;
 
-function Slot(id, count, damage) {
-  this.id = id;
-  this.count = count;
-  this.damage = damage;
-}
-
-Slot.prototype.setDamage = function(damage) {
-  this.damage = damage;
-};
-
-Slot.prototype.setCount = function(count) {
-  this.count = count;
-};
-
 function inject(bot) {
   var addItem = function(item, slot) {
     if (item.id === -1) {
       bot.entity.inventory[slot] = null;
     } else {
-      bot.entity.inventory[slot] = new Slot(item.id, item.itemCount, item.itemDamage);
+      bot.entity.inventory[slot] = item;
     }
     bot.emit('inventoryUpdate');
     if (slot === bot.entity.heldSlot) {


### PR DESCRIPTION
Events: inventoryUpdate, equipmentUpdate, quickbarUpdate
Fields: entity.inventory, entity.quickbar, entity.heldSlot (from 0x10)
Functions: bot.hold(slot)

Some of the stuff dealing with the held item is a little hacky since the held item number comes in before the inventory on login. Can be improved on a bit but I think it works well enough for now
