### PR TITLE
Start the bot alive

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -1,7 +1,7 @@
 module.exports = inject
 
 function inject (bot) {
-  bot.isAlive = false
+  bot.isAlive = true
 
   bot._client.on('respawn', (packet) => {
     bot.isAlive = false


### PR DESCRIPTION
Some servers don't send update_health and it's better to start alive.