### PR TITLE
Remove requireindex, for browserify support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,34 @@ var mc = require('minecraft-protocol');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var path = require('path');
-var requireIndex = require('requireindex');
-var plugins = requireIndex(path.join(__dirname, 'lib', 'plugins'));
+var plugins = {
+  bed: require('./lib/plugins/bed'),
+  block_actions: require('./lib/plugins/block_actions'),
+  blocks: require('./lib/plugins/blocks'),
+  chat: require('./lib/plugins/chat'),
+  chest: require('./lib/plugins/chest'),
+  craft: require('./lib/plugins/craft'),
+  creative: require('./lib/plugins/creative'),
+  digging: require('./lib/plugins/digging'),
+  dispenser: require('./lib/plugins/dispenser'),
+  enchantment_table: require('./lib/plugins/enchantment_table'),
+  entities: require('./lib/plugins/entities'),
+  experience: require('./lib/plugins/experience'),
+  furnace: require('./lib/plugins/furnace'),
+  game: require('./lib/plugins/game'),
+  health: require('./lib/plugins/health'),
+  inventory: require('./lib/plugins/inventory'),
+  kick: require('./lib/plugins/kick'),
+  physics: require('./lib/plugins/physics'),
+  rain: require('./lib/plugins/rain'),
+  scoreboard: require('./lib/plugins/scoreboard'),
+  settings: require('./lib/plugins/settings'),
+  simple_inventory: require('./lib/plugins/simple_inventory'),
+  sound: require('./lib/plugins/sound'),
+  spawn_point: require('./lib/plugins/spawn_point'),
+  time: require('./lib/plugins/time')
+};
+
 var mcData = require('./lib/minecraft-data');
 var version = require('./lib/version');
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "prismarine-windows": "0.0.0",
     "prismarine-recipe": "0.0.0",
     "quotemeta": "0.0.0",
-    "requireindex": "~1.0.0",
     "vec3": "~0.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Not the most ideal fix but I couldn't find any other feasible solution unfortunately. Background in https://github.com/deathcap/wsmc/issues/19#issuecomment-170791081 but long story short, this change allows using `require('mineflayer')` in a browserified environment.

Previously I was using `require('mineflayer/lib/block')` etc. and not accessing the mineflayer index.js at all, but this changed in https://github.com/PrismarineJS/mineflayer/commit/ca365c3c1bbdb39cf6632b71e7f3d6363d36c2ae so I tried to use `require('mineflayer').Block` instead but then it runs the unbrowserifiable requireindex module. With this PR, index.js can be browserified.

Another option is to include a separate browser.js listing the modules and keep requireindex in the main index.js, but this means it has to be maintained separately. I think making the change to index.js is the simplest solution, although it does mean that this file will have to be updated when new plugins are added. Open to other suggestions but this is the best I could come up with so far (see https://github.com/deathcap/wsmc/issues/19#issuecomment-170791081)