### PR TITLE
Fix villager assert + failing test

### DIFF
--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -8,7 +8,6 @@ function noop (err) {
 }
 
 function inject (bot, { version }) {
-  const mcData = require('minecraft-data')(version)
   const Item = require('prismarine-item')(version)
   const windows = require('prismarine-windows')(version).windows
 
@@ -53,7 +52,7 @@ function inject (bot, { version }) {
   ])
 
   function openVillager (villagerEntity) {
-    assert.strictEqual(villagerEntity.entityType, mcData.entitiesByName.villager)
+    assert.strictEqual(villagerEntity.name.toLowerCase(), 'villager')
     let ready = false
     const villager = bot.openEntity(villagerEntity, Villager)
     villager.trades = null

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -23,7 +23,7 @@ module.exports = () => (bot, done) => {
     })
   })
 
-  bot.on('playerCollect', (collector, collected) => {
+  bot.once('playerCollect', (collector, collected) => {
     if (collected.type === 'object') {
       bot.test.sayEverywhere('I caught: ' + collected.displayName)
       done()


### PR DESCRIPTION
In 1.8 villager has a capital letter, so in 1.8 the assert throws when it shouldn't