### PR TITLE
Handle disabled physics

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ class Bot extends EventEmitter {
     const self = this
     self._client = mc.createClient(options)
     self.username = self._client.username
+    self.plugins = options.plugins
     self._client.on('session', () => {
       self.username = self._client.username
     })

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -10,7 +10,8 @@ function inject (bot) {
   function dig (block, cb) {
     if (bot.targetDigBlock) bot.stopDigging()
     cb = cb || noop
-    bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false, () => {
+
+    function lookCb () {
       bot._client.write('block_dig', {
         status: 0, // start digging
         location: block.position,
@@ -77,7 +78,13 @@ function inject (bot) {
         bot.lastDigTime = new Date()
         bot._updateBlockState(block.position, 0)
       }
-    })
+    }
+
+    if (bot.plugins.physics === false) {
+      lookCb()
+    } else {
+      bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false, lookCb)
+    }
   }
 
   function canDigBlock (block) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -172,7 +172,7 @@ function inject (bot, { version }) {
 
   function activateBlock (block, cb) {
     // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false, () => {
+    function lookCb () {
       // place block message
       if (bot.supportFeature('blockPlaceHasHeldItem')) {
         bot._client.write('block_place', {
@@ -217,18 +217,30 @@ function inject (bot, { version }) {
       bot.swingArm()
 
       if (cb) cb()
-    })
+    }
+
+    if (bot.plugins.physics === false) {
+      lookCb()
+    } else {
+      bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false, lookCb)
+    }
   }
 
   function activateEntity (entity, cb) {
     // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(entity.position.offset(0, 1, 0), false, () => {
+    function lookCb () {
       bot._client.write('use_entity', {
         target: entity.id,
         mouse: 0
       })
       if (cb) cb()
-    })
+    }
+
+    if (bot.plugins.physics === false) {
+      lookCb()
+    } else {
+      bot.lookAt(entity.position.offset(0, 1, 0), false, lookCb)
+    }
   }
 
   function transfer (options, cb) {


### PR DESCRIPTION
If you try to open a chest (for example) with the physics plugin disabled the bot tries to call `bot.lookAt(...` and as the plugin that handles that function is disabled, the bot throws error. I don't think this shold happen

Edit: If you encountered the same problem, an easy _fix_ is to add a bot.look function yourself that calls the callback. Something like this:
```js
const bot = mineflayer.createBot({
  // ...
})
bot.lookAt = (a, b, cb) => {
  cb()
}
```