### PR TITLE
Add support for Minecraft 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create Minecraft bots with a powerful, stable, and high level JavaScript API.
 
 ## Features
 
- * Supports Minecraft 1.8, 1.9, 1.10 and 1.11.
+ * Supports Minecraft 1.8, 1.9, 1.10, 1.11 and 1.12.
  * Entity knowledge and tracking.
  * Block knowledge. You can query the world around you.
  * Basic physics and movement - currently blocks are either "solid" or "empty".

--- a/doc/history.md
+++ b/doc/history.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* support version 1.12
+
 ## 2.2.0
 
 * added book writing plugin (thanks @plexigras)

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -104,7 +104,7 @@ function inject(bot,{version}) {
       if(bot.majorVersion=="1.8") {
         entity.position.set(packet.x/32, packet.y/32, packet.z/32);
       }
-      if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+      if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
         entity.position.set(packet.x, packet.y, packet.z);
       }
       entity.yaw = conv.fromNotchianYawByte(packet.yaw);
@@ -152,7 +152,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.set(packet.x/32, packet.y/32, packet.z/32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.set(packet.x, packet.y, packet.z);
     }
     entity.uuid=packet.entityUUID;
@@ -168,7 +168,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.set(packet.x/32, packet.y/32, packet.z/32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.set(packet.x, packet.y, packet.z);
     }
     entity.count = packet.count;
@@ -200,7 +200,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.set(packet.x/32, packet.y/32, packet.z/32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.set(packet.x, packet.y, packet.z);
     }
     entity.yaw = conv.fromNotchianYawByte(packet.yaw);
@@ -238,7 +238,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.translate(packet.dX / 32, packet.dY / 32, packet.dZ / 32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.translate(packet.dX / (128*32), packet.dY / (128*32), packet.dZ / (128*32));
     }
     bot.emit('entityMoved', entity);
@@ -258,7 +258,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.translate(packet.dX / 32, packet.dY / 32, packet.dZ / 32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.translate(packet.dX / (128*32), packet.dY / (128*32), packet.dZ / (128*32));
     }
     entity.yaw = conv.fromNotchianYawByte(packet.yaw);
@@ -272,7 +272,7 @@ function inject(bot,{version}) {
     if(bot.majorVersion=="1.8") {
       entity.position.set(packet.x/32, packet.y/32, packet.z/32);
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       entity.position.set(packet.x, packet.y, packet.z);
     }
     entity.yaw = conv.fromNotchianYawByte(packet.yaw);

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -35,7 +35,7 @@ function inject(bot,{version}) {
         cursorZ: -1
       });
     }
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       bot._client.write('use_item', {
         hand:0
       });
@@ -129,7 +129,7 @@ function inject(bot,{version}) {
         });
       }
 
-      if(bot.majorVersion=="1.11") {
+      if(bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
         bot._client.write('block_place', {
           location: block.position,
           direction: 1,
@@ -347,7 +347,7 @@ function inject(bot,{version}) {
         });
       }
 
-      if(bot.majorVersion=="1.11") {
+      if(bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
         bot._client.write('block_place', {
           location: pos,
           direction: vectorToDirection(faceVector),

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -358,7 +358,7 @@ function inject(bot) {
       sendPositionAndLook(bot.entity);
     }
 
-    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11") {
+    if(bot.majorVersion=="1.9" || bot.majorVersion=="1.10" || bot.majorVersion=="1.11" || bot.majorVersion=="1.12") {
       bot._client.write('teleport_confirm', {teleportId: packet.teleportId});
       bot.emit("move");
     }

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports={
-  defaultVersion:'1.11.2',
-  supportedVersions:['1.8','1.9','1.10','1.11.2']
+  defaultVersion:'1.12',
+  supportedVersions:['1.8','1.9','1.10','1.11.2','1.12']
 };


### PR DESCRIPTION
1.12 does not significantly change existing packets, so this is mostly a matter of reproducing 1.11 behavior.