### PR TITLE
Improve block placement

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -379,7 +379,11 @@ function inject (bot, { version }) {
 
   function placeBlock (referenceBlock, faceVector, cb = noop) {
     if (!bot.heldItem) return cb(new Error('must be holding an item to place a block'))
-    bot.lookAt(referenceBlock.position.offset(0.5, 0.5, 0.5), false, () => {
+    // Look at the center of the face
+    const dx = 0.5 + faceVector.x * 0.5
+    const dy = 0.5 + faceVector.y * 0.5
+    const dz = 0.5 + faceVector.z * 0.5
+    bot.lookAt(referenceBlock.position.offset(dx, dy, dz), false, () => {
       // TODO: tell the server that we are sneaking while doing this
       bot.swingArm()
       const pos = referenceBlock.position


### PR DESCRIPTION
Makes the bot look at the face it's clicking instead of the center of the block. This looks better especially when the bot is making a bridge (placing block while standing on the reference block).