### PR TITLE
Fix #873

### DIFF
--- a/lib/plugins/tablist.js
+++ b/lib/plugins/tablist.js
@@ -1,7 +1,7 @@
 module.exports = inject
 
 const escapeValueNewlines = str => {
-  return str.replace(/": *"((?:\\"|[^"])+)/, (_, match) => '":"' + match.replace('\n', '\\n'))
+  return str.replace(/(": *"(?:\\"|[^"])+")/g, (_, match) => match.replace('\n', '\\n'))
 }
 
 function inject (bot) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -30,7 +30,6 @@ mineflayer.supportedVersions.forEach((supportedVersion, i) => {
           username: 'player',
           version: supportedVersion,
           port: 25567
-          // logErrors: false
         })
         done()
       })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -30,6 +30,7 @@ mineflayer.supportedVersions.forEach((supportedVersion, i) => {
           username: 'player',
           version: supportedVersion,
           port: 25567
+          // logErrors: false
         })
         done()
       })
@@ -338,6 +339,29 @@ mineflayer.supportedVersions.forEach((supportedVersion, i) => {
               { type: 0, key: 0, value: 0 },
               { type: 0, key: 1, value: 1 }
             ]
+          })
+        })
+      })
+    })
+
+    describe('tablist', () => {
+      it('handles newlines in header and footer', (done) => {
+        const HEADER = 'asd\ndsa'
+        const FOOTER = '\nas\nas\nas\n'
+
+        bot._client.on('playerlist_header', (packet) => {
+          console.log(packet)
+          setImmediate(() => {
+            assert.strictEqual(bot.tablist.header.toString(), HEADER)
+            assert.strictEqual(bot.tablist.footer.toString(), FOOTER)
+            done()
+          })
+        })
+
+        server.on('login', (client) => {
+          client.write('playerlist_header', {
+            header: { text: '', extra: [{ text: HEADER, color: 'yellow' }] },
+            footer: { text: '', extra: [{ text: FOOTER, color: 'yellow' }] }
           })
         })
       })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -350,7 +350,6 @@ mineflayer.supportedVersions.forEach((supportedVersion, i) => {
         const FOOTER = '\nas\nas\nas\n'
 
         bot._client.on('playerlist_header', (packet) => {
-          console.log(packet)
           setImmediate(() => {
             assert.strictEqual(bot.tablist.header.toString(), HEADER)
             assert.strictEqual(bot.tablist.footer.toString(), FOOTER)
@@ -360,8 +359,8 @@ mineflayer.supportedVersions.forEach((supportedVersion, i) => {
 
         server.on('login', (client) => {
           client.write('playerlist_header', {
-            header: { text: '', extra: [{ text: HEADER, color: 'yellow' }] },
-            footer: { text: '', extra: [{ text: FOOTER, color: 'yellow' }] }
+            header: JSON.stringify({ text: '', extra: [{ text: HEADER, color: 'yellow' }] }),
+            footer: JSON.stringify({ text: '', extra: [{ text: FOOTER, color: 'yellow' }] })
           })
         })
       })


### PR DESCRIPTION
I'm matching whole replaced string so I don't have to add `": "` later.
Also I'm replacing every matched string which fixes #873