### PR TITLE
Fixed bot.sleep()

### DIFF
--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -19,7 +19,8 @@ function inject(bot) {
   }
 
   function sleep(bedBlock, cb) {
-    if(!(bot.time.day >= 12541 && bot.time.day <= 23458))
+    var time = bot.time.day % 24000;
+    if(!(time >= 12541 && time <= 23458))
       cb(new Error("it's not night"));
     else if(bot.isSleeping)
       cb(new Error("already sleeping"));


### PR DESCRIPTION
Modified bot.sleep() to account for time being returned as ticks total and not ticks for the current day.

Documentation
```
bot.time.day

Time of the day, in ticks.

Time is based on ticks, where 20 ticks happen every second. There are 24000 
ticks in a day, making Minecraft days exactly 20 minutes long.

The time of day is based on the timestamp 
modulo 24000. 0 is sunrise, 6000 is noon, 
12000 is sunset, and 18000 is midnight.
```