### PR TITLE
Fix SyntaxError: Unexpected token {

### DIFF
--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -14,7 +14,7 @@ class ScoreBoard {
   setTitle (title) {
     try {
       this.title = JSON.parse(title).text // version>1.13
-    } catch {
+    } catch(e) {
       this.title = title
     }
   }


### PR DESCRIPTION
```
C:\Users\<censored>\Desktop\mc\node_modules\mineflayer\lib\scoreboard.js:17
    } catch {
            ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```