### PR TITLE
add session authentication example

### DIFF
--- a/examples/session.js
+++ b/examples/session.js
@@ -1,0 +1,30 @@
+var mineflayer = require('mineflayer');
+var path = require('path');
+
+if(process.argv.length !== 5) {
+  console.log("Usage : node session.js <host> <port> <pathToLauncherProfiles>");
+  process.exit(1);
+}
+
+var profile = require(path.resolve(process.argv[4], 'launcher_profiles.json'));
+var auth = profile.authenticationDatabase[profile.selectedUser];
+
+var session = {
+  accessToken: auth.accessToken,
+  clientToken: profile.clientToken,
+  selectedProfile: {
+    id: profile.selectedUser,
+    name: auth.displayName
+  }
+};
+
+var bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  session: session
+});
+
+bot.once('login', function() {
+  console.log('loged in');
+  bot.quit();
+});


### PR DESCRIPTION
an example on how to authenticate your client using the session object.

no password required 😃
`node session.js play.cubecraft.net 25565 ~/.minecraft`

ps.: someone should check if this works with the new lancher.