### PR TITLE
Kick API improvements

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -118,7 +118,7 @@
       - ["game"](#game)
       - ["rain"](#rain)
       - ["time"](#time)
-      - ["kicked" (reason)](#kicked-reason)
+      - ["kicked" (reason, loggedIn)](#kicked-reason-loggedIn)
       - ["end"](#end)
       - ["spawnReset"](#spawnreset)
       - ["death"](#death)
@@ -762,10 +762,12 @@ server where it is already raining, this event will fire.
 
 Emitted when the server sends a time update. See `bot.time`.
 
-#### "kicked" (reason)
+#### "kicked" (reason, loggedIn)
 
 Emitted when the bot is kicked from the server. `reason`
-is a chat message explaining why you were kicked.
+is a chat message explaining why you were kicked. `loggedIn`
+is `true` if the client was kicked after successfully logging in,
+or `false` if the kick occurred in the login phase.
 
 #### "end"
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -765,7 +765,7 @@ Emitted when the server sends a time update. See `bot.time`.
 #### "kicked" (reason)
 
 Emitted when the bot is kicked from the server. `reason`
-is a string explaining why you were kicked.
+is a chat message explaining why you were kicked.
 
 #### "end"
 

--- a/lib/plugins/kick.js
+++ b/lib/plugins/kick.js
@@ -2,10 +2,10 @@ module.exports = inject;
 
 function inject(bot) {
   bot._client.on('kick_disconnect', function(packet) {
-    bot.emit('kicked', packet.reason);
+    bot.emit('kicked', packet.reason, true);
   });
   bot._client.on('disconnect', function(packet) {
-    bot.emit('kicked', packet.reason);
+    bot.emit('kicked', packet.reason, false);
   });
   bot.quit = function(reason) {
     reason = reason || 'disconnect.quitting';

--- a/lib/plugins/kick.js
+++ b/lib/plugins/kick.js
@@ -4,6 +4,9 @@ function inject(bot) {
   bot._client.on('kick_disconnect', function(packet) {
     bot.emit('kicked', packet.reason);
   });
+  bot._client.on('disconnect', function(packet) {
+    bot.emit('kicked', packet.reason);
+  });
   bot.quit = function(reason) {
     reason = reason || 'disconnect.quitting';
     bot._client.end(reason);


### PR DESCRIPTION
Listens for disconnect kicks in the login phase, fixes https://github.com/PrismarineJS/mineflayer/issues/359. The same `kicked` API event is emitted, but with an additional parameter to optionally differentiate between gameplay-phase kicks and login-phase kicks (existing clients like examples/chatterbot.js can ignore this extra parameter to handle both types of kicks identically).
