### PR TITLE
Fix craft

### DIFF
--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -149,6 +149,9 @@ function inject (bot, { version }) {
 
       function grabResult () {
         assert.strictEqual(window.selectedItem, null)
+        // put the recipe result in the output
+        const item = new Item(recipe.result.id, recipe.result.count, recipe.result.metadata)
+        window.updateSlot(0, item)
         // move the result to inventory
         bot.putAway(0, (err) => {
           if (err) {


### PR DESCRIPTION
Revert part of https://github.com/PrismarineJS/mineflayer/pull/940 to fix craft for versions <1.12