### PR TITLE
Add support for block entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 # different than .npmignore
 node_modules
 package-lock.json
+yarn.lock
 /README.md
 versions/

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -14,12 +14,15 @@ const paintingFaceToVec = [
 ]
 
 function inject (bot, { version }) {
+  const nbt = require('prismarine-nbt')
   const Chunk = require('prismarine-chunk')(version)
   const ChatMessage = require('../chat_message')(version)
   let columns = {}
   const signs = {}
   const paintingsByPos = {}
   const paintingsById = {}
+
+  const blockEntities = new Map()
 
   function addPainting (painting) {
     paintingsById[painting.id] = painting
@@ -49,6 +52,26 @@ function inject (bot, { version }) {
       bot.emit('error', e)
       return
     }
+
+    const chunkBlockEntities = {}
+
+    for (const nbtTag of args.blockEntities) {
+      const blockEntity = nbt.simplify(nbtTag)
+      const absolutePoint = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
+      const loc = new Location(absolutePoint)
+
+      // Handle signs
+      if (blockEntity.id === 'minecraft:sign') {
+        blockEntity.Text1 = new ChatMessage(JSON.parse(blockEntity.Text1)).toString()
+        blockEntity.Text2 = new ChatMessage(JSON.parse(blockEntity.Text2)).toString()
+        blockEntity.Text3 = new ChatMessage(JSON.parse(blockEntity.Text3)).toString()
+        blockEntity.Text4 = new ChatMessage(JSON.parse(blockEntity.Text4)).toString()
+      }
+
+      chunkBlockEntities[loc.floored] = blockEntity
+    }
+
+    blockEntities.set(column, chunkBlockEntities)
 
     bot.emit('chunkColumnLoad', columnCorner)
   }
@@ -98,6 +121,7 @@ function inject (bot, { version }) {
     block.position = loc.floored
     block.signText = signs[loc.floored]
     block.painting = paintingsByPos[loc.floored]
+    block.blockEntity = blockEntities.get(column)[loc.floored]
 
     return block
   }
@@ -175,7 +199,8 @@ function inject (bot, { version }) {
       bitMap: packet.bitMap,
       skyLightSent: bot.game.dimension === 'overworld',
       groundUp: packet.groundUp,
-      data: packet.chunkData
+      data: packet.chunkData,
+      blockEntities: packet.blockEntities
     })
   })
 
@@ -280,6 +305,7 @@ function inject (bot, { version }) {
     signs[pos] = `${new ChatMessage(JSON.parse(packet.text1))}\n${new ChatMessage(JSON.parse(packet.text2))}\n${new ChatMessage(JSON.parse(packet.text3))}\n${new ChatMessage(JSON.parse(packet.text4))}`
     emitBlockUpdate(oldBlock, blockAt(pos))
   })
+
   bot.updateSign = (block, text) => {
     const lines = text.split('\n')
     if (lines.length > 4) {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -35,19 +35,19 @@ function inject (bot, { version }) {
   }
 
   function addBlockEntity (nbtData) {
-      const blockEntity = nbt.simplify(nbtData)
-      const absolutePoint = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
-      const loc = new Location(absolutePoint)
+    const blockEntity = nbt.simplify(nbtData)
+    const absolutePoint = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
+    const loc = new Location(absolutePoint)
 
-      // Handle signs
-      if (blockEntity.id === 'minecraft:sign') {
-        blockEntity.Text1 = new ChatMessage(JSON.parse(blockEntity.Text1)).toString()
-        blockEntity.Text2 = new ChatMessage(JSON.parse(blockEntity.Text2)).toString()
-        blockEntity.Text3 = new ChatMessage(JSON.parse(blockEntity.Text3)).toString()
-        blockEntity.Text4 = new ChatMessage(JSON.parse(blockEntity.Text4)).toString()
-      }
+    // Handle signs
+    if (blockEntity.id === 'minecraft:sign') {
+      blockEntity.Text1 = new ChatMessage(JSON.parse(blockEntity.Text1)).toString()
+      blockEntity.Text2 = new ChatMessage(JSON.parse(blockEntity.Text2)).toString()
+      blockEntity.Text3 = new ChatMessage(JSON.parse(blockEntity.Text3)).toString()
+      blockEntity.Text4 = new ChatMessage(JSON.parse(blockEntity.Text4)).toString()
+    }
 
-      blockEntities[loc.floored] = blockEntity
+    blockEntities[loc.floored] = blockEntity
   }
 
   function addColumn (args) {
@@ -309,8 +309,6 @@ function inject (bot, { version }) {
 
   bot._client.on('tile_entity_data', (packet) => {
     addBlockEntity(packet.nbtData)
-    const blockEntity = nbt.simplify(packet.nbtData)
-    const point = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
   })
 
   bot.updateSign = (block, text) => {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -34,6 +34,22 @@ function inject (bot, { version }) {
     delete paintingsByPos[painting.position]
   }
 
+  function addBlockEntity (nbtData) {
+      const blockEntity = nbt.simplify(nbtData)
+      const absolutePoint = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
+      const loc = new Location(absolutePoint)
+
+      // Handle signs
+      if (blockEntity.id === 'minecraft:sign') {
+        blockEntity.Text1 = new ChatMessage(JSON.parse(blockEntity.Text1)).toString()
+        blockEntity.Text2 = new ChatMessage(JSON.parse(blockEntity.Text2)).toString()
+        blockEntity.Text3 = new ChatMessage(JSON.parse(blockEntity.Text3)).toString()
+        blockEntity.Text4 = new ChatMessage(JSON.parse(blockEntity.Text4)).toString()
+      }
+
+      blockEntities[loc.floored] = blockEntity
+  }
+
   function addColumn (args) {
     const columnCorner = new Vec3(args.x * 16, 0, args.z * 16)
     const key = columnKeyXZ(columnCorner.x, columnCorner.z)
@@ -53,25 +69,9 @@ function inject (bot, { version }) {
       return
     }
 
-    const chunkBlockEntities = {}
-
-    for (const nbtTag of args.blockEntities) {
-      const blockEntity = nbt.simplify(nbtTag)
-      const absolutePoint = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
-      const loc = new Location(absolutePoint)
-
-      // Handle signs
-      if (blockEntity.id === 'minecraft:sign') {
-        blockEntity.Text1 = new ChatMessage(JSON.parse(blockEntity.Text1)).toString()
-        blockEntity.Text2 = new ChatMessage(JSON.parse(blockEntity.Text2)).toString()
-        blockEntity.Text3 = new ChatMessage(JSON.parse(blockEntity.Text3)).toString()
-        blockEntity.Text4 = new ChatMessage(JSON.parse(blockEntity.Text4)).toString()
-      }
-
-      chunkBlockEntities[loc.floored] = blockEntity
+    for (const nbtData of args.blockEntities) {
+      addBlockEntity(nbtData)
     }
-
-    blockEntities.set(column, chunkBlockEntities)
 
     bot.emit('chunkColumnLoad', columnCorner)
   }
@@ -121,7 +121,7 @@ function inject (bot, { version }) {
     block.position = loc.floored
     block.signText = signs[loc.floored]
     block.painting = paintingsByPos[loc.floored]
-    block.blockEntity = blockEntities.get(column)[loc.floored]
+    block.blockEntity = blockEntities[loc.floored]
 
     return block
   }
@@ -184,6 +184,7 @@ function inject (bot, { version }) {
     column.setBlockType(posInChunk(point), type)
     column.setBlockData(posInChunk(point), metadata)
 
+    delete blockEntities[loc.floored]
     delete signs[loc.floored]
 
     const painting = paintingsByPos[loc.floored]
@@ -304,6 +305,12 @@ function inject (bot, { version }) {
 
     signs[pos] = `${new ChatMessage(JSON.parse(packet.text1))}\n${new ChatMessage(JSON.parse(packet.text2))}\n${new ChatMessage(JSON.parse(packet.text3))}\n${new ChatMessage(JSON.parse(packet.text4))}`
     emitBlockUpdate(oldBlock, blockAt(pos))
+  })
+
+  bot._client.on('tile_entity_data', (packet) => {
+    addBlockEntity(packet.nbtData)
+    const blockEntity = nbt.simplify(packet.nbtData)
+    const point = new Vec3(blockEntity.x, blockEntity.y, blockEntity.z)
   })
 
   bot.updateSign = (block, text) => {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -69,10 +69,6 @@ function inject (bot, { version }) {
       return
     }
 
-    for (const nbtData of args.blockEntities) {
-      addBlockEntity(nbtData)
-    }
-
     bot.emit('chunkColumnLoad', columnCorner)
   }
 
@@ -200,9 +196,14 @@ function inject (bot, { version }) {
       bitMap: packet.bitMap,
       skyLightSent: bot.game.dimension === 'overworld',
       groundUp: packet.groundUp,
-      data: packet.chunkData,
-      blockEntities: packet.blockEntities
+      data: packet.chunkData
     })
+
+    if (typeof packet.blockEntities !== 'undefined') {
+      for (const nbtData of packet.blockEntities) {
+        addBlockEntity(nbtData)
+      }
+    }
   })
 
   bot._client.on('map_chunk_bulk', (packet) => {


### PR DESCRIPTION
Adds a `blockEntity` field to the result of `bot.blockAt(position)`. 

Kind of workaround for #675 as we can now read sign text as follows:
```js
const { Text1, Text2, Text3, Text4 } = sign.blockEntity
if (Text1 === bot.username) {
  bot.chat('That\'s my sign!')
}
```

This also allows to gain data about stuff defined [there](https://minecraft.gamepedia.com/Block_entity)