### PR TITLE
Add a callback to `bot.creative.setInventorySlot` and fix tests failing randomly

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -260,7 +260,7 @@
       - [bot.moveSlotItem(sourceSlot, destSlot, cb)](#botmoveslotitemsourceslot-destslot-cb)
       - [bot.updateHeldItem()](#botupdatehelditem)
     - [bot.creative](#botcreative)
-      - [bot.creative.setInventorySlot(slot, item)](#botcreativesetinventoryslotslot-item)
+      - [bot.creative.setInventorySlot(slot, item, [callback])](#botcreativesetinventoryslotslot-item-callback)
       - [bot.creative.flyTo(destination, [cb])](#botcreativeflytodestination-cb)
       - [bot.creative.startFlying()](#botcreativestartflying)
       - [bot.creative.stopFlying()](#botcreativestopflying)
@@ -1565,13 +1565,14 @@ This collection of apis is useful in creative mode.
 Detecting and changing gamemodes is not implemented here,
 but it is assumed and often required that the bot be in creative mode for these features to work.
 
-#### bot.creative.setInventorySlot(slot, item)
+#### bot.creative.setInventorySlot(slot, item, [callback])
 
 Gives the bot the specified item in the specified inventory slot.
 
  * `slot` is in inventory window coordinates (where 36 is the first quickbar slot, etc.).
  * `item` can presumably be anything, specified with arbitrary metadata, nbtdata, etc.
     If `item` is `null`, the item at the specified slot is deleted.
+ * `callback(error)` (optional) is a callback which gets fired when the servers sets the slot
 
 If this method changes anything, you can be notified via `bot.inventory.on("windowUpdate")`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1568,11 +1568,12 @@ but it is assumed and often required that the bot be in creative mode for these 
 #### bot.creative.setInventorySlot(slot, item, [callback])
 
 Gives the bot the specified item in the specified inventory slot.
+If called twice on the same slot before first callback exceeds, first callback will have an error parameter
 
  * `slot` is in inventory window coordinates (where 36 is the first quickbar slot, etc.).
  * `item` can presumably be anything, specified with arbitrary metadata, nbtdata, etc.
     If `item` is `null`, the item at the specified slot is deleted.
- * `callback(error)` (optional) is a callback which gets fired when the servers sets the slot
+ * `callback(err)` (optional) is a callback which gets fired when the servers sets the slot
 
 If this method changes anything, you can be notified via `bot.inventory.on("windowUpdate")`.
 

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -14,8 +14,27 @@ function inject (bot, { version }) {
     stopFlying
   }
 
-  function setInventorySlot (slot, item) {
+  const creativeSlotsUpdates = new Map()
+  bot._client.on('set_slot', ({ windowId, slot, item }) => {
+    if (windowId === 0 && creativeSlotsUpdates.has(slot)) {
+      const cb = creativeSlotsUpdates.get(slot)
+      creativeSlotsUpdates.delete(slot)
+
+      setImmediate(cb)
+    }
+  })
+
+  function setInventorySlot (slot, item, cb) {
     assert(slot >= 0 && slot <= 44)
+
+    if (cb != null) {
+      if (creativeSlotsUpdates.has(slot)) {
+        cb(new Error('Server has not set this slot yet'))
+      }
+
+      creativeSlotsUpdates.set(slot, cb)
+    }
+
     bot._client.write('set_creative_slot', {
       slot,
       item: Item.toNotch(item)

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -24,12 +24,14 @@ function inject (bot, { version }) {
     }
   })
 
+  // WARN: This method should not be called twice on the same slot before first callback exceeds
   function setInventorySlot (slot, item, cb) {
     assert(slot >= 0 && slot <= 44)
 
     if (cb != null) {
       if (creativeSlotsUpdates.has(slot)) {
-        cb(new Error('Server has not set this slot yet'))
+        const oldCb = creativeSlotsUpdates.get(slot)
+        oldCb(new Error(`Setting slot ${slot} cancelled due to calling bot.creative.setInventorySlot(${slot}, ...) again`))
       }
 
       creativeSlotsUpdates.set(slot, cb)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -63,6 +63,7 @@ function inject (bot, { version }) {
     if (lastEating) {
       lastEating(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
+
     if (bot.food === 20) {
       return cb(new Error('Food is full'))
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -63,7 +63,6 @@ function inject (bot, { version }) {
     if (lastEating) {
       lastEating(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
-
     if (bot.food === 20) {
       return cb(new Error('Food is full'))
     }

--- a/test/externalTests/consume.js
+++ b/test/externalTests/consume.js
@@ -34,7 +34,9 @@ module.exports = () => (bot, done) => {
     }
   }
 
-  bot.test.setInventorySlot(36, new Item(297, 5, 0), () => {
+  bot.test.setInventorySlot(36, new Item(297, 5, 0), (err) => {
+    assert.ifError(err)
+
     // Cannot consume if bot.food === 20
     bot.consume((err) => {
       assert.notStrictEqual(err, undefined)

--- a/test/externalTests/crafting.js
+++ b/test/externalTests/crafting.js
@@ -1,3 +1,4 @@
+const assert = require('assert')
 const vec3 = require('vec3')
 
 module.exports = () => (bot, done) => {
@@ -45,7 +46,10 @@ module.exports = () => (bot, done) => {
 
   const craftTest = [
     (cb) => {
-      bot.test.setInventorySlot(36, new Item(mcData.blocksByName.log.id, 1, 0), cb)
+      bot.test.setInventorySlot(36, new Item(mcData.blocksByName.log.id, 1, 0), (err) => {
+        assert.ifError(err)
+        cb()
+      })
     },
     bot.test.becomeSurvival,
     (cb) => {

--- a/test/externalTests/creative.js
+++ b/test/externalTests/creative.js
@@ -1,0 +1,21 @@
+const assert = require('assert')
+const SLOT = 36
+
+module.exports = () => (bot, done) => {
+  const Item = require('prismarine-item')(bot.version)
+
+  const item1 = new Item(1, 1, 0)
+  const item2 = new Item(2, 1, 0)
+
+  bot.creative.setInventorySlot(SLOT, item1, (err) => {
+    assert.ok(err instanceof Error, 'The error has not been passed')
+    assert.ok(bot.inventory.slots[SLOT] == null)
+  })
+
+  bot.creative.setInventorySlot(SLOT, item2, (err) => {
+    assert.ifError(err)
+    assert.ok(bot.inventory.slots[SLOT] != null)
+    assert.ok(bot.inventory.slots[SLOT].type === item2.type)
+    done()
+  })
+}

--- a/test/externalTests/creative.js
+++ b/test/externalTests/creative.js
@@ -7,15 +7,19 @@ module.exports = () => (bot, done) => {
   const item1 = new Item(1, 1, 0)
   const item2 = new Item(2, 1, 0)
 
+  let firstCallbackFired = false
   bot.creative.setInventorySlot(SLOT, item1, (err) => {
     assert.ok(err instanceof Error, 'The error has not been passed')
     assert.ok(bot.inventory.slots[SLOT] == null)
+    firstCallbackFired = true
   })
 
   bot.creative.setInventorySlot(SLOT, item2, (err) => {
     assert.ifError(err)
     assert.ok(bot.inventory.slots[SLOT] != null)
     assert.ok(bot.inventory.slots[SLOT].type === item2.type)
+    assert.ok(firstCallbackFired)
+
     done()
   })
 }

--- a/test/externalTests/digAndBuild.js
+++ b/test/externalTests/digAndBuild.js
@@ -7,7 +7,10 @@ module.exports = () => (bot, done) => {
 
   const dirtCollectTest = [
     (cb) => {
-      bot.test.setInventorySlot(36, new Item(mcData.blocksByName.dirt.id, 1, 0), cb)
+      bot.test.setInventorySlot(36, new Item(mcData.blocksByName.dirt.id, 1, 0), (err) => {
+        assert.ifError(err)
+        cb()
+      })
     },
     (cb) => {
       bot.test.fly(new Vec3(0, 2, 0), cb)
@@ -24,7 +27,7 @@ module.exports = () => (bot, done) => {
     (cb) => {
       // we are bare handed
       bot.dig(bot.blockAt(bot.entity.position.plus(new Vec3(0, -1, 0))), (err) => {
-        assert(!err)
+        assert.ifError(err)
         cb()
       })
     },

--- a/test/externalTests/digEverything.js
+++ b/test/externalTests/digEverything.js
@@ -71,7 +71,10 @@ function digSomething (blockId, bot, done) {
 
   const diggingTest = [
     (cb) => {
-      bot.test.setInventorySlot(36, new Item(blockId, 1, 0), cb)
+      bot.test.setInventorySlot(36, new Item(blockId, 1, 0), (err) => {
+        assert.ifError(err)
+        cb()
+      })
     },
     (cb) => {
       // TODO: find a better way than this setTimeout(cb,200);
@@ -81,7 +84,10 @@ function digSomething (blockId, bot, done) {
     },
     bot.test.clearInventory,
     (cb) => {
-      bot.test.setInventorySlot(36, new Item(mcData.itemsByName.diamond_pickaxe.id, 1, 0), cb)
+      bot.test.setInventorySlot(36, new Item(mcData.itemsByName.diamond_pickaxe.id, 1, 0), (err) => {
+        assert.ifError(err)
+        cb()
+      })
     },
     bot.test.becomeSurvival,
     (cb) => {

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -5,7 +5,9 @@ module.exports = () => (bot, done) => {
 
   bot.test.sayEverywhere('/weather thunder')
   bot.test.sayEverywhere('/fill ~-5 ~-1 ~-5 ~5 ~-1 ~5 water')
-  bot.test.setInventorySlot(36, new Item(346, 1, 0), () => {
+  bot.test.setInventorySlot(36, new Item(346, 1, 0), (err) => {
+    assert.ifError(err)
+
     bot.lookAt(bot.entity.position, true, () => {
       bot.fish((err) => {
         setTimeout(() => {

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -149,9 +149,8 @@ function inject (bot) {
       // already good to go
       return setImmediate(cb)
     }
-    bot.creative.setInventorySlot(targetSlot, item)
-    // TODO: instead of that timeout, it would be better to have a good callback inside setInventorySlot
-    setTimeout(cb, 500)
+
+    bot.creative.setInventorySlot(targetSlot, item, cb)
   }
 
   function teleport (position, cb) {

--- a/test/externalTests/sign.js
+++ b/test/externalTests/sign.js
@@ -33,7 +33,8 @@ module.exports = () => (bot, done) => {
   })
 
   bot.lookAt(lowerBlock.position, true, () => {
-    bot.test.setInventorySlot(36, new Item(323, 1, 0), () => {
+    bot.test.setInventorySlot(36, new Item(323, 1, 0), (err) => {
+      assert.ifError(err)
       bot.placeBlock(lowerBlock, new Vec3(0, 1, 0), () => {})
     })
   })

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -19,9 +19,16 @@ module.exports = () => (bot, done) => {
 
     return [
       (cb) => {
-        bot.test.setInventorySlot(chestSlot, new Item(mcData.blocksByName.chest.id, 3, 0), () => {
-          bot.test.setInventorySlot(trappedChestSlot, new Item(mcData.blocksByName.trapped_chest.id, 3, 0), () => {
-            bot.test.setInventorySlot(boneSlot, new Item(mcData.itemsByName.bone.id, 3, 0), cb)
+        bot.test.setInventorySlot(chestSlot, new Item(mcData.blocksByName.chest.id, 3, 0), (err) => {
+          assert.ifError(err)
+
+          bot.test.setInventorySlot(trappedChestSlot, new Item(mcData.blocksByName.trapped_chest.id, 3, 0), (err) => {
+            assert.ifError(err)
+
+            bot.test.setInventorySlot(boneSlot, new Item(mcData.itemsByName.bone.id, 3, 0), (err) => {
+              assert.ifError(err)
+              cb()
+            })
           })
         })
       },


### PR DESCRIPTION
Well, this "randomly" was depending on the latency between client and server in the tests. We didn't have a callback in `bot.creative.setInventorySlot` and depended on `setTimeout`. This PR adds a callback and fixes this error.