### PR TITLE
delete npmignore and use whitelist in package.json instead

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-# shared with .gitignore
-# different than .gitignore
-test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.9.6",
   "description": "create minecraft bots with a stable, high level API",
   "main": "index.js",
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "scripts": {
     "test": "mocha --reporter spec",
     "pretest": "npm run lint",


### PR DESCRIPTION
Fixes a severe bundle size leak.