### PR TITLE
Prevent error from being thrown when chunk fails to load

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -43,7 +43,12 @@ function inject (bot, { version }) {
     let column = columns[key]
     if (!column) columns[key] = column = new Chunk()
 
-    column.load(args.data, args.bitMap, args.skyLightSent)
+    try {
+      column.load(args.data, args.bitMap, args.skyLightSent)
+    } catch (e) {
+      bot.emit('error', e)
+      return
+    }
 
     bot.emit('chunkColumnLoad', columnCorner)
   }

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -3,7 +3,7 @@ const PROTO_VER_1_10 = require('minecraft-data')('1.10.2').version.version
 module.exports = inject
 
 function inject (bot, options) {
-  const CHAT_LENGTH_LIMIT = (options.chatLengthLimit) ? options.chatLengthLimit : ((bot.protocolVersion > PROTO_VER_1_10) ? 256 : 100)
+  const CHAT_LENGTH_LIMIT = options.chatLengthLimit || ((bot.protocolVersion > PROTO_VER_1_10) ? 256 : 100)
 
   const ChatMessage = require('../chat_message')(bot.version)
   // add an array, containing objects such as {pattern:/regex pattern/, chatType:"string", description:"string"}


### PR DESCRIPTION
Sometimes (usually on custom servers not running vanilla), a chunk fails to load, and the error is directly thrown instead of going to the error event emitter.

Also fixes a suggestion @plexigras made on my PR like two years ago