### PR TITLE
Add bot.canSeeBlock()

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -164,7 +164,7 @@ function inject(bot) {
       na=a.plus(v);
       // check that blocks don't inhabit the same position
       if(!na.floored().equals(a.floored())) {
-        // check block block not transparent
+        // check block is not transparent
         if(blockIsNotEmpty(na)) return false;
       }
       a=na;
@@ -172,7 +172,8 @@ function inject(bot) {
     return true;
   }
 
-  // if passed in block is within line of sight to the bot, returns true.
+  // if passed in block is within line of sight to the bot, returns true
+  // also works on anything with a position value
   function canSeeBlock(block) {
     // this emits a ray from the center of the bots body to the block
     if(visiblePosition(bot.entity.position.offset(0,bot.entity.height*0.5,0),block.position) ) {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -157,7 +157,8 @@ function inject(bot) {
     var na;
     for(var i=1;i<u;i++) {
       na=a.plus(v);
-      if(!sameBlock(na,a)) {
+      // check to see that blocks don't inhabit the same position
+      if(!pos1.floored().equals(pos2.floored())) {
         if(isNotEmpty(na)) return false;
       }
       a=na;

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -162,7 +162,7 @@ function inject(bot) {
     for(var i=1;i<u;i++) {
       na=a.plus(v);
       // check to see that blocks don't inhabit the same position
-      if(!pos1.floored().equals(pos2.floored())) {
+      if(!na.floored().equals(a.floored())) {
         if(isNotEmpty(na)) return false;
       }
       a=na;

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -147,8 +147,9 @@ function inject(bot) {
     }
   }
 
-  function isNotEmpty(b) {
-    return b!==null && b.boundingBox!=="empty";
+  function blockIsNotEmpty(pos) {
+    var block = bot.blockAt(pos);
+    return block!==null && block.boundingBox!=="empty";
   }
 
   // maybe this should be moved to math.js instead?
@@ -161,9 +162,10 @@ function inject(bot) {
     var na;
     for(var i=1;i<u;i++) {
       na=a.plus(v);
-      // check to see that blocks don't inhabit the same position
+      // check that blocks don't inhabit the same position
       if(!na.floored().equals(a.floored())) {
-        if(isNotEmpty(na)) return false;
+        // check block block not transparent
+        if(blockIsNotEmpty(na)) return false;
       }
       a=na;
     }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -147,6 +147,33 @@ function inject(bot) {
     }
   }
 
+  // maybe this should be moved to math.js instead?
+  function visiblePosition(a,b) {
+    var v=b.minus(a);
+    var t=Math.sqrt(v.x*v.x+v.y*v.y+v.z*v.z);
+    v=v.scaled(1/t);
+    v=v.scaled(1/5);
+    var u=t*5;
+    var na;
+    for(var i=1;i<u;i++) {
+      na=a.plus(v);
+      if(!sameBlock(na,a)) {
+        if(isNotEmpty(na)) return false;
+      }
+      a=na;
+    }
+    return true;
+  }
+
+  // if passed in block is within line of sight to the bot, returns true.
+  function canSeeBlock(block) {
+    // this emits a ray from the center of the bots body to the block
+    if(visiblePosition(bot.entity.position.offset(0,bot.entity.height*0.5,0),block.position) ) {
+      return true;
+    }
+    return false;
+  }
+
   function chunkColumn(x, z) {
     var key = columnKeyXZ(x, z);
     return columns[key];
@@ -322,6 +349,7 @@ function inject(bot) {
   });
 
   bot.findBlock = findBlock;
+  bot.canSeeBlock = canSeeBlock;
   bot.blockAt = blockAt;
   bot._chunkColumn = chunkColumn;
   bot._updateBlock = updateBlock;
@@ -352,4 +380,3 @@ function Column() {
   this.skyLight = new Array(16);
   this.biome = null;
 }
-

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -147,6 +147,10 @@ function inject(bot) {
     }
   }
 
+  function isNotEmpty(b) {
+    return b!==null && b.boundingBox!=="empty";
+  }
+
   // maybe this should be moved to math.js instead?
   function visiblePosition(a,b) {
     var v=b.minus(a);


### PR DESCRIPTION
This pull request adds bot.canSeeBlock and some other methods it requires. Currently everything was added into blocks.js but there might be better places to add these functions.

bot.canSeeBlock() returns true when the bot is within visible range of the block parameter and false otherwise.

I've tested this on my own setup and it seems to work as described.