### PR TITLE
Don't suppress your own chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ var bot = mineflayer.createBot({
   password: "12345678",       // online-mode=true servers
 });
 bot.on('chat', function(username, message) {
+  if (username === bot.username) return;
   bot.chat(message);
 });
 ```

--- a/doc/api.md
+++ b/doc/api.md
@@ -234,7 +234,7 @@ Age of the world, in ticks.
 
 #### "chat" (username, message, rawMessage)
 
- * `username` - who said the message
+ * `username` - who said the message (compare with bot.username to ignore your own chat)
  * `message` - stripped of any control characters
  * `rawMessage` - unmodified message from the server
 

--- a/examples/echo.js
+++ b/examples/echo.js
@@ -6,5 +6,6 @@ var bot = mineflayer.createBot({
   // online-mode set to false.
 });
 bot.on('chat', function(username, message) {
+  if (username === bot.username) return;
   bot.chat(message);
 });

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -15,8 +15,6 @@ function inject(bot) {
       // spoken chat
       var username = match[1];
       var content = match[2];
-      // suppress talking to yourself
-      if (username === bot.username) return;
       bot.emit('chat', username, content, message);
     } else {
       // non-spoken chat

--- a/test/test.js
+++ b/test/test.js
@@ -20,7 +20,7 @@ describe("mineflayer", function() {
     server.close();
   });
   it("chat", function(done) {
-    bot.on('chat', function(username, message) {
+    bot.once('chat', function(username, message) {
       assert.strictEqual(username, "gary");
       assert.strictEqual(message, "hello");
       bot.chat("hi");


### PR DESCRIPTION
Getting your own chat shouldn't be a special case.  This allows bots to listen to themselves with the bot.on('chat') event.
