### PR TITLE
Add dynamic chat lengths depending on options or version

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -637,6 +637,7 @@ Create and return an instance of the class bot.
  * [viewDistance](bot.settings.viewDistance)
  * [difficulty](bot.settings.difficulty)
  * [showCape](bot.settings.showCape)
+ * chatLengthLimit : the maximum amount of characters that can be sent in a single message. If this is not set, it will be 100 in < 1.11 and 256 in >= 1.11.
 
 ### Properties
 

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class Bot extends EventEmitter {
       if (supportedVersions.indexOf(version.majorVersion) === -1) {
         throw new Error(`Version ${version.minecraftVersion} is not supported.`)
       }
+      self.protocolVersion = version.version
       self.majorVersion = version.majorVersion
       self.version = version.minecraftVersion
       options.version = version.minecraftVersion

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,4 +1,4 @@
-const PROTO_VER_1_10 = require('minecraft-data')('1.10.2').version.version;
+const PROTO_VER_1_10 = require('minecraft-data')('1.10.2').version.version
 
 module.exports = inject
 

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,7 +1,9 @@
+const PROTO_VER_1_10 = require('minecraft-data')('1.10.2').version.version;
+
 module.exports = inject
 
 function inject (bot, options) {
-  const CHAT_LENGTH_LIMIT = (options.chatLengthLimit) ? options.chatLengthLimit : ((bot.protocolVersion >= 301) ? 256 : 100)
+  const CHAT_LENGTH_LIMIT = (options.chatLengthLimit) ? options.chatLengthLimit : ((bot.protocolVersion > PROTO_VER_1_10) ? 256 : 100)
 
   const ChatMessage = require('../chat_message')(bot.version)
   // add an array, containing objects such as {pattern:/regex pattern/, chatType:"string", description:"string"}

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,8 +1,8 @@
-const CHAT_LENGTH_LIMIT = 100
-
 module.exports = inject
 
-function inject (bot) {
+function inject (bot, options) {
+  const CHAT_LENGTH_LIMIT = (options.chatLengthLimit) ? options.chatLengthLimit : ((bot.protocolVersion >= 301) ? 256 : 100)
+
   const ChatMessage = require('../chat_message')(bot.version)
   // add an array, containing objects such as {pattern:/regex pattern/, chatType:"string", description:"string"}
   // chat.pattern.type will emit an event for bot.on() of the same type, eg chatType = whisper will trigger bot.on('whisper')


### PR DESCRIPTION
Improvement on https://github.com/PrismarineJS/mineflayer/pull/588 (I was also looking to change it and saw the PR already made), this allows dynamic chat length depending on the version.

This PR does a few things:
* Adds `bot.protocolVersion`
* Adds a `chatLengthLimit` option to the `createBot` function
* Adds the dynamic chat limit

The chat limit is determined as follows:
1. If a chatLengthLimit is provided, use that
2. If the protocol version is 301 or higher (the first 1.11 snapshot or higher), the length is 256
3. Otherwise, it's 100

The chatLengthLimit option is provided in case the length changes in the future (to allow people to change it without diving into the module itself), and for servers with backwards compatibility that allow more characters even if the client thinks it's 1.8 (for instance, Mineplex allows this).