### PR TITLE
unload chunks on mc version 1.9-1.12

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -68,14 +68,20 @@ function inject (bot, { version }) {
 
     blockEntities[loc.floored] = blockEntity
   }
+  
+  function delColumn (chunkX, chunkY) {
+    const columnCorner = new Vec3(chunkX * 16, 0, chunkY * 16)
+    const key = columnKeyXZ(columnCorner.x, columnCorner.z)
+    delete columns[key]
+    bot.emit('chunkColumnUnload', columnCorner)
+  }
 
   function addColumn (args) {
     const columnCorner = new Vec3(args.x * 16, 0, args.z * 16)
     const key = columnKeyXZ(columnCorner.x, columnCorner.z)
     if (!args.bitMap) {
       // stop storing the chunk column
-      delete columns[key]
-      bot.emit('chunkColumnUnload', columnCorner)
+      delColumn (args.x, args.z)
       return
     }
     let column = columns[key]
@@ -210,6 +216,10 @@ function inject (bot, { version }) {
 
     emitBlockUpdate(oldBlock, newBlock)
   }
+  
+  bot._client.on('unload_chunk', (packet) => {
+    delColumn(packet.x, packet.z)
+  })
 
   bot._client.on('map_chunk', (packet) => {
     addColumn({

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -68,7 +68,7 @@ function inject (bot, { version }) {
 
     blockEntities[loc.floored] = blockEntity
   }
-  
+
   function delColumn (chunkX, chunkY) {
     const columnCorner = new Vec3(chunkX * 16, 0, chunkY * 16)
     const key = columnKeyXZ(columnCorner.x, columnCorner.z)
@@ -81,7 +81,7 @@ function inject (bot, { version }) {
     const key = columnKeyXZ(columnCorner.x, columnCorner.z)
     if (!args.bitMap) {
       // stop storing the chunk column
-      delColumn (args.x, args.z)
+      delColumn(args.x, args.z)
       return
     }
     let column = columns[key]
@@ -216,7 +216,7 @@ function inject (bot, { version }) {
 
     emitBlockUpdate(oldBlock, newBlock)
   }
-  
+
   bot._client.on('unload_chunk', (packet) => {
     delColumn(packet.x, packet.z)
   })


### PR DESCRIPTION
mc versions 1.9-1.12 dont send an empty map_chunk packet anymore, but rather an unload_chunk packet, implement functionality for it to prevent memory leaks