### PR TITLE
Ensured lookAt takes entity.height into account

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -286,7 +286,7 @@ function inject(bot) {
   };
 
   bot.lookAt = function(point, force) {
-    var delta = point.minus(bot.entity.position);
+    var delta = point.minus(bot.entity.position.offset(0, bot.entity.height, 0));
     var yaw = Math.atan2(-delta.x, -delta.z);
     var groundDistance = Math.sqrt(delta.x * delta.x + delta.z * delta.z);
     var pitch = Math.atan2(delta.y, groundDistance);


### PR DESCRIPTION
Without it, the bot will always look 1.62 too high.

Verification bot here: https://gist.github.com/4637048
