### PR TITLE
remove chat filter

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,15 +1,8 @@
 var assert = require('assert');
-var quoteMeta = require('quotemeta');
 var ChatMessage = require('../chat_message');
-var LEGAL_CHARS = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~⌂ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜø£Ø×ƒáíóúñÑªº¿®¬½¼¡«»§';
 var CHAT_LENGTH_LIMIT = 100;
 
 module.exports = inject;
-
-var quotedLegalChars = quoteMeta(LEGAL_CHARS);
-var incomingFilter = new RegExp("([^" + quotedLegalChars + "]|§.)", 'g');
-var outgoingFilter = new RegExp("([^" + quotedLegalChars + "])", 'g');
-
 
 function inject(bot) {
   // add an array, containing objects such as {pattern:/regex pattern/, chatType:"string", description:"string"}
@@ -30,11 +23,10 @@ function inject(bot) {
   bot._client.on('chat', function(packet) {
     // Function used to process "unidentified" messages, such as 1.6 chat and bukkit servers
     function parseOldMessage(stringMsg) {
-      var legalContent = stringMsg.replace(incomingFilter, '');
       var match, username, content;
       // iterate through each object in chat.patterns array and test if .pattern matches
       for(i = 0; i < bot.chatPatterns.length; i++) {
-        if(match = legalContent.match(bot.chatPatterns[i].pattern)) {
+        if(match = stringMsg.match(bot.chatPatterns[i].pattern)) {
           username = match[1];
           message = match[2];
           bot.emit(bot.chatPatterns[i].type, username, message, null, {text: stringMsg}, match);
@@ -52,11 +44,11 @@ function inject(bot) {
       var content;
       if(typeof jsonMsg.translate === 'string' && jsonMsg.translate.match(/^chat\./)) {
         username = jsonMsg.using[0];
-        content = jsonMsg.using[1].replace(incomingFilter, '');
+        content = jsonMsg.using[1];
         bot.emit('chat', username, content, jsonMessage.translate, jsonMessage)
       } else if(jsonMsg.translate === "commands.message.display.incoming") {
         username = jsonMsg.using[0];
-        content = jsonMsg.using[1].replace(incomingFilter, '');
+        content = jsonMsg.using[1];
         bot.emit('whisper', username, content, jsonMsg.translate, jsonMsg);
       } else if(typeof jsonMsg.text === 'string') {
         // craftbukkit message format
@@ -122,7 +114,6 @@ function inject(bot) {
   });
 
   function chatWithHeader(header, message) {
-    message = message.replace(outgoingFilter, '');
     var lengthLimit = CHAT_LENGTH_LIMIT - header.length;
     message.split("\n").forEach(function(subMessage) {
       if(!subMessage) return;


### PR DESCRIPTION
So I can't see what was the point of this filter. Without it echo.js can correctly parse and send:
* '
* "
* \"
* test
* 我

Merging this soon if no one can figure out if this filter has still any use.