### PR TITLE
Add sprinting support

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -22,6 +22,7 @@ function inject(bot) {
     playerHeight: 1.74, // tested with a binary search
     jumpSpeed: 9.0, // seems good
     yawSpeed: 3.0, // seems good
+    sprintSpeed: 1.3, // correct
   };
 
   var controlState = {
@@ -30,8 +31,10 @@ function inject(bot) {
     left: false,
     right: false,
     jump: false,
+    sprint: false,
   };
   var jumpQueued = false;
+  var sprintQueued = false;
   var lastSentYaw = null;
   var positionUpdateTimer = null;
   var doPhysicsTimer = null;
@@ -81,6 +84,19 @@ function inject(bot) {
       var inputYaw = bot.entity.yaw + rotationFromInput;
       acceleration.x += physics.walkingAcceleration * -Math.sin(inputYaw);
       acceleration.z += physics.walkingAcceleration * -Math.cos(inputYaw);
+      if (controlState.sprint) {
+        acceleration.x *= physics.sprintSpeed;
+        acceleration.z *= physics.sprintSpeed;
+      }
+    }
+    // sprinting
+    if (sprintQueued) {
+      var packet = {
+        entityId: bot.entity.id,
+        actionId: controlState.sprint ? 4 : 5,
+      };
+      bot.client.write(0x13, packet);
+      sprintQueued = false;
     }
 
     // jumping
@@ -253,9 +269,11 @@ function inject(bot) {
     assert.ok(control in controlState, "invalid control: " + control);
     controlState[control] = state;
     if (state && control === 'jump') jumpQueued = true;
+    else if (control === 'sprint') sprintQueued = true;
   };
 
   bot.clearControlStates = function() {
+    if (controlState.sprint) sprintQueued = true;
     for (var control in controlState) {
       controlState[control] = false;
     }


### PR DESCRIPTION
Usage: bot.setControlState('sprint', true)
Tested locally. Feel free to implement it differently.

TODO: Stop sprinting when hunger < min (when the proper API is done)
