### PR TITLE
expose controlState as bot.controlState

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -115,6 +115,7 @@
       - [bot.targetDigBlock](#bottargetdigblock)
       - [bot.isSleeping](#botissleeping)
       - [bot.scoreboards](#botscoreboards)
+      - [bot.controlState](#botcontrolstate)
     - [Events](#events)
       - ["chat" (username, message, translate, jsonMsg, matches)](#chat-username-message-translate-jsonmsg-matches)
       - ["whisper" (username, message, translate, jsonMsg, matches)](#whisper-username-message-translate-jsonmsg-matches)
@@ -194,7 +195,6 @@
       - [bot.wake([cb])](#botwakecb)
       - [bot.setControlState(control, state)](#botsetcontrolstatecontrol-state)
       - [bot.clearControlStates()](#botclearcontrolstates)
-      - [bot.getControlStates()](#botgetcontrolstates)
       - [bot.lookAt(point, [force], [callback])](#botlookatpoint-force-callback)
       - [bot.look(yaw, pitch, [force], [callback])](#botlookyaw-pitch-force-callback)
       - [bot.updateSign(block, text)](#botupdatesignblock-text)
@@ -784,6 +784,12 @@ Boolean, whether or not you are in bed.
 
 All scoreboards known to the bot in an object scoreboard name -> scoreboard.
 
+#### bot.controlState
+
+An object whose keys are the main control states: ['forward', 'back', 'left', 'right', 'jump', 'sprint'].
+
+Setting values for this object internally calls [bot.setControlState](#botsetcontrolstatecontrol-state).
+
 ### Events
 
 #### "chat" (username, message, translate, jsonMsg, matches)
@@ -1143,14 +1149,6 @@ Get out of bed. `cb` can have an err parameter if the bot cannot wake up.
 #### bot.clearControlStates()
 
 Sets all controls to off.
-
-#### bot.getControlStates()
-
-Get an object containing the keys ['forward', 'back', 'left', 'right', 'jump', 'sprint'],
-whose values are booleans indicating whether the control state is on (true) or off (false).
-
-This object is a clone of the one used by the bot (so chanaing them does nothing), use 
-`setControlState` to change these values.
 
 #### bot.lookAt(point, [force], [callback])
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -194,6 +194,7 @@
       - [bot.wake([cb])](#botwakecb)
       - [bot.setControlState(control, state)](#botsetcontrolstatecontrol-state)
       - [bot.clearControlStates()](#botclearcontrolstates)
+      - [bot.getControlStates()](#botgetcontrolstates)
       - [bot.lookAt(point, [force], [callback])](#botlookatpoint-force-callback)
       - [bot.look(yaw, pitch, [force], [callback])](#botlookyaw-pitch-force-callback)
       - [bot.updateSign(block, text)](#botupdatesignblock-text)
@@ -1142,6 +1143,14 @@ Get out of bed. `cb` can have an err parameter if the bot cannot wake up.
 #### bot.clearControlStates()
 
 Sets all controls to off.
+
+#### bot.getControlStates()
+
+Get an object containing the keys ['forward', 'back', 'left', 'right', 'jump', 'sprint'],
+whose values are booleans indicating whether the control state is on (true) or off (false).
+
+This object is a clone of the one used by the bot (so chanaing them does nothing), use 
+`setControlState` to change these values.
 
 #### bot.lookAt(point, [force], [callback])
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -289,8 +289,9 @@ function inject (bot) {
 
   bot.physics = physics
 
-  bot.setControlState = (control, state) => {
+  bot.setControlState = function setControlState (control, state) {
     assert.ok(control in controlState, `invalid control: ${control}`)
+    assert.ok(typeof state === 'boolean', `invalid state: ${state}`)
     if (controlState[control] === state) return
     controlState[control] = state
     if (control === 'jump' && state) {
@@ -310,7 +311,19 @@ function inject (bot) {
     }
   }
 
-  bot.getControlStates = () => Object.assign({}, controlState);
+  bot.controlState = {}
+
+  for (const control of Object.keys(controlState)) {
+    Object.defineProperty(bot.controlState, control, {
+      get () {
+        return controlState[control]
+      },
+      set (state) {
+        bot.setControlState(control, state)
+        return state
+      }
+    })
+  }
 
   function noop (err) {
     if (err) throw err

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -310,6 +310,8 @@ function inject (bot) {
     }
   }
 
+  bot.getControlStates = () => Object.assign({}, controlState);
+
   function noop (err) {
     if (err) throw err
   }


### PR DESCRIPTION
This adds a property `controlState` to the bot object, which allows getting and setting of control states. When control states are set through this object, `bot.setControlState()` is called and the state is written. 

This PR also adds a check inside `bot.setControlState()` to ensure the state being set is a boolean.