### PR TITLE
Update inventory window slot count

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -21,7 +21,7 @@ function inject (bot, { version }) {
   // 0-8, null = uninitialized
   // which quick bar slot is selected
   bot.quickBarSlot = null
-  bot.inventory = new windows.InventoryWindow(0, 'Inventory', 46)
+  bot.inventory = new windows.InventoryWindow(0, 'Inventory', bot.majorVersion === '1.8' ? 45 : 46)
   bot.currentWindow = null
   bot.heldItem = null
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -21,7 +21,7 @@ function inject (bot, { version }) {
   // 0-8, null = uninitialized
   // which quick bar slot is selected
   bot.quickBarSlot = null
-  bot.inventory = new windows.InventoryWindow(0, 'Inventory', 44)
+  bot.inventory = new windows.InventoryWindow(0, 'Inventory', 46)
   bot.currentWindow = null
   bot.heldItem = null
 


### PR DESCRIPTION
The current inventory size we use for initializing the slots array for the player inventory window is 44 for some arbitrary reason, the actual value is 46 (https://wiki.vg/index.php?title=Inventory&oldid=14093#Player_Inventory), and since js arrays have an unfixed length when the normal window_items packet is sent to update the player's inventory on login the slots array gets resized to 46 anyways.