### PR TITLE
Add bossBar events

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -419,6 +419,51 @@ function inject (bot, { version }) {
     }
   })
 
+  const bossBar = 'bossBar'
+  if (bot.majorVersion === '1.8') {
+    const enderDragon = 'Ender Dragon'
+    const wither = 'Wither'
+
+    bot._client.on('entity_metadata', (packet) => {
+      const entity = bot.entities[packet.entityId]
+      if (entity.mobType === enderDragon || entity.mobType === wither) {
+        const meta6 = entity.metadata['6']
+        if (meta6 !== undefined) {
+          const hp = meta6 / (entity.mobType === enderDragon ? 200 : 300)
+          bot.emit('bossBarHealth', 'entity', entity, hp)
+        }
+      }
+    })
+
+    bot.on('entityGone', (entity) => {
+      if (entity.mobType === enderDragon || entity.mobType === wither) {
+        bot.emit('bossBarRemove', 'entity', entity)
+      }
+    })
+
+    bot.on('entitySpawn', (entity) => {
+      if (entity.mobType === enderDragon || entity.mobType === wither) {
+        bot.emit('bossBarCreate', 'entity', entity)
+        bot.emit('bossBarTitle', 'entity', entity, entity.mobType)
+      }
+    })
+  } else {
+    bot._client.on('boss_bar', (packet) => {
+      const ChatMessage = require('../chat_message')(bot.version)
+      if (packet.action === 0) {
+        bot.emit('bossBarCreate', 'entityUUID', packet.entityUUID)
+        bot.emit('bossBarHealth', 'entityUUID', packet.entityUUID, packet.health)
+        bot.emit('bossBarTitle', 'entityUUID', packet.entityUUID, new ChatMessage(packet.title))
+      } else if (packet.action === 1) {
+        bot.emit('bossBarRemove', 'entityUUID', packet.entityUUID)
+      } else if (packet.action === 2) {
+        bot.emit('bossBarHealth', 'entityUUID', packet.entityUUID, packet.health)
+      } else if (packet.action === 3) {
+        bot.emit('bossBarTitle', 'entityUUID', packet.entityUUID, new ChatMessage(packet.title))
+      }
+    })
+  }
+
   bot.attack = attack
   bot.mount = mount
   bot.dismount = dismount


### PR DESCRIPTION
Add bossBar events that work for all minecraft versions including 1.8,
from minecraft 1.9 and onwards it's simple to listen to the boss bars as
you just have to listen to the boss_bar packet. This commit also adds
support for boss bars in 1.8 where it's simulated by using a renamed
dragon or wither

As requested in issue #639 

All the new events work in a similiar way. The first argument is always the entity type e.g either entityUUID or just entity. This argument indicates if the next argument will be an entity object or the uuid of the entity. The next arguments are then relevant to the event in question.

I decided against finding the entity in the bot.entities array from 1.9 and upward due to uncessarry overhead. These packets get sent quite a lot and it's pointless to find the entity each time if the user doesn't really need to know. Most of the time there will only be a single boss bar.