### PR TITLE
Update physics.js

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -15,7 +15,7 @@ const WAIT_TIME_BEFORE_NEW_JUMP = 0.07
 
 function inject (bot) {
   const physics = {
-    maxGroundSpeed: 4.27, // according to the internet
+    maxGroundSpeed: 4.317, // according to the internet
     terminalVelocity: 20.0, // guess
     walkingAcceleration: 100.0, // seems good
     gravity: 27.0, // seems good
@@ -138,6 +138,9 @@ function inject (bot) {
       currentMaxGroundSpeed = physics.maxGroundSpeedWater
     } else {
       currentMaxGroundSpeed = physics.maxGroundSpeed
+    }
+    if (controlState.sprint) {
+      currentMaxGroundSpeed *= physics.sprintSpeed
     }
 
     const groundSpeedSquared = calcGroundSpeedSquared()


### PR DESCRIPTION
Updated maxGroundSpeed to value given in Minecraft wiki.
MaxGroundSpeed did not take into account the fact that the player could have been sprinting.