### PR TITLE
Fix issue: Item tossed when crafted

### DIFF
--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -149,10 +149,7 @@ function inject (bot, { version }) {
 
       function grabResult () {
         assert.strictEqual(window.selectedItem, null)
-        // put the recipe result in the output
-        const item = new Item(recipe.result.id, recipe.result.count, recipe.result.metadata)
-        window.updateSlot(0, item)
-        // shift click result
+        // move the result to inventory
         bot.putAway(0, (err) => {
           if (err) {
             cb(err)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -508,7 +508,8 @@ function inject (bot, { version }) {
       mouseButton,
       mode,
       id: actionId,
-      windowId: window.id
+      windowId: window.id,
+      item: slot === -999 ? null : window.slots[slot]
     }
     windowClickQueue.push(click)
     bot._client.write('window_click', {


### PR DESCRIPTION
When picking the crafting result, the server update the slot before acknowledging the click:

```
client->server: play window_click : {"windowId":0,"slot":0,"mouseButton":0,"action":5,"mode":0,"item":{"blockId":58,"itemCount":1,"itemDamage":0}}
client<-server: play.unlock_recipes :{"action":1,"craftingBookOpen":false,"filteringCraftable":false,"recipes1":[]}
client<-server: play.set_slot :{"windowId":0,"slot":0,"item":{"blockId":-1}}
client<-server: play.set_slot :{"windowId":0,"slot":0,"item":{"blockId":72,"itemCount":1,"itemDamage":0}}
client<-server: play.set_slot :{"windowId":0,"slot":0,"item":{"blockId":143,"itemCount":1,"itemDamage":0}}
client<-server: play.set_slot :{"windowId":0,"slot":0,"item":{"blockId":-1}}
client<-server: play.transaction :{"windowId":0,"action":5,"accepted":true}
```

This result in slots[0] being set to null before `window.acceptSwapAreaLeftClick(click)` is called, so it cannot set `window.selectedItem` to the picked item (it is set to null).
Because of that, `putSelectedItemRange` does nothing and the item is toss later because the item was never stored in an inventory slot.

The solution I have is to save the item that was in the slot at the moment of the click (in the click object itself) so we can access it when the click is accepted, even if the slot has been changed (possibly multiple time) by the server.

I also noticed another bug in https://github.com/PrismarineJS/mineflayer/blob/master/lib/plugins/craft.js#L154

When forcing the crafting result to be the result of the recipe, instead of what the server sent, it can be that the metadata of the object is changed (for instance, when crafting planks from different kind of logs), so I just removed the lines 153-154.

Goes with https://github.com/PrismarineJS/prismarine-windows/pull/6

Close #905 #661