### PR TITLE
Make chatMessage instance work in strings

### DIFF
--- a/lib/chat_message.js
+++ b/lib/chat_message.js
@@ -228,6 +228,10 @@ class ChatMessage {
     return message.replace(/§[0-9a-flnmokr]/g, '')
   }
 
+  valueOf () {
+    return this.toString()
+  }
+
   toMotd (lang = defaultLang) {
     const codes = {
       color: {


### PR DESCRIPTION
So there is this fancy property that can let us use ChatMessage instance with normal strings.

![image](https://user-images.githubusercontent.com/13330620/67154535-310c1080-f2fe-11e9-877e-716ecfa3994e.png)

In the above example the literal is wrong because javascript is interpreting `${a}` as `a.toString()`. And since we have a `.toString` on ChatMessage, it should work just fine