### PR TITLE
Fix 2 transfer bugs

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -261,7 +261,6 @@ function inject (bot, { version }) {
         if (!sourceItem) return cb(new Error(`missing source item ${itemType}:${metadata} in (${sourceStart},${sourceEnd})`))
         if (firstSourceSlot === null) firstSourceSlot = sourceItem.slot
         // number of item that can be moved from that slot
-        var sourceItemCount = sourceItem.count
         clickWindow(sourceItem.slot, 0, 0, (err) => {
           if (err) {
             cb(err)
@@ -295,8 +294,8 @@ function inject (bot, { version }) {
           }
         }
         // move the maximum number of item that can be moved
-        const destSlotCount = destSlot.count ? destSlot.count : 0
-        const movedItems = Math.min(64 - destSlotCount, sourceItemCount)
+        const destSlotCount = destItem && destItem.count ? destItem.count : 0
+        const movedItems = Math.min(window.selectedItem.stackSize - destSlotCount, window.selectedItem.count)
         // if the number of item the left click moves is less than the number of item we want to move
         // several at the same time (left click)
         if (movedItems <= count) {
@@ -304,9 +303,7 @@ function inject (bot, { version }) {
             if (err) {
               cb(err)
             } else {
-              // update the number of item that can be moved at the source slot (sourceItemCount)
-              sourceItemCount -= movedItems
-              // and the number of item we want to move (count)
+              // update the number of item we want to move (count)
               count -= movedItems
               transferOne()
             }


### PR DESCRIPTION
This PR fix 2 bugs in the transfer function:
* Closes #988 thanks @ImHarvol for finding the bug
* I also confirm the bug in https://github.com/PrismarineJS/mineflayer/pull/954/files but the fix doesn't require to add a dependency on mcData, so I cleaned-up and included the fix of @khang-hoang

To give more insights:
* first bug is due to the use of a variable declared outside of the scope (`sourceItemCount`)
* second bug is that `destSlot` is an integer and never contains a count, `destItem` is the variable we want to use.

Lastly, in his PR @khang-hoang fixed a potential issue for items that don't have a `stackSize` of 64 (like enderpearls with a `stackSize` of 16), so it is included as well.