### PR TITLE
Fix error when trying to place a block

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -378,8 +378,8 @@ function inject (bot, { version }) {
   }
 
   function placeBlock (referenceBlock, faceVector, cb = noop) {
-    if (!bot.heldItem) cb(new Error('must be holding an item to place a block'))
     bot.lookAt(referenceBlock.position.offset(0.5, 0.5, 0.5), false, () => {
+      if (!bot.heldItem) return cb(new Error('must be holding an item to place a block'))
       // TODO: tell the server that we are sneaking while doing this
       bot.swingArm()
       const pos = referenceBlock.position

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -378,8 +378,8 @@ function inject (bot, { version }) {
   }
 
   function placeBlock (referenceBlock, faceVector, cb = noop) {
+    if (!bot.heldItem) return cb(new Error('must be holding an item to place a block'))
     bot.lookAt(referenceBlock.position.offset(0.5, 0.5, 0.5), false, () => {
-      if (!bot.heldItem) return cb(new Error('must be holding an item to place a block'))
       // TODO: tell the server that we are sneaking while doing this
       bot.swingArm()
       const pos = referenceBlock.position
@@ -549,6 +549,7 @@ function inject (bot, { version }) {
       clickWindow(destSlot, 0, 0, (err) => {
         // if we're holding an item, put it back where the source item was.
         // otherwise we're done.
+        updateHeldItem()
         if (err) {
           cb(err)
         } else if (bot.inventory.selectedItem) {


### PR DESCRIPTION
When trying to place a block after equipping the item without any delay, the check for the item being held gets triggered, but the block placing doesn't get cancelled as it should, resulting in the callback being called twice (first with an error because the item held has not been updated, secondly when the block placement succeed).

I also moved the check in the callback of the lookat action, because the extra delay seems to be giving the time for the item to update.

While this fix is solving the problem in my tests, I think the `bot.equip` function should watch the destination slot and only return successfully when the server acknowledged that the item is in it.