### PR TITLE
Incorrect window id in apologize packet

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -480,7 +480,7 @@ function inject (bot, { version }) {
 
     function onRejected () {
       bot._client.write('transaction', {
-        windowId: 0,
+        windowId: window.Id,
         action: click.id,
         accepted: false
       })


### PR DESCRIPTION
To fix successive window click being rejected due to wrong window id in the apologize packet.
(refer to https://wiki.vg/Protocol#Window_Confirmation_.28serverbound.29)