### PR TITLE
The Physic Update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@ higher level API on top of Mineflayer.
 
  * [navigate](https://github.com/andrewrk/mineflayer-navigate/) - get around
    easily using A* pathfinding. [YouTube Demo](https://www.youtube.com/watch?v=O6lQdmRz8eE)
+ * [pathfinder](https://github.com/Karang/mineflayer-pathfinder) - advanced A* pathfinding with a lot of configurable features
  * [radar](https://github.com/andrewrk/mineflayer-radar/) - web based radar
    interface using canvas and socket.io. [YouTube Demo](https://www.youtube.com/watch?v=FjDmAfcVulQ)
  * [blockfinder](https://github.com/Darthfett/mineflayer-blockFinder) - find blocks in the 3D world

--- a/lib/aabb.js
+++ b/lib/aabb.js
@@ -1,0 +1,107 @@
+class AABB {
+  constructor (x0, y0, z0, x1, y1, z1) {
+    this.minX = x0
+    this.minY = y0
+    this.minZ = z0
+    this.maxX = x1
+    this.maxY = y1
+    this.maxZ = z1
+  }
+
+  clone () {
+    return new AABB(this.minX, this.minY, this.minZ, this.maxX, this.maxY, this.maxZ)
+  }
+
+  floor () {
+    this.minX = Math.floor(this.minX)
+    this.minY = Math.floor(this.minY)
+    this.minZ = Math.floor(this.minZ)
+    this.maxX = Math.floor(this.maxX)
+    this.maxY = Math.floor(this.maxY)
+    this.maxZ = Math.floor(this.maxZ)
+  }
+
+  extend (dx, dy, dz) {
+    if (dx < 0) this.minX += dx
+    else this.maxX += dx
+
+    if (dy < 0) this.minY += dy
+    else this.maxY += dy
+
+    if (dz < 0) this.minZ += dz
+    else this.maxZ += dz
+
+    return this
+  }
+
+  contract (x, y, z) {
+    this.minX += x
+    this.minY += y
+    this.minZ += z
+    this.maxX -= x
+    this.maxY -= y
+    this.maxZ -= z
+    return this
+  }
+
+  expand (x, y, z) {
+    this.minX -= x
+    this.minY -= y
+    this.minZ -= z
+    this.maxX += x
+    this.maxY += y
+    this.maxZ += z
+    return this
+  }
+
+  offset (x, y, z) {
+    this.minX += x
+    this.minY += y
+    this.minZ += z
+    this.maxX += x
+    this.maxY += y
+    this.maxZ += z
+    return this
+  }
+
+  computeOffsetX (other, offsetX) {
+    if (other.maxY > this.minY && other.minY < this.maxY && other.maxZ > this.minZ && other.minZ < this.maxZ) {
+      if (offsetX > 0.0 && other.maxX <= this.minX) {
+        offsetX = Math.min(this.minX - other.maxX, offsetX)
+      } else if (offsetX < 0.0 && other.minX >= this.maxX) {
+        offsetX = Math.max(this.maxX - other.minX, offsetX)
+      }
+    }
+    return offsetX
+  }
+
+  computeOffsetY (other, offsetY) {
+    if (other.maxX > this.minX && other.minX < this.maxX && other.maxZ > this.minZ && other.minZ < this.maxZ) {
+      if (offsetY > 0.0 && other.maxY <= this.minY) {
+        offsetY = Math.min(this.minY - other.maxY, offsetY)
+      } else if (offsetY < 0.0 && other.minY >= this.maxY) {
+        offsetY = Math.max(this.maxY - other.minY, offsetY)
+      }
+    }
+    return offsetY
+  }
+
+  computeOffsetZ (other, offsetZ) {
+    if (other.maxX > this.minX && other.minX < this.maxX && other.maxY > this.minY && other.minY < this.maxY) {
+      if (offsetZ > 0.0 && other.maxZ <= this.minZ) {
+        offsetZ = Math.min(this.minZ - other.maxZ, offsetZ)
+      } else if (offsetZ < 0.0 && other.minZ >= this.maxZ) {
+        offsetZ = Math.max(this.maxZ - other.minZ, offsetZ)
+      }
+    }
+    return offsetZ
+  }
+
+  intersects (other) {
+    return this.minX < other.maxX && this.maxX > other.minX &&
+           this.minY < other.maxY && this.maxY > other.minY &&
+           this.minZ < other.maxZ && this.maxZ > other.minZ
+  }
+}
+
+module.exports = AABB

--- a/lib/conversions.js
+++ b/lib/conversions.js
@@ -6,8 +6,8 @@ const PI_2 = Math.PI * 2
 const TO_RAD = PI / 180
 const TO_DEG = 1 / TO_RAD
 const FROM_NOTCH_BYTE = 360 / 256
-const FROM_NOTCH_VEL_VERTICAL = 1 / 512 * 1.5
-const FROM_NOTCH_VEL_HORIZONTAL = 1 / 256
+// From wiki.vg: Velocity is believed to be in units of 1/8000 of a block per server tick (50ms)
+const FROM_NOTCH_VEL = 1 / 8000
 
 exports.toRadians = toRadians
 exports.toDegrees = toDegrees
@@ -36,5 +36,5 @@ function fromNotchianPitch (pitch) {
 }
 
 function fromNotchVelocity (vel) {
-  return new Vec3(vel.x * FROM_NOTCH_VEL_HORIZONTAL, vel.y * FROM_NOTCH_VEL_VERTICAL, vel.z * FROM_NOTCH_VEL_HORIZONTAL)
+  return new Vec3(vel.x * FROM_NOTCH_VEL, vel.y * FROM_NOTCH_VEL, vel.z * FROM_NOTCH_VEL)
 }

--- a/lib/features.json
+++ b/lib/features.json
@@ -90,6 +90,11 @@
       "versions": ["1.8"]
     },
     {
+      "name": "positionUpdateSentEveryTick",
+      "description": "",
+      "versions": ["1.8", "1.9", "1.10", "1.11"]
+    },
+    {
       "name": "teleportUsesOwnPacket",
       "description": "teleport is done using its own packet",
       "versions": ["1.9", "1.10", "1.11", "1.12", "1.13", "1.14", "1.15"]

--- a/lib/math.js
+++ b/lib/math.js
@@ -1,9 +1,5 @@
 exports.clamp = function clamp (min, x, max) {
-  return x < min ? min : x > max ? max : x
-}
-
-exports.sign = function sign (n) {
-  return n > 0 ? 1 : n < 0 ? -1 : 0
+  return Math.max(min, Math.min(x, max))
 }
 
 exports.euclideanMod = function euclideanMod (numerator, denominator) {

--- a/lib/physics.js
+++ b/lib/physics.js
@@ -29,20 +29,36 @@ function Physics (mcData, world) {
 
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
+    airdrag: (1 - 0.02), // actually (1 - drag)
     yawSpeed: 3.0,
     sprintSpeed: 1.3,
+    sneakSpeed: 0.3,
     stepHeight: 0.6, // how much height can the bot step on without jump
-    negligeableVelocity: 0.003 // actually 0.005 for 1.8, but seems fine
+    negligeableVelocity: 0.003, // actually 0.005 for 1.8, but seems fine
+    soulsandSpeed: 0.4,
+    ladderMaxSpeed: 0.15,
+    ladderClimbSpeed: 0.2,
+    playerHalfWidth: 0.3,
+    playerHeight: 1.8,
+    waterInertia: 0.8,
+    lavaInertia: 0.5,
+    liquidAcceleration: 0.02,
+    airborneInertia: 0.91,
+    airborneAcceleration: 0.02,
+    defaultSlipperiness: 0.6,
+    outOfLiquidImpulse: 0.3,
+    autojumpCooldown: 10 // ticks (0.5s)
   }
 
   function getPlayerBB (pos) {
-    return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
+    const w = physics.playerHalfWidth
+    return new AABB(-w, 0, -w, w, physics.playerHeight, w).offset(pos.x, pos.y, pos.z)
   }
 
   function setPositionToBB (bb, pos) {
-    pos.x = bb.minX + 0.3
+    pos.x = bb.minX + physics.playerHalfWidth
     pos.y = bb.minY
-    pos.z = bb.minZ + 0.3
+    pos.z = bb.minZ + physics.playerHalfWidth
   }
 
   function getSurroundingBBs (world, queryBB) {
@@ -215,8 +231,8 @@ function Physics (mcData, world) {
           const block = world.getBlock(cursor)
           if (block) {
             if (block.type === soulsandId) {
-              vel.x *= 0.4
-              vel.z *= 0.4
+              vel.x *= physics.soulsandSpeed
+              vel.z *= physics.soulsandSpeed
             } else if (block.type === webId) {
               entity.isInWeb = true
             }
@@ -255,11 +271,11 @@ function Physics (mcData, world) {
 
     if (!entity.isInWater && !entity.isInLava) {
       // Normal movement
-      let acceleration = 0.02 // airborne
-      let inertia = 0.91
+      let acceleration = physics.airborneAcceleration
+      let inertia = physics.airborneInertia
       const blockUnder = world.getBlock(pos.offset(0, -1, 0))
       if (entity.onGround && blockUnder) {
-        inertia = (blockSlipperiness[blockUnder.type] || 0.6) * 0.91
+        inertia = (blockSlipperiness[blockUnder.type] || physics.defaultSlipperiness) * 0.91
         acceleration = 0.1 * (0.1627714 / (inertia * inertia * inertia))
       }
       if (entity.control.sprint) acceleration *= physics.sprintSpeed
@@ -267,27 +283,26 @@ function Physics (mcData, world) {
       applyHeading(entity, strafe, forward, acceleration)
 
       if (isOnLadder(world, pos)) {
-        const ladderMaxSpeed = 0.15
-        vel.x = math.clamp(-ladderMaxSpeed, vel.x, ladderMaxSpeed)
-        vel.z = math.clamp(-ladderMaxSpeed, vel.z, ladderMaxSpeed)
-        vel.y = Math.max(vel.y, entity.control.sneak ? 0 : -ladderMaxSpeed)
+        vel.x = math.clamp(-physics.ladderMaxSpeed, vel.x, physics.ladderMaxSpeed)
+        vel.z = math.clamp(-physics.ladderMaxSpeed, vel.z, physics.ladderMaxSpeed)
+        vel.y = Math.max(vel.y, entity.control.sneak ? 0 : -physics.ladderMaxSpeed)
       }
 
       moveEntity(entity, world, vel.x, vel.y, vel.z)
 
       if (entity.isCollidedHorizontally && isOnLadder(world, pos)) {
-        vel.y = 0.2 // climb ladder
+        vel.y = physics.ladderClimbSpeed // climb ladder
       }
 
       // Apply friction and gravity
       vel.y -= physics.gravity
-      vel.y *= 0.98 // air drag
+      vel.y *= physics.airdrag
       vel.x *= inertia
       vel.z *= inertia
     } else {
       // Water / Lava movement
-      const acceleration = 0.02
-      const inertia = entity.isInWater ? 0.8 : 0.5
+      const acceleration = physics.liquidAcceleration
+      const inertia = entity.isInWater ? physics.waterInertia : physics.lavaInertia
       // TODO: depth strider enchantement (for water)
       applyHeading(entity, strafe, forward, acceleration)
       moveEntity(entity, world, vel.x, vel.y, vel.z)
@@ -297,7 +312,7 @@ function Physics (mcData, world) {
       vel.z *= inertia
 
       if (entity.isCollidedHorizontally) { // TODO: && isOffsetPositionInLiquid
-        vel.y = 0.3 // jump out of liquid
+        vel.y = physics.outOfLiquidImpulse // jump out of liquid
       }
     }
   }
@@ -417,7 +432,7 @@ function Physics (mcData, world) {
           vel.x -= Math.sin(yaw) * 0.2
           vel.z += Math.cos(yaw) * 0.2
         }
-        entity.jumpTicks = 10 // activate autojump cooldown (0.5s)
+        entity.jumpTicks = physics.autojumpCooldown
       }
     } else {
       entity.jumpTicks = 0 // reset autojump cooldown
@@ -428,8 +443,8 @@ function Physics (mcData, world) {
     let forward = (entity.control.forward - entity.control.back) * 0.98
 
     if (entity.control.sneak) {
-      strafe *= 0.3
-      forward *= 0.3
+      strafe *= physics.sneakSpeed
+      forward *= physics.sneakSpeed
     }
 
     moveEntityWithHeading(entity, world, strafe, forward)

--- a/lib/physics.js
+++ b/lib/physics.js
@@ -1,0 +1,476 @@
+const Vec3 = require('vec3').Vec3
+const AABB = require('./aabb')
+const math = require('./math')
+
+function Physics (mcData, world) {
+  const blocksByName = mcData.blocksByName
+
+  // Block Slipperiness
+  // https://www.mcpk.wiki/w/index.php?title=Slipperiness
+  const blockSlipperiness = {}
+  const slimeBlockId = blocksByName.slime_block ? blocksByName.slime_block.id : blocksByName.slime.id
+  blockSlipperiness[slimeBlockId] = 0.8
+  blockSlipperiness[blocksByName.ice.id] = 0.98
+  blockSlipperiness[blocksByName.packed_ice.id] = 0.98
+  if (blocksByName.frosted_ice) { // 1.9+
+    blockSlipperiness[blocksByName.frosted_ice.id] = 0.98
+  }
+  if (blocksByName.blue_ice) { // 1.13+
+    blockSlipperiness[blocksByName.blue_ice.id] = 0.989
+  }
+
+  // Block ids
+  const soulsandId = blocksByName.soul_sand.id
+  const webId = blocksByName.cobweb ? blocksByName.cobweb.id : blocksByName.web.id
+  const waterId = blocksByName.water.id
+  const lavaId = blocksByName.lava.id
+  const ladderId = blocksByName.ladder.id
+  const vineId = blocksByName.vine.id
+
+  const physics = {
+    gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
+    yawSpeed: 3.0,
+    sprintSpeed: 1.3,
+    stepHeight: 0.6, // how much height can the bot step on without jump
+    negligeableVelocity: 0.003 // actually 0.005 for 1.8, but seems fine
+  }
+
+  function getPlayerBB (pos) {
+    return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
+  }
+
+  function setPositionToBB (bb, pos) {
+    pos.x = bb.minX + 0.3
+    pos.y = bb.minY
+    pos.z = bb.minZ + 0.3
+  }
+
+  function getSurroundingBBs (world, queryBB) {
+    const surroundingBBs = []
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
+          const block = world.getBlock(cursor)
+          if (block) {
+            const blockPos = block.position
+            for (const shape of block.shapes) {
+              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5])
+              blockBB.offset(blockPos.x, blockPos.y, blockPos.z)
+              surroundingBBs.push(blockBB)
+            }
+          }
+        }
+      }
+    }
+    return surroundingBBs
+  }
+
+  physics.adjustPositionHeight = (pos) => {
+    const playerBB = getPlayerBB(pos)
+    const queryBB = playerBB.clone().extend(0, -1, 0)
+    const surroundingBBs = getSurroundingBBs(world, queryBB)
+
+    let dy = -1
+    for (const blockBB of surroundingBBs) {
+      dy = blockBB.computeOffsetY(playerBB, dy)
+    }
+    pos.y += dy
+  }
+
+  function moveEntity (entity, world, dx, dy, dz) {
+    const vel = entity.vel
+    const pos = entity.pos
+
+    if (entity.isInWeb) {
+      dx *= 0.25
+      dy *= 0.05
+      dz *= 0.25
+      vel.x = 0
+      vel.y = 0
+      vel.z = 0
+      entity.isInWeb = false
+    }
+
+    const oldVelX = dx
+    const oldVelY = dy
+    const oldVelZ = dz
+
+    let playerBB = getPlayerBB(pos)
+    const queryBB = playerBB.clone().extend(dx, dy, dz)
+    const surroundingBBs = getSurroundingBBs(world, queryBB)
+    const oldBB = playerBB.clone()
+
+    for (const blockBB of surroundingBBs) {
+      dy = blockBB.computeOffsetY(playerBB, dy)
+    }
+    playerBB.offset(0, dy, 0)
+
+    for (const blockBB of surroundingBBs) {
+      dx = blockBB.computeOffsetX(playerBB, dx)
+    }
+    playerBB.offset(dx, 0, 0)
+
+    for (const blockBB of surroundingBBs) {
+      dz = blockBB.computeOffsetZ(playerBB, dz)
+    }
+    playerBB.offset(0, 0, dz)
+
+    // Step on block if height < stepHeight
+    if (physics.stepHeight > 0 &&
+        (entity.onGround || (dy !== oldVelY && oldVelY < 0)) &&
+        (dx !== oldVelX || dz !== oldVelZ)) {
+      const oldVelXCol = dx
+      const oldVelYCol = dy
+      const oldVelZCol = dz
+      const oldBBCol = playerBB.clone()
+
+      dy = physics.stepHeight
+      const queryBB = oldBB.clone().extend(oldVelX, dy, oldVelZ)
+      const surroundingBBs = getSurroundingBBs(world, queryBB)
+
+      const BB1 = oldBB.clone()
+      const BB2 = oldBB.clone()
+      const BB_XZ = BB1.clone().extend(dx, 0, dz)
+
+      let dy1 = dy
+      let dy2 = dy
+      for (const blockBB of surroundingBBs) {
+        dy1 = blockBB.computeOffsetY(BB_XZ, dy1)
+        dy2 = blockBB.computeOffsetY(BB2, dy2)
+      }
+      BB1.offset(0, dy1, 0)
+      BB2.offset(0, dy2, 0)
+
+      let dx1 = oldVelX
+      let dx2 = oldVelX
+      for (const blockBB of surroundingBBs) {
+        dx1 = blockBB.computeOffsetX(BB1, dx1)
+        dx2 = blockBB.computeOffsetX(BB2, dx2)
+      }
+      BB1.offset(dx1, 0, 0)
+      BB2.offset(dx2, 0, 0)
+
+      let dz1 = oldVelZ
+      let dz2 = oldVelZ
+      for (const blockBB of surroundingBBs) {
+        dz1 = blockBB.computeOffsetZ(BB1, dz1)
+        dz2 = blockBB.computeOffsetZ(BB2, dz2)
+      }
+      BB1.offset(0, 0, dz1)
+      BB2.offset(0, 0, dz2)
+
+      const norm1 = dx1 * dx1 + dz1 * dz1
+      const norm2 = dx2 * dx2 + dz2 * dz2
+
+      if (norm1 > norm2) {
+        dx = dx1
+        dy = -dy1
+        dz = dz1
+        playerBB = BB1
+      } else {
+        dx = dx2
+        dy = -dy2
+        dz = dz2
+        playerBB = BB2
+      }
+
+      for (const blockBB of surroundingBBs) {
+        dy = blockBB.computeOffsetY(playerBB, dy)
+      }
+      playerBB.offset(0, dy, 0)
+
+      if (oldVelXCol * oldVelXCol + oldVelZCol * oldVelZCol >= dx * dx + dz * dz) {
+        dx = oldVelXCol
+        dy = oldVelYCol
+        dz = oldVelZCol
+        playerBB = oldBBCol
+      }
+    }
+
+    // Update flags
+    setPositionToBB(playerBB, pos)
+    entity.isCollidedHorizontally = dx !== oldVelX || dz !== oldVelZ
+    entity.isCollidedVertically = dy !== oldVelY
+    entity.onGround = entity.isCollidedVertically && oldVelY < 0
+
+    const blockAtFeet = world.getBlock(pos.offset(0, -0.2, 0))
+
+    if (dx !== oldVelX) vel.x = 0
+    if (dz !== oldVelZ) vel.z = 0
+    if (dy !== oldVelY) {
+      if (blockAtFeet && blockAtFeet.type === slimeBlockId && !entity.control.sneak) {
+        vel.y = -vel.y
+      } else {
+        vel.y = 0
+      }
+    }
+
+    // Finally, apply block collisions (web, soulsand...)
+    playerBB.contract(0.001, 0.001, 0.001)
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(playerBB.minY); cursor.y <= Math.floor(playerBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(playerBB.minZ); cursor.z <= Math.floor(playerBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(playerBB.minX); cursor.x <= Math.floor(playerBB.maxX); cursor.x++) {
+          const block = world.getBlock(cursor)
+          if (block) {
+            if (block.type === soulsandId) {
+              vel.x *= 0.4
+              vel.z *= 0.4
+            } else if (block.type === webId) {
+              entity.isInWeb = true
+            }
+          }
+        }
+      }
+    }
+  }
+
+  function applyHeading (entity, strafe, forward, multiplier) {
+    let speed = Math.sqrt(strafe * strafe + forward * forward)
+    if (speed < 0.01) return new Vec3(0, 0, 0)
+
+    speed = multiplier / Math.max(speed, 1)
+
+    strafe *= speed
+    forward *= speed
+
+    const yaw = Math.PI - entity.yaw
+    const sin = Math.sin(yaw)
+    const cos = Math.cos(yaw)
+
+    const vel = entity.vel
+    vel.x += strafe * cos - forward * sin
+    vel.z += forward * cos + strafe * sin
+  }
+
+  function isOnLadder (world, pos) {
+    const block = world.getBlock(pos)
+    return (block && (block.type === ladderId || block.type === vineId))
+  }
+
+  function moveEntityWithHeading (entity, world, strafe, forward) {
+    const vel = entity.vel
+    const pos = entity.pos
+
+    if (!entity.isInWater && !entity.isInLava) {
+      // Normal movement
+      let acceleration = 0.02 // airborne
+      let inertia = 0.91
+      const blockUnder = world.getBlock(pos.offset(0, -1, 0))
+      if (entity.onGround && blockUnder) {
+        inertia = (blockSlipperiness[blockUnder.type] || 0.6) * 0.91
+        acceleration = 0.1 * (0.1627714 / (inertia * inertia * inertia))
+      }
+      if (entity.control.sprint) acceleration *= physics.sprintSpeed
+
+      applyHeading(entity, strafe, forward, acceleration)
+
+      if (isOnLadder(world, pos)) {
+        const ladderMaxSpeed = 0.15
+        vel.x = math.clamp(-ladderMaxSpeed, vel.x, ladderMaxSpeed)
+        vel.z = math.clamp(-ladderMaxSpeed, vel.z, ladderMaxSpeed)
+        vel.y = Math.max(vel.y, entity.control.sneak ? 0 : -ladderMaxSpeed)
+      }
+
+      moveEntity(entity, world, vel.x, vel.y, vel.z)
+
+      if (entity.isCollidedHorizontally && isOnLadder(world, pos)) {
+        vel.y = 0.2 // climb ladder
+      }
+
+      // Apply friction and gravity
+      vel.y -= physics.gravity
+      vel.y *= 0.98 // air drag
+      vel.x *= inertia
+      vel.z *= inertia
+    } else {
+      // Water / Lava movement
+      const acceleration = 0.02
+      const inertia = entity.isInWater ? 0.8 : 0.5
+      // TODO: depth strider enchantement (for water)
+      applyHeading(entity, strafe, forward, acceleration)
+      moveEntity(entity, world, vel.x, vel.y, vel.z)
+      vel.y *= inertia
+      vel.y -= 0.02
+      vel.x *= inertia
+      vel.z *= inertia
+
+      if (entity.isCollidedHorizontally) { // TODO: && isOffsetPositionInLiquid
+        vel.y = 0.3 // jump out of liquid
+      }
+    }
+  }
+
+  function isMaterialInBB (world, queryBB, type) {
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
+          const block = world.getBlock(cursor)
+          if (block && block.type === type) return true
+        }
+      }
+    }
+    return false
+  }
+
+  function getLiquidHeightPcent (block) {
+    return (getRenderedDepth(block) + 1) / 9
+  }
+
+  function getRenderedDepth (block) {
+    if (!block || block.type !== waterId) return -1
+    const meta = block.metadata
+    return meta >= 8 ? 0 : meta
+  }
+
+  function getFlow (world, block) {
+    const curlevel = getRenderedDepth(block)
+    const flow = new Vec3(0, 0, 0)
+    for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
+      const adjBlock = world.getBlock(block.position.offset(dx, 0, dz))
+      const adjLevel = getRenderedDepth(adjBlock)
+      if (adjLevel < 0) {
+        if (adjBlock.boundingBox !== 'empty') {
+          const adjLevel = getRenderedDepth(world.getBlock(block.position.offset(dx, -1, dz)))
+          if (adjLevel >= 0) {
+            const f = adjLevel - (curlevel - 8)
+            flow.x += dx * f
+            flow.z += dz * f
+          }
+        }
+      } else {
+        const f = adjLevel - curlevel
+        flow.x += dx * f
+        flow.z += dz * f
+      }
+    }
+
+    if (block.metadata >= 8) {
+      for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
+        const adjBlock = world.getBlock(block.position.offset(dx, 0, dz))
+        const adjUpBlock = world.getBlock(block.position.offset(dx, 1, dz))
+        if (adjBlock.boundingBox !== 'empty' || adjUpBlock.boundingBox !== 'empty') {
+          flow.normalize().translate(0, -6, 0)
+        }
+      }
+    }
+
+    return flow.normalize()
+  }
+
+  function isInWaterApplyCurrent (world, bb, vel) {
+    let isInWater = false
+    const acceleration = new Vec3(0, 0, 0)
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(bb.minY); cursor.y <= Math.floor(bb.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(bb.minZ); cursor.z <= Math.floor(bb.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(bb.minX); cursor.x <= Math.floor(bb.maxX); cursor.x++) {
+          const block = world.getBlock(cursor)
+          if (block && block.type === waterId) {
+            const waterLevel = cursor.y + 1 - getLiquidHeightPcent(block)
+            if (Math.ceil(bb.maxY) >= waterLevel) {
+              isInWater = true
+              const flow = getFlow(world, block)
+              acceleration.add(flow)
+            }
+          }
+        }
+      }
+    }
+
+    const len = acceleration.norm()
+    if (len > 0) {
+      vel.x += acceleration.x / len * 0.014
+      vel.y += acceleration.y / len * 0.014
+      vel.z += acceleration.z / len * 0.014
+    }
+    return isInWater
+  }
+
+  physics.simulatePlayer = (entity, world) => {
+    const vel = entity.vel
+    const pos = entity.pos
+
+    const waterBB = getPlayerBB(pos).contract(0.001, 0.401, 0.001)
+    const lavaBB = getPlayerBB(pos).contract(0.1, 0.4, 0.1)
+
+    entity.isInWater = isInWaterApplyCurrent(world, waterBB, vel)
+    entity.isInLava = isMaterialInBB(world, lavaBB, lavaId)
+
+    // Reset velocity component if it falls under the threshold
+    if (Math.abs(vel.x) < physics.negligeableVelocity) vel.x = 0
+    if (Math.abs(vel.y) < physics.negligeableVelocity) vel.y = 0
+    if (Math.abs(vel.z) < physics.negligeableVelocity) vel.z = 0
+
+    // Handle inputs
+    if (entity.control.jump || entity.jumpQueued) {
+      if (entity.jumpTicks > 0) entity.jumpTicks--
+      if (entity.isInWater || entity.isInLava) {
+        vel.y += 0.04
+      } else if (entity.onGround && entity.jumpTicks === 0) {
+        vel.y = 0.42
+        // TODO: jump potion effect
+        if (entity.control.sprint) {
+          const yaw = Math.PI - entity.yaw
+          vel.x -= Math.sin(yaw) * 0.2
+          vel.z += Math.cos(yaw) * 0.2
+        }
+        entity.jumpTicks = 10 // activate autojump cooldown (0.5s)
+      }
+    } else {
+      entity.jumpTicks = 0 // reset autojump cooldown
+    }
+    entity.jumpQueued = false
+
+    let strafe = (entity.control.right - entity.control.left) * 0.98
+    let forward = (entity.control.forward - entity.control.back) * 0.98
+
+    if (entity.control.sneak) {
+      strafe *= 0.3
+      forward *= 0.3
+    }
+
+    moveEntityWithHeading(entity, world, strafe, forward)
+
+    return entity
+  }
+
+  return physics
+}
+
+class PlayerState {
+  constructor (bot, control) {
+    // Input / Outputs
+    this.pos = bot.entity.position.clone()
+    this.vel = bot.entity.velocity.clone()
+    this.onGround = bot.entity.onGround
+    this.isInWater = bot.entity.isInWater
+    this.isInLava = bot.entity.isInLava
+    this.isInWeb = bot.entity.isInWeb
+    this.isCollidedHorizontally = bot.entity.isCollidedHorizontally
+    this.isCollidedVertically = bot.entity.isCollidedVertically
+    this.jumpTicks = bot.jumpTicks
+    this.jumpQueued = bot.jumpQueued
+
+    // Input only (not modified)
+    this.yaw = bot.entity.yaw
+    this.control = control
+  }
+
+  apply (bot) {
+    bot.entity.position = this.pos
+    bot.entity.velocity = this.vel
+    bot.entity.onGround = this.onGround
+    bot.entity.isInWater = this.isInWater
+    bot.entity.isInLava = this.isInLava
+    bot.entity.isInWeb = this.isInWeb
+    bot.entity.isCollidedHorizontally = this.isCollidedHorizontally
+    bot.entity.isCollidedVertically = this.isCollidedVertically
+    bot.jumpTicks = this.jumpTicks
+    bot.jumpQueued = this.jumpQueued
+  }
+}
+
+module.exports = { Physics, PlayerState }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -229,11 +229,6 @@ function inject (bot, { version }) {
     const entity = fetchEntity(packet.entityId)
     const notchVel = new Vec3(packet.velocityX, packet.velocityY, packet.velocityZ)
     entity.velocity.update(conv.fromNotchVelocity(notchVel))
-
-    if (entity === bot.entity) {
-      const vel = conv.fromNotchVelocity(notchVel)
-      entity.velocity.update(vel)
-    }
   })
 
   bot._client.on('entity_destroy', (packet) => {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -2,13 +2,13 @@ const Vec3 = require('vec3').Vec3
 const assert = require('assert')
 const math = require('../math')
 const conv = require('../conversions')
+const { performance } = require('perf_hooks')
 
 module.exports = inject
 
 const EPSILON = 0.000001 // good enough so that the player can actually see the bot landing and so the bot doesn't die from "fell from high ground"
 const PI = Math.PI
 const PI_2 = Math.PI * 2
-const POSITION_UPDATE_INTERVAL_MS = 50
 const PHYSICS_INTERVAL_MS = 50
 const MAX_PHYSICS_DELTA_SECONDS = 0.2
 const WAIT_TIME_BEFORE_NEW_JUMP = 0.07
@@ -40,37 +40,36 @@ function inject (bot) {
   }
   let jumpQueued = false
   let lastSentYaw = null
-  let positionUpdateTimer = null
   let doPhysicsTimer = null
-  let lastPositionSentTime = null
   let lastPhysicsFrameTime = null
-  let lastFlyingUpdate = 0
+  let physicEnabled = false
+
+  const lastSent = {
+    x: 0,
+    y: 0,
+    z: 0,
+    yaw: 0,
+    pitch: 0,
+    onGround: false,
+    time: 0
+  }
 
   function doPhysics () {
-    const now = new Date()
+    const now = performance.now()
     const deltaSeconds = (now - lastPhysicsFrameTime) / 1000
     lastPhysicsFrameTime = now
-    const deltaToUse = deltaSeconds < MAX_PHYSICS_DELTA_SECONDS
-      ? deltaSeconds : MAX_PHYSICS_DELTA_SECONDS
-    nextFrame(deltaToUse)
+    const deltaToUse = deltaSeconds < MAX_PHYSICS_DELTA_SECONDS ? deltaSeconds : MAX_PHYSICS_DELTA_SECONDS
+
+    if (physicEnabled) updatePlayerPhysic(deltaToUse)
+    updatePosition(deltaSeconds)
   }
 
   function cleanup () {
-    stopPhysics()
-    stopPositionUpdates()
-  }
-
-  function stopPositionUpdates () {
-    clearInterval(positionUpdateTimer)
-    positionUpdateTimer = null
-  }
-
-  function stopPhysics () {
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
   }
 
-  function nextFrame (deltaSeconds) {
+  function updatePlayerPhysic (deltaSeconds) {
     if (deltaSeconds < EPSILON) return // too fast
     const pos = bot.entity.position
     const vel = bot.entity.velocity
@@ -154,13 +153,11 @@ function inject (bot) {
 
     // calculate new positions and resolve collisions
     let boundingBox = getBoundingBox()
-    let boundingBoxMin
-    let boundingBoxMax
     if (vel.x !== 0) {
       pos.x += vel.x * deltaSeconds
-      const blockX = Math.floor(pos.x + math.sign(vel.x) * physics.playerApothem)
-      boundingBoxMin = new Vec3(blockX, boundingBox.min.y, boundingBox.min.z)
-      boundingBoxMax = new Vec3(blockX, boundingBox.max.y, boundingBox.max.z)
+      const blockX = Math.floor(pos.x + Math.sign(vel.x) * physics.playerApothem)
+      const boundingBoxMin = new Vec3(blockX, boundingBox.min.y, boundingBox.min.z)
+      const boundingBoxMax = new Vec3(blockX, boundingBox.max.y, boundingBox.max.z)
       if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
         pos.x = blockX + (vel.x < 0 ? 1 + physics.playerApothem : -physics.playerApothem) * 1.001
         vel.x = 0
@@ -170,9 +167,9 @@ function inject (bot) {
 
     if (vel.z !== 0) {
       pos.z += vel.z * deltaSeconds
-      const blockZ = Math.floor(pos.z + math.sign(vel.z) * physics.playerApothem)
-      boundingBoxMin = new Vec3(boundingBox.min.x, boundingBox.min.y, blockZ)
-      boundingBoxMax = new Vec3(boundingBox.max.x, boundingBox.max.y, blockZ)
+      const blockZ = Math.floor(pos.z + Math.sign(vel.z) * physics.playerApothem)
+      const boundingBoxMin = new Vec3(boundingBox.min.x, boundingBox.min.y, blockZ)
+      const boundingBoxMax = new Vec3(boundingBox.max.x, boundingBox.max.y, blockZ)
       if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
         pos.z = blockZ + (vel.z < 0 ? 1 + physics.playerApothem : -physics.playerApothem) * 1.001
         vel.z = 0
@@ -184,9 +181,9 @@ function inject (bot) {
     if (vel.y !== 0) {
       pos.y += vel.y * deltaSeconds
       const playerHalfHeight = physics.playerHeight / 2
-      const blockY = Math.floor(pos.y + playerHalfHeight + math.sign(vel.y) * playerHalfHeight)
-      boundingBoxMin = new Vec3(boundingBox.min.x, blockY, boundingBox.min.z)
-      boundingBoxMax = new Vec3(boundingBox.max.x, blockY, boundingBox.max.z)
+      const blockY = Math.floor(pos.y + playerHalfHeight + Math.sign(vel.y) * playerHalfHeight)
+      const boundingBoxMin = new Vec3(boundingBox.min.x, blockY, boundingBox.min.z)
+      const boundingBoxMax = new Vec3(boundingBox.max.x, blockY, boundingBox.max.z)
       if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
         pos.y = blockY + (vel.y < 0 ? 1 : -physics.playerHeight) * 1.001
         bot.entity.onGround = vel.y < 0 ? true : bot.entity.onGround
@@ -202,11 +199,10 @@ function inject (bot) {
 
   function collisionInRange (boundingBoxMin, boundingBoxMax) {
     const cursor = new Vec3(0, 0, 0)
-    let block
-    for (cursor.x = boundingBoxMin.x; cursor.x <= boundingBoxMax.x; cursor.x++) {
-      for (cursor.y = boundingBoxMin.y; cursor.y <= boundingBoxMax.y; cursor.y++) {
-        for (cursor.z = boundingBoxMin.z; cursor.z <= boundingBoxMax.z; cursor.z++) {
-          block = bot.blockAt(cursor)
+    for (cursor.y = boundingBoxMin.y; cursor.y <= boundingBoxMax.y; cursor.y++) {
+      for (cursor.z = boundingBoxMin.z; cursor.z <= boundingBoxMax.z; cursor.z++) {
+        for (cursor.x = boundingBoxMin.x; cursor.x <= boundingBoxMax.x; cursor.x++) {
+          const block = bot.blockAt(cursor)
           if (block && block.boundingBox === 'block') return true
         }
       }
@@ -236,68 +232,82 @@ function inject (bot) {
     }
   }
 
-  function sendPositionAndLook (entity) {
+  function sendPacketPosition (position, onGround) {
     // sends data, no logic
-    const packet = {
-      x: entity.position.x,
-      y: entity.position.y,
-      z: entity.position.z,
-      onGround: entity.onGround
-    }
-    packet.yaw = conv.toNotchianYaw(entity.yaw)
-    packet.pitch = conv.toNotchianPitch(entity.pitch)
-    bot._client.write('position_look', packet)
-
-    bot.emit('move')
+    const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
+    lastSent.x = position.x
+    lastSent.y = position.y
+    lastSent.z = position.z
+    lastSent.onGround = onGround
+    bot._client.write('position', lastSent)
+    bot.emit('move', oldPos)
   }
 
-  function sendPosition () {
-    // increment the yaw in baby steps so that notchian clients (not the server) can keep up.
-    if (typeof bot.entity.height !== 'number' || isNaN(bot.entity.height) || bot.entity.height < 0.1 || bot.entity.height > 1.65) {
-      // Sometimes this is NaN, not sure of why, it seems it's set via a position packet
-      // Note seems some packets handled by 'position' event do not have a stance.
-      bot.entity.height = 1.62
-    }
-    const sentPosition = {
-      yaw: bot.entity.yaw % PI_2,
-      pitch: bot.entity.pitch,
-      position: bot.entity.position,
-      velocity: bot.entity.velocity,
-      height: bot.entity.height,
-      onGround: bot.entity.onGround
-    }
-    let deltaYaw = math.euclideanMod(sentPosition.yaw - lastSentYaw, PI_2)
-    deltaYaw = deltaYaw < 0
-      ? (deltaYaw < -PI ? deltaYaw + PI_2 : deltaYaw)
-      : (deltaYaw > PI ? deltaYaw - PI_2 : deltaYaw)
-    const absDeltaYaw = Math.abs(deltaYaw)
-    assert.ok(absDeltaYaw < PI + 0.001)
+  function sendPacketLook (yaw, pitch, onGround) {
+    // sends data, no logic
+    const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
+    lastSent.yaw = yaw
+    lastSent.pitch = pitch
+    lastSent.onGround = onGround
+    bot._client.write('look', lastSent)
+    bot.emit('move', oldPos)
+  }
 
-    const now = new Date()
-    const deltaMs = now - lastPositionSentTime
-    lastPositionSentTime = now
-    const maxDeltaYaw = deltaMs / 1000 * physics.yawSpeed
-    deltaYaw = absDeltaYaw > maxDeltaYaw ? maxDeltaYaw * math.sign(deltaYaw) : deltaYaw
-    lastSentYaw = (lastSentYaw + deltaYaw) % PI_2
-    sentPosition.yaw = lastSentYaw
+  function sendPacketPositionAndLook (position, yaw, pitch, onGround) {
+    // sends data, no logic
+    const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
+    lastSent.x = position.x
+    lastSent.y = position.y
+    lastSent.z = position.z
+    lastSent.yaw = yaw
+    lastSent.pitch = pitch
+    lastSent.onGround = onGround
+    bot._client.write('position_look', lastSent)
+    bot.emit('move', oldPos)
+  }
 
-    if (new Date() - lastFlyingUpdate > 1000) {
-      // Always send flying messages
-      // If you're dead, you're probably on the ground though ...
-      if (!bot.isAlive) bot.entity.onGround = true
+  function updatePosition (dt) {
+    // If you're dead, you're probably on the ground though ...
+    if (!bot.isAlive) bot.entity.onGround = true
+
+    // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
+    let deltaYaw = (bot.entity.yaw - lastSentYaw) % PI_2
+    if (deltaYaw < -PI) deltaYaw += PI_2
+    else if (deltaYaw > PI) deltaYaw -= PI_2
+
+    // Vanilla doesn't clamp yaw, so we don't want to do it either
+    const maxDeltaYaw = dt * physics.yawSpeed
+    lastSentYaw += math.clamp(-maxDeltaYaw, deltaYaw, maxDeltaYaw)
+
+    const yaw = conv.toNotchianYaw(lastSentYaw)
+    const pitch = conv.toNotchianPitch(bot.entity.pitch)
+    const position = bot.entity.position
+    const onGround = bot.entity.onGround
+
+    // Only send a position update if necessary, select the appropriate packet
+    const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z
+    const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
+
+    if (positionUpdated && lookUpdated && bot.isAlive) {
+      sendPacketPositionAndLook(position, yaw, pitch, onGround)
+    } else if (positionUpdated && bot.isAlive) {
+      sendPacketPosition(position, onGround)
+    } else if (lookUpdated && bot.isAlive) {
+      sendPacketLook(yaw, pitch, onGround)
+    } else if (performance.now() - lastSent.time >= 1000) {
+      // Send a position packet every second, even if no update was made
+      sendPacketPosition(position, onGround)
+      lastSent.time = performance.now()
+    } else if (bot.supportFeature('positionUpdateSentEveryTick') && bot.isAlive) {
+      // For versions < 1.12, one player packet should be sent every tick
+      // for the server to update health correctly
       bot._client.write('flying', { onGround: bot.entity.onGround })
-      lastFlyingUpdate = new Date()
-    }
-
-    // Only send location when alive though
-    if (bot.isAlive) {
-      sendPositionAndLook(sentPosition)
     }
   }
 
   bot.physics = physics
 
-  bot.setControlState = function setControlState (control, state) {
+  bot.setControlState = (control, state) => {
     assert.ok(control in controlState, `invalid control: ${control}`)
     assert.ok(typeof state === 'boolean', `invalid state: ${state}`)
     if (controlState[control] === state) return
@@ -350,7 +360,7 @@ function inject (bot) {
     bot.entity.pitch = pitch
     if (force) lastSentYaw = yaw
     function checkYaw () {
-      if (Math.abs((lastSentYaw - yaw) % PI_2) < 0.001) {
+      if (Math.abs(((lastSentYaw % PI_2) - yaw) % PI_2) < 0.001) {
         bot.removeListener('move', checkYaw)
         cb()
       }
@@ -366,40 +376,42 @@ function inject (bot) {
     bot.look(yaw, pitch, force, cb)
   }
 
-  // player position and look
+  // player position and look (clientbound)
   bot._client.on('position', (packet) => {
-    if (positionUpdateTimer === null) {
-      // got first 0x0d. start the clocks
-      bot.entity.yaw = conv.fromNotchianYaw(packet.yaw)
-      bot.entity.pitch = conv.fromNotchianPitch(packet.pitch)
-      positionUpdateTimer = setInterval(sendPosition, POSITION_UPDATE_INTERVAL_MS)
-    }
-
+    bot.entity.height = 1.62
     bot.entity.velocity.set(0, 0, 0)
-    bot.entity.position.set(packet.x, packet.y, packet.z)
 
-    // Packet 0x08 Player Position And Look, does not send a stance
-    if (packet.stance) bot.entity.height = packet.stance - bot.entity.position.y
-    else bot.entity.height = 1.62
+    // If flag is set, then the corresponding value is relative, else it is absolute
+    const pos = bot.entity.position
+    pos.set(
+      packet.flags & 1 ? (pos.x + packet.x) : packet.x,
+      packet.flags & 2 ? (pos.y + packet.y) : packet.y,
+      packet.flags & 4 ? (pos.z + packet.z) : packet.z
+    )
+
+    const newYaw = (packet.flags & 8 ? conv.toNotchianYaw(bot.entity.yaw) : 0) + packet.yaw
+    const newPitch = (packet.flags & 16 ? conv.toNotchianPitch(bot.entity.pitch) : 0) + packet.pitch
+    bot.entity.yaw = conv.fromNotchianYaw(newYaw)
+    bot.entity.pitch = conv.fromNotchianPitch(newPitch)
 
     if (bot.supportFeature('teleportUsesPositionPacket')) {
-      sendPositionAndLook(bot.entity)
+      sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
     } else if (bot.supportFeature('teleportUsesOwnPacket')) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })
-      bot.emit('move')
     }
 
+    physicEnabled = true
+    bot.entity.timeSinceOnGround = 0
+    lastSentYaw = bot.entity.yaw
+
     if (doPhysicsTimer === null) {
-      bot.entity.timeSinceOnGround = 0
-      lastSentYaw = math.euclideanMod(bot.entity.yaw, PI_2)
-      lastPositionSentTime = new Date()
-      lastPhysicsFrameTime = new Date()
+      lastPhysicsFrameTime = performance.now()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
     bot.emit('forcedMove')
   })
 
-  bot.on('mount', stopPhysics)
-  bot.on('respawn', stopPhysics)
+  bot.on('mount', () => { physicEnabled = false })
+  bot.on('respawn', () => { physicEnabled = false })
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -4,30 +4,48 @@ const math = require('../math')
 const conv = require('../conversions')
 const { performance } = require('perf_hooks')
 
+const AABB = require('../aabb')
+
 module.exports = inject
 
-const EPSILON = 0.000001 // good enough so that the player can actually see the bot landing and so the bot doesn't die from "fell from high ground"
 const PI = Math.PI
 const PI_2 = Math.PI * 2
 const PHYSICS_INTERVAL_MS = 50
 const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000
-const WAIT_TIME_BEFORE_NEW_JUMP = 0.07
 
 function inject (bot) {
-  const physics = {
-    maxGroundSpeed: 4.317, // according to the internet
-    terminalVelocity: 20.0, // guess
-    walkingAcceleration: 100.0, // seems good
-    gravity: 27.0, // seems good
-    groundFriction: 0.9, // seems good
-    playerApothem: 0.32, // notch's client F3 says 0.30, but that caused spankings
-    playerHeight: 1.74, // tested with a binary search
-    jumpSpeed: 9.0, // seems good
-    yawSpeed: 3.0, // seems good
-    sprintSpeed: 1.3 // correct
+  const mcData = require('minecraft-data')(bot.version)
+
+  // Block Slipperiness
+  // https://www.mcpk.wiki/w/index.php?title=Slipperiness
+  const blockSlipperiness = {}
+  if (mcData.blocksByName.slime_block) {
+    blockSlipperiness[mcData.blocksByName.slime_block.id] = 0.8
+  } else {
+    blockSlipperiness[mcData.blocksByName.slime.id] = 0.8
   }
-  physics.maxGroundSpeedSoulSand = physics.maxGroundSpeed * 0.4
-  physics.maxGroundSpeedWater = physics.maxGroundSpeed * 0.3 // seems about right?
+  blockSlipperiness[mcData.blocksByName.ice.id] = 0.98
+  blockSlipperiness[mcData.blocksByName.packed_ice.id] = 0.98
+  if (mcData.blocksByName.frosted_ice) { // 1.9+
+    blockSlipperiness[mcData.blocksByName.frosted_ice.id] = 0.98
+  }
+  if (mcData.blocksByName.blue_ice) { // 1.13+
+    blockSlipperiness[mcData.blocksByName.blue_ice.id] = 0.989
+  }
+
+  // Block ids
+  // const soulsandId = mcData.blocksByName.soul_sand.id
+  const waterId = mcData.blocksByName.water.id
+  const lavaId = mcData.blocksByName.lava.id
+  // const ladderId = mcData.blocksByName.ladder.id
+  // const vineId = mcData.blocksByName.vine.id
+
+  const physics = {
+    gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
+    yawSpeed: 3.0, // seems good
+    sprintSpeed: 1.3, // correct
+    negligeableVelocity: 0.003 // actually 0.005 for 1.8, but seems fine
+  }
 
   const controlState = {
     forward: false,
@@ -38,7 +56,6 @@ function inject (bot) {
     sprint: false,
     sneak: false
   }
-  let jumpQueued = false
   let lastSentYaw = null
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
@@ -54,8 +71,11 @@ function inject (bot) {
     time: 0
   }
 
+  let jumpQueued = false
+  let jumpTicks = 0 // autojump cooldown
+
   // This function should be executed each tick (every 0.05 seconds)
-  // How this work: https://gafferongames.com/post/fix_your_timestep/
+  // How it works: https://gafferongames.com/post/fix_your_timestep/
   let timeAccumulator = 0
   function doPhysics () {
     const now = performance.now()
@@ -65,7 +85,10 @@ function inject (bot) {
     timeAccumulator += deltaSeconds
 
     while (timeAccumulator >= PHYSICS_TIMESTEP) {
-      if (physicEnabled) updatePlayerPhysic(PHYSICS_TIMESTEP)
+      if (physicEnabled) {
+        updatePlayer()
+        bot.emit('physicTick')
+      }
       updatePosition(PHYSICS_TIMESTEP)
       timeAccumulator -= PHYSICS_TIMESTEP
     }
@@ -76,162 +99,184 @@ function inject (bot) {
     doPhysicsTimer = null
   }
 
-  function updatePlayerPhysic (deltaSeconds) {
+  function getPlayerBB () {
     const pos = bot.entity.position
-    const vel = bot.entity.velocity
-
-    // derive xy movement vector from controls
-    const movementRight = (controlState.right - controlState.left)
-    const movementForward = (controlState.forward - controlState.back)
-
-    // acceleration is m/s/s
-    const acceleration = new Vec3(0, 0, 0)
-    if (movementForward || movementRight) {
-      // input acceleration
-      const rotationFromInput = Math.atan2(-movementRight, movementForward)
-      const inputYaw = bot.entity.yaw + rotationFromInput
-      acceleration.x += physics.walkingAcceleration * -Math.sin(inputYaw)
-      acceleration.z += physics.walkingAcceleration * -Math.cos(inputYaw)
-      if (controlState.sprint) {
-        acceleration.x *= physics.sprintSpeed
-        acceleration.z *= physics.sprintSpeed
-      }
-    }
-
-    // jumping
-    if ((controlState.jump || jumpQueued) && bot.entity.onGround && bot.entity.timeSinceOnGround > WAIT_TIME_BEFORE_NEW_JUMP) {
-      vel.y = physics.jumpSpeed
-    }
-    jumpQueued = false
-
-    // gravity
-    acceleration.y -= physics.gravity
-
-    const oldGroundSpeedSquared = calcGroundSpeedSquared()
-    if (oldGroundSpeedSquared < EPSILON) {
-      // stopped
-      vel.x = 0
-      vel.z = 0
-    } else {
-      // non-zero ground speed
-      const oldGroundSpeed = Math.sqrt(oldGroundSpeedSquared)
-      let groundFriction = physics.groundFriction * physics.walkingAcceleration
-      // less friction for air
-      if (!bot.entity.onGround) groundFriction *= 0.05
-      // if friction would stop the motion, do it
-      const maybeNewGroundFriction = oldGroundSpeed / deltaSeconds
-      groundFriction = groundFriction > maybeNewGroundFriction
-        ? maybeNewGroundFriction : groundFriction
-      acceleration.x -= vel.x / oldGroundSpeed * groundFriction
-      acceleration.z -= vel.z / oldGroundSpeed * groundFriction
-    }
-
-    // calculate new speed
-    vel.add(acceleration.scaled(deltaSeconds))
-
-    // limit speed
-    let currentMaxGroundSpeed
-    const underBlock = bot.blockAt(pos.offset(0, -1, 0))
-    const inBlock = bot.blockAt(pos.offset(0, 0, 0))
-    if (underBlock && underBlock.type === 88) {
-      currentMaxGroundSpeed = physics.maxGroundSpeedSoulSand
-    } else if (inBlock && inBlock.type === 9) {
-      currentMaxGroundSpeed = physics.maxGroundSpeedWater
-    } else {
-      currentMaxGroundSpeed = physics.maxGroundSpeed
-    }
-    if (controlState.sprint) {
-      currentMaxGroundSpeed *= physics.sprintSpeed
-    }
-
-    const groundSpeedSquared = calcGroundSpeedSquared()
-    if (groundSpeedSquared > currentMaxGroundSpeed * currentMaxGroundSpeed) {
-      const groundSpeed = Math.sqrt(groundSpeedSquared)
-      const correctionScale = currentMaxGroundSpeed / groundSpeed
-      vel.x *= correctionScale
-      vel.z *= correctionScale
-    }
-    vel.y = math.clamp(-physics.terminalVelocity, vel.y, physics.terminalVelocity)
-
-    // calculate new positions and resolve collisions
-    let boundingBox = getBoundingBox()
-    if (vel.x !== 0) {
-      pos.x += vel.x * deltaSeconds
-      const blockX = Math.floor(pos.x + Math.sign(vel.x) * physics.playerApothem)
-      const boundingBoxMin = new Vec3(blockX, boundingBox.min.y, boundingBox.min.z)
-      const boundingBoxMax = new Vec3(blockX, boundingBox.max.y, boundingBox.max.z)
-      if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
-        pos.x = blockX + (vel.x < 0 ? 1 + physics.playerApothem : -physics.playerApothem) * 1.001
-        vel.x = 0
-        boundingBox = getBoundingBox()
-      }
-    }
-
-    if (vel.z !== 0) {
-      pos.z += vel.z * deltaSeconds
-      const blockZ = Math.floor(pos.z + Math.sign(vel.z) * physics.playerApothem)
-      const boundingBoxMin = new Vec3(boundingBox.min.x, boundingBox.min.y, blockZ)
-      const boundingBoxMax = new Vec3(boundingBox.max.x, boundingBox.max.y, blockZ)
-      if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
-        pos.z = blockZ + (vel.z < 0 ? 1 + physics.playerApothem : -physics.playerApothem) * 1.001
-        vel.z = 0
-        boundingBox = getBoundingBox()
-      }
-    }
-
-    bot.entity.onGround = false
-    if (vel.y !== 0) {
-      pos.y += vel.y * deltaSeconds
-      const playerHalfHeight = physics.playerHeight / 2
-      const blockY = Math.floor(pos.y + playerHalfHeight + Math.sign(vel.y) * playerHalfHeight)
-      const boundingBoxMin = new Vec3(boundingBox.min.x, blockY, boundingBox.min.z)
-      const boundingBoxMax = new Vec3(boundingBox.max.x, blockY, boundingBox.max.z)
-      if (collisionInRange(boundingBoxMin, boundingBoxMax)) {
-        pos.y = blockY + (vel.y < 0 ? 1 : -physics.playerHeight) * 1.001
-        bot.entity.onGround = vel.y < 0 ? true : bot.entity.onGround
-        vel.y = 0
-      }
-    }
-    if (bot.entity.onGround) {
-      bot.entity.timeSinceOnGround += deltaSeconds
-    } else {
-      bot.entity.timeSinceOnGround = 0
-    }
+    return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
   }
 
-  function collisionInRange (boundingBoxMin, boundingBoxMax) {
+  function moveEntity () {
+    const entity = bot.entity
+    const vel = entity.velocity
+    const pos = entity.position
+
+    const oldVelX = vel.x
+    const oldVelY = vel.y
+    const oldVelZ = vel.z
+
+    const playerBB = getPlayerBB()
+    const queryBB = playerBB.clone().extend(vel.x, vel.y, vel.z)
+
+    const surroundingBBs = []
     const cursor = new Vec3(0, 0, 0)
-    for (cursor.y = boundingBoxMin.y; cursor.y <= boundingBoxMax.y; cursor.y++) {
-      for (cursor.z = boundingBoxMin.z; cursor.z <= boundingBoxMax.z; cursor.z++) {
-        for (cursor.x = boundingBoxMin.x; cursor.x <= boundingBoxMax.x; cursor.x++) {
+    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
           const block = bot.blockAt(cursor)
-          if (block && block.boundingBox === 'block') return true
+          if (block) {
+            const blockPos = block.position
+            for (const shape of block.shapes) {
+              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5])
+              blockBB.offset(blockPos.x, blockPos.y, blockPos.z)
+              surroundingBBs.push(blockBB)
+            }
+          }
         }
       }
     }
 
+    for (const blockBB of surroundingBBs) {
+      vel.y = blockBB.computeOffsetY(playerBB, vel.y)
+    }
+    playerBB.offset(0, vel.y, 0)
+    pos.y += vel.y
+
+    for (const blockBB of surroundingBBs) {
+      vel.x = blockBB.computeOffsetX(playerBB, vel.x)
+    }
+    playerBB.offset(vel.x, 0, 0)
+    pos.x += vel.x
+
+    for (const blockBB of surroundingBBs) {
+      vel.z = blockBB.computeOffsetZ(playerBB, vel.z)
+    }
+    playerBB.offset(0, 0, vel.z)
+    pos.z += vel.z
+
+    entity.isCollidedHorizontally = vel.x !== oldVelX || vel.z !== oldVelZ
+    entity.isCollidedVertically = vel.y !== oldVelY
+    entity.onGround = entity.isCollidedVertically && oldVelY < 0
+
+    if (vel.x !== oldVelX) vel.x = 0
+    if (vel.y !== oldVelY) vel.y = 0
+    if (vel.z !== oldVelZ) vel.z = 0
+  }
+
+  function applyHeading (strafe, forward, multiplier) {
+    let speed = Math.sqrt(strafe * strafe + forward * forward)
+    if (speed < 0.01) return new Vec3(0, 0, 0)
+
+    speed = multiplier / Math.max(speed, 1)
+
+    strafe *= speed
+    forward *= speed
+
+    const yaw = PI - bot.entity.yaw
+    const sin = Math.sin(yaw)
+    const cos = Math.cos(yaw)
+
+    const vel = bot.entity.velocity
+    vel.x += strafe * cos - forward * sin
+    vel.z += forward * cos + strafe * sin
+  }
+
+  function moveEntityWithHeading (strafe, forward) {
+    const vel = bot.entity.velocity
+    const pos = bot.entity.position
+
+    if (!bot.entity.isInWater && !bot.entity.isInLava) {
+      // Normal movement
+      let acceleration = 0.02 // airborne
+      let inertia = 0.91
+      const blockUnder = bot.blockAt(pos.offset(0, -1, 0))
+      if (bot.entity.onGround && blockUnder) {
+        inertia = (blockSlipperiness[blockUnder.type] || 0.6) * 0.91
+        acceleration = 0.1 * (0.1627714 / (inertia * inertia * inertia))
+      }
+      if (controlState.sprint) acceleration *= physics.sprintSpeed
+
+      applyHeading(strafe, forward, acceleration)
+      // TODO: ladder handling
+      moveEntity()
+
+      // Apply friction and gravity
+      vel.y -= physics.gravity
+      vel.y *= 0.98 // air drag
+      vel.x *= inertia
+      vel.z *= inertia
+    } else {
+      // Water / Lava movement
+      const acceleration = 0.02
+      const inertia = bot.entity.isInWater ? 0.8 : 0.5
+      // TODO: depth strider enchantement (for water)
+      applyHeading(strafe, forward, acceleration)
+      moveEntity()
+      vel.y *= inertia
+      vel.y -= 0.02
+      vel.x *= inertia
+      vel.z *= inertia
+
+      if (bot.entity.isCollidedHorizontally) { // TODO: && isOffsetPositionInLiquid
+        vel.y = 0.3 // jump out of liquid
+      }
+    }
+  }
+
+  function isMaterialInBB (queryBB, type) {
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
+          const block = bot.blockAt(cursor)
+          if (block && block.type === type) return true
+        }
+      }
+    }
     return false
   }
 
-  function calcGroundSpeedSquared () {
+  function updatePlayer () {
     const vel = bot.entity.velocity
-    return vel.x * vel.x + vel.z * vel.z
-  }
 
-  function getBoundingBox () {
-    const pos = bot.entity.position
-    return {
-      min: new Vec3(
-        pos.x - physics.playerApothem,
-        pos.y,
-        pos.z - physics.playerApothem
-      ).floor(),
-      max: new Vec3(
-        pos.x + physics.playerApothem,
-        pos.y + physics.playerHeight,
-        pos.z + physics.playerApothem
-      ).floor()
+    const waterBB = getPlayerBB().contract(0.001, 0.401, 0.001)
+    const lavaBB = getPlayerBB().contract(0.1, 0.4, 0.1)
+
+    bot.entity.isInWater = isMaterialInBB(waterBB, waterId) // TODO: liquid flow
+    bot.entity.isInLava = isMaterialInBB(lavaBB, lavaId)
+
+    // Reset velocity component if it falls under the threshold
+    if (Math.abs(vel.x) < physics.negligeableVelocity) vel.x = 0
+    if (Math.abs(vel.y) < physics.negligeableVelocity) vel.y = 0
+    if (Math.abs(vel.z) < physics.negligeableVelocity) vel.z = 0
+
+    // Handle inputs
+    if (controlState.jump || jumpQueued) {
+      if (jumpTicks > 0) jumpTicks--
+      if (bot.entity.isInWater || bot.entity.isInLava) {
+        vel.y += 0.04
+      } else if (bot.entity.onGround && jumpTicks === 0) {
+        vel.y = 0.42
+        // TODO: jump potion effect
+        if (controlState.sprint) {
+          const yaw = PI - bot.entity.yaw
+          vel.x -= Math.sin(yaw) * 0.2
+          vel.z += Math.cos(yaw) * 0.2
+        }
+        jumpTicks = 10 // activate autojump cooldown (0.5s)
+      }
+    } else {
+      jumpTicks = 0 // reset autojump cooldown
     }
+    jumpQueued = false
+
+    let strafe = (controlState.right - controlState.left) * 0.98
+    let forward = (controlState.forward - controlState.back) * 0.98
+
+    if (controlState.sneak) {
+      strafe *= 0.3
+      forward *= 0.3
+    }
+
+    moveEntityWithHeading(strafe, forward)
   }
 
   function sendPacketPosition (position, onGround) {
@@ -395,6 +440,7 @@ function inject (bot) {
     const newPitch = (packet.flags & 16 ? conv.toNotchianPitch(bot.entity.pitch) : 0) + packet.pitch
     bot.entity.yaw = conv.fromNotchianYaw(newYaw)
     bot.entity.pitch = conv.fromNotchianPitch(newPitch)
+    bot.entity.onGround = false
 
     if (bot.supportFeature('teleportUsesPositionPacket')) {
       sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -20,11 +20,8 @@ function inject (bot) {
   // Block Slipperiness
   // https://www.mcpk.wiki/w/index.php?title=Slipperiness
   const blockSlipperiness = {}
-  if (blocksByName.slime_block) {
-    blockSlipperiness[blocksByName.slime_block.id] = 0.8
-  } else {
-    blockSlipperiness[blocksByName.slime.id] = 0.8
-  }
+  const slimeBlockId = blocksByName.slime_block ? blocksByName.slime_block.id : blocksByName.slime.id
+  blockSlipperiness[slimeBlockId] = 0.8
   blockSlipperiness[blocksByName.ice.id] = 0.98
   blockSlipperiness[blocksByName.packed_ice.id] = 0.98
   if (blocksByName.frosted_ice) { // 1.9+
@@ -263,9 +260,17 @@ function inject (bot) {
     entity.isCollidedVertically = dy !== oldVelY
     entity.onGround = entity.isCollidedVertically && oldVelY < 0
 
+    const blockAtFeet = bot.blockAt(pos.offset(0, -0.2, 0))
+
     if (dx !== oldVelX) vel.x = 0
-    if (dy !== oldVelY) vel.y = 0
     if (dz !== oldVelZ) vel.z = 0
+    if (dy !== oldVelY) {
+      if (blockAtFeet && blockAtFeet.type === slimeBlockId && !controlState.sneak) {
+        vel.y = -vel.y
+      } else {
+        vel.y = 0
+      }
+    }
 
     // Finally, apply block collisions (web, soulsand...)
     playerBB.contract(0.001, 0.001, 0.001)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -36,8 +36,8 @@ function inject (bot) {
   const webId = blocksByName.cobweb ? blocksByName.cobweb.id : blocksByName.web.id
   const waterId = blocksByName.water.id
   const lavaId = blocksByName.lava.id
-  // const ladderId = blocksByName.ladder.id
-  // const vineId = blocksByName.vine.id
+  const ladderId = blocksByName.ladder.id
+  const vineId = blocksByName.vine.id
 
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
@@ -310,6 +310,11 @@ function inject (bot) {
     vel.z += forward * cos + strafe * sin
   }
 
+  function isOnLadder (pos) {
+    const block = bot.blockAt(pos)
+    return (block && (block.type === ladderId || block.type === vineId))
+  }
+
   function moveEntityWithHeading (strafe, forward) {
     const vel = bot.entity.velocity
     const pos = bot.entity.position
@@ -326,8 +331,19 @@ function inject (bot) {
       if (controlState.sprint) acceleration *= physics.sprintSpeed
 
       applyHeading(strafe, forward, acceleration)
-      // TODO: ladder handling
+
+      if (isOnLadder(pos)) {
+        const ladderMaxSpeed = 0.15
+        vel.x = math.clamp(-ladderMaxSpeed, vel.x, ladderMaxSpeed)
+        vel.z = math.clamp(-ladderMaxSpeed, vel.z, ladderMaxSpeed)
+        vel.y = Math.max(vel.y, controlState.sneak ? 0 : -ladderMaxSpeed)
+      }
+
       moveEntity(vel.x, vel.y, vel.z)
+
+      if (bot.entity.isCollidedHorizontally && isOnLadder(pos)) {
+        vel.y = 0.2 // climb ladder
+      }
 
       // Apply friction and gravity
       vel.y -= physics.gravity

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -10,7 +10,7 @@ const EPSILON = 0.000001 // good enough so that the player can actually see the 
 const PI = Math.PI
 const PI_2 = Math.PI * 2
 const PHYSICS_INTERVAL_MS = 50
-const MAX_PHYSICS_DELTA_SECONDS = 0.2
+const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000
 const WAIT_TIME_BEFORE_NEW_JUMP = 0.07
 
 function inject (bot) {
@@ -54,14 +54,21 @@ function inject (bot) {
     time: 0
   }
 
+  // This function should be executed each tick (every 0.05 seconds)
+  // How this work: https://gafferongames.com/post/fix_your_timestep/
+  let timeAccumulator = 0
   function doPhysics () {
     const now = performance.now()
     const deltaSeconds = (now - lastPhysicsFrameTime) / 1000
     lastPhysicsFrameTime = now
-    const deltaToUse = deltaSeconds < MAX_PHYSICS_DELTA_SECONDS ? deltaSeconds : MAX_PHYSICS_DELTA_SECONDS
 
-    if (physicEnabled) updatePlayerPhysic(deltaToUse)
-    updatePosition(deltaSeconds)
+    timeAccumulator += deltaSeconds
+
+    while (timeAccumulator >= PHYSICS_TIMESTEP) {
+      if (physicEnabled) updatePlayerPhysic(PHYSICS_TIMESTEP)
+      updatePosition(PHYSICS_TIMESTEP)
+      timeAccumulator -= PHYSICS_TIMESTEP
+    }
   }
 
   function cleanup () {
@@ -70,17 +77,12 @@ function inject (bot) {
   }
 
   function updatePlayerPhysic (deltaSeconds) {
-    if (deltaSeconds < EPSILON) return // too fast
     const pos = bot.entity.position
     const vel = bot.entity.velocity
 
     // derive xy movement vector from controls
-    let movementRight = 0
-    if (controlState.right) movementRight += 1
-    if (controlState.left) movementRight -= 1
-    let movementForward = 0
-    if (controlState.forward) movementForward += 1
-    if (controlState.back) movementForward -= 1
+    const movementRight = (controlState.right - controlState.left)
+    const movementForward = (controlState.forward - controlState.back)
 
     // acceleration is m/s/s
     const acceleration = new Vec3(0, 0, 0)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -4,7 +4,7 @@ const math = require('../math')
 const conv = require('../conversions')
 const { performance } = require('perf_hooks')
 
-const AABB = require('../aabb')
+const { Physics, PlayerState } = require('../physics')
 
 module.exports = inject
 
@@ -15,37 +15,12 @@ const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000
 
 function inject (bot) {
   const mcData = require('minecraft-data')(bot.version)
-  const blocksByName = mcData.blocksByName
 
-  // Block Slipperiness
-  // https://www.mcpk.wiki/w/index.php?title=Slipperiness
-  const blockSlipperiness = {}
-  const slimeBlockId = blocksByName.slime_block ? blocksByName.slime_block.id : blocksByName.slime.id
-  blockSlipperiness[slimeBlockId] = 0.8
-  blockSlipperiness[blocksByName.ice.id] = 0.98
-  blockSlipperiness[blocksByName.packed_ice.id] = 0.98
-  if (blocksByName.frosted_ice) { // 1.9+
-    blockSlipperiness[blocksByName.frosted_ice.id] = 0.98
-  }
-  if (blocksByName.blue_ice) { // 1.13+
-    blockSlipperiness[blocksByName.blue_ice.id] = 0.989
-  }
+  const world = { getBlock: (pos) => { return bot.blockAt(pos) } }
+  const physics = Physics(mcData, world)
 
-  // Block ids
-  const soulsandId = blocksByName.soul_sand.id
-  const webId = blocksByName.cobweb ? blocksByName.cobweb.id : blocksByName.web.id
-  const waterId = blocksByName.water.id
-  const lavaId = blocksByName.lava.id
-  const ladderId = blocksByName.ladder.id
-  const vineId = blocksByName.vine.id
-
-  const physics = {
-    gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
-    yawSpeed: 3.0,
-    sprintSpeed: 1.3,
-    stepHeight: 0.6, // how much height can the bot step on without jump
-    negligeableVelocity: 0.003 // actually 0.005 for 1.8, but seems fine
-  }
+  bot.jumpQueued = false
+  bot.jumpTicks = 0 // autojump cooldown
 
   const controlState = {
     forward: false,
@@ -71,9 +46,6 @@ function inject (bot) {
     time: 0
   }
 
-  let jumpQueued = false
-  let jumpTicks = 0 // autojump cooldown
-
   // This function should be executed each tick (every 0.05 seconds)
   // How it works: https://gafferongames.com/post/fix_your_timestep/
   let timeAccumulator = 0
@@ -86,7 +58,7 @@ function inject (bot) {
 
     while (timeAccumulator >= PHYSICS_TIMESTEP) {
       if (physicEnabled) {
-        updatePlayer()
+        physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
         bot.emit('physicTick')
       }
       updatePosition(PHYSICS_TIMESTEP)
@@ -97,409 +69,6 @@ function inject (bot) {
   function cleanup () {
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
-  }
-
-  function getPlayerBB (pos) {
-    return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
-  }
-
-  function setPositionToBB (bb) {
-    const pos = bot.entity.position
-    pos.x = bb.minX + 0.3
-    pos.y = bb.minY
-    pos.z = bb.minZ + 0.3
-  }
-
-  function getSurroundingBBs (queryBB) {
-    const surroundingBBs = []
-    const cursor = new Vec3(0, 0, 0)
-    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
-      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
-        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
-          const block = bot.blockAt(cursor)
-          if (block) {
-            const blockPos = block.position
-            for (const shape of block.shapes) {
-              const blockBB = new AABB(shape[0], shape[1], shape[2], shape[3], shape[4], shape[5])
-              blockBB.offset(blockPos.x, blockPos.y, blockPos.z)
-              surroundingBBs.push(blockBB)
-            }
-          }
-        }
-      }
-    }
-    return surroundingBBs
-  }
-
-  physics.adjustPositionHeight = (pos) => {
-    const playerBB = getPlayerBB(pos)
-    const queryBB = playerBB.clone().extend(0, -1, 0)
-    const surroundingBBs = getSurroundingBBs(queryBB)
-
-    let dy = -1
-    for (const blockBB of surroundingBBs) {
-      dy = blockBB.computeOffsetY(playerBB, dy)
-    }
-    pos.y += dy
-  }
-
-  function moveEntity (dx, dy, dz) {
-    const entity = bot.entity
-    const vel = entity.velocity
-    const pos = entity.position
-
-    if (bot.entity.isInWeb) {
-      dx *= 0.25
-      dy *= 0.05
-      dz *= 0.25
-      vel.x = 0
-      vel.y = 0
-      vel.z = 0
-      bot.entity.isInWeb = false
-    }
-
-    const oldVelX = dx
-    const oldVelY = dy
-    const oldVelZ = dz
-
-    let playerBB = getPlayerBB(pos)
-    const queryBB = playerBB.clone().extend(dx, dy, dz)
-    const surroundingBBs = getSurroundingBBs(queryBB)
-    const oldBB = playerBB.clone()
-
-    for (const blockBB of surroundingBBs) {
-      dy = blockBB.computeOffsetY(playerBB, dy)
-    }
-    playerBB.offset(0, dy, 0)
-
-    for (const blockBB of surroundingBBs) {
-      dx = blockBB.computeOffsetX(playerBB, dx)
-    }
-    playerBB.offset(dx, 0, 0)
-
-    for (const blockBB of surroundingBBs) {
-      dz = blockBB.computeOffsetZ(playerBB, dz)
-    }
-    playerBB.offset(0, 0, dz)
-
-    // Step on block if height < stepHeight
-    if (physics.stepHeight > 0 &&
-       (bot.entity.onGround || (dy !== oldVelY && oldVelY < 0)) &&
-       (dx !== oldVelX || dz !== oldVelZ)) {
-      const oldVelXCol = dx
-      const oldVelYCol = dy
-      const oldVelZCol = dz
-      const oldBBCol = playerBB.clone()
-
-      dy = physics.stepHeight
-      const queryBB = oldBB.clone().extend(oldVelX, dy, oldVelZ)
-      const surroundingBBs = getSurroundingBBs(queryBB)
-
-      const BB1 = oldBB.clone()
-      const BB2 = oldBB.clone()
-      const BB_XZ = BB1.clone().extend(dx, 0, dz)
-
-      let dy1 = dy
-      let dy2 = dy
-      for (const blockBB of surroundingBBs) {
-        dy1 = blockBB.computeOffsetY(BB_XZ, dy1)
-        dy2 = blockBB.computeOffsetY(BB2, dy2)
-      }
-      BB1.offset(0, dy1, 0)
-      BB2.offset(0, dy2, 0)
-
-      let dx1 = oldVelX
-      let dx2 = oldVelX
-      for (const blockBB of surroundingBBs) {
-        dx1 = blockBB.computeOffsetX(BB1, dx1)
-        dx2 = blockBB.computeOffsetX(BB2, dx2)
-      }
-      BB1.offset(dx1, 0, 0)
-      BB2.offset(dx2, 0, 0)
-
-      let dz1 = oldVelZ
-      let dz2 = oldVelZ
-      for (const blockBB of surroundingBBs) {
-        dz1 = blockBB.computeOffsetZ(BB1, dz1)
-        dz2 = blockBB.computeOffsetZ(BB2, dz2)
-      }
-      BB1.offset(0, 0, dz1)
-      BB2.offset(0, 0, dz2)
-
-      const norm1 = dx1 * dx1 + dz1 * dz1
-      const norm2 = dx2 * dx2 + dz2 * dz2
-
-      if (norm1 > norm2) {
-        dx = dx1
-        dy = -dy1
-        dz = dz1
-        playerBB = BB1
-      } else {
-        dx = dx2
-        dy = -dy2
-        dz = dz2
-        playerBB = BB2
-      }
-
-      for (const blockBB of surroundingBBs) {
-        dy = blockBB.computeOffsetY(playerBB, dy)
-      }
-      playerBB.offset(0, dy, 0)
-
-      if (oldVelXCol * oldVelXCol + oldVelZCol * oldVelZCol >= dx * dx + dz * dz) {
-        dx = oldVelXCol
-        dy = oldVelYCol
-        dz = oldVelZCol
-        playerBB = oldBBCol
-      }
-    }
-
-    // Update flags
-    setPositionToBB(playerBB)
-    entity.isCollidedHorizontally = dx !== oldVelX || dz !== oldVelZ
-    entity.isCollidedVertically = dy !== oldVelY
-    entity.onGround = entity.isCollidedVertically && oldVelY < 0
-
-    const blockAtFeet = bot.blockAt(pos.offset(0, -0.2, 0))
-
-    if (dx !== oldVelX) vel.x = 0
-    if (dz !== oldVelZ) vel.z = 0
-    if (dy !== oldVelY) {
-      if (blockAtFeet && blockAtFeet.type === slimeBlockId && !controlState.sneak) {
-        vel.y = -vel.y
-      } else {
-        vel.y = 0
-      }
-    }
-
-    // Finally, apply block collisions (web, soulsand...)
-    playerBB.contract(0.001, 0.001, 0.001)
-    const cursor = new Vec3(0, 0, 0)
-    for (cursor.y = Math.floor(playerBB.minY); cursor.y <= Math.floor(playerBB.maxY); cursor.y++) {
-      for (cursor.z = Math.floor(playerBB.minZ); cursor.z <= Math.floor(playerBB.maxZ); cursor.z++) {
-        for (cursor.x = Math.floor(playerBB.minX); cursor.x <= Math.floor(playerBB.maxX); cursor.x++) {
-          const block = bot.blockAt(cursor)
-          if (block) {
-            if (block.type === soulsandId) {
-              vel.x *= 0.4
-              vel.z *= 0.4
-            } else if (block.type === webId) {
-              bot.entity.isInWeb = true
-            }
-          }
-        }
-      }
-    }
-  }
-
-  function applyHeading (strafe, forward, multiplier) {
-    let speed = Math.sqrt(strafe * strafe + forward * forward)
-    if (speed < 0.01) return new Vec3(0, 0, 0)
-
-    speed = multiplier / Math.max(speed, 1)
-
-    strafe *= speed
-    forward *= speed
-
-    const yaw = PI - bot.entity.yaw
-    const sin = Math.sin(yaw)
-    const cos = Math.cos(yaw)
-
-    const vel = bot.entity.velocity
-    vel.x += strafe * cos - forward * sin
-    vel.z += forward * cos + strafe * sin
-  }
-
-  function isOnLadder (pos) {
-    const block = bot.blockAt(pos)
-    return (block && (block.type === ladderId || block.type === vineId))
-  }
-
-  function moveEntityWithHeading (strafe, forward) {
-    const vel = bot.entity.velocity
-    const pos = bot.entity.position
-
-    if (!bot.entity.isInWater && !bot.entity.isInLava) {
-      // Normal movement
-      let acceleration = 0.02 // airborne
-      let inertia = 0.91
-      const blockUnder = bot.blockAt(pos.offset(0, -1, 0))
-      if (bot.entity.onGround && blockUnder) {
-        inertia = (blockSlipperiness[blockUnder.type] || 0.6) * 0.91
-        acceleration = 0.1 * (0.1627714 / (inertia * inertia * inertia))
-      }
-      if (controlState.sprint) acceleration *= physics.sprintSpeed
-
-      applyHeading(strafe, forward, acceleration)
-
-      if (isOnLadder(pos)) {
-        const ladderMaxSpeed = 0.15
-        vel.x = math.clamp(-ladderMaxSpeed, vel.x, ladderMaxSpeed)
-        vel.z = math.clamp(-ladderMaxSpeed, vel.z, ladderMaxSpeed)
-        vel.y = Math.max(vel.y, controlState.sneak ? 0 : -ladderMaxSpeed)
-      }
-
-      moveEntity(vel.x, vel.y, vel.z)
-
-      if (bot.entity.isCollidedHorizontally && isOnLadder(pos)) {
-        vel.y = 0.2 // climb ladder
-      }
-
-      // Apply friction and gravity
-      vel.y -= physics.gravity
-      vel.y *= 0.98 // air drag
-      vel.x *= inertia
-      vel.z *= inertia
-    } else {
-      // Water / Lava movement
-      const acceleration = 0.02
-      const inertia = bot.entity.isInWater ? 0.8 : 0.5
-      // TODO: depth strider enchantement (for water)
-      applyHeading(strafe, forward, acceleration)
-      moveEntity(vel.x, vel.y, vel.z)
-      vel.y *= inertia
-      vel.y -= 0.02
-      vel.x *= inertia
-      vel.z *= inertia
-
-      if (bot.entity.isCollidedHorizontally) { // TODO: && isOffsetPositionInLiquid
-        vel.y = 0.3 // jump out of liquid
-      }
-    }
-  }
-
-  function isMaterialInBB (queryBB, type) {
-    const cursor = new Vec3(0, 0, 0)
-    for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
-      for (cursor.z = Math.floor(queryBB.minZ); cursor.z <= Math.floor(queryBB.maxZ); cursor.z++) {
-        for (cursor.x = Math.floor(queryBB.minX); cursor.x <= Math.floor(queryBB.maxX); cursor.x++) {
-          const block = bot.blockAt(cursor)
-          if (block && block.type === type) return true
-        }
-      }
-    }
-    return false
-  }
-
-  function getLiquidHeightPcent (block) {
-    return (getRenderedDepth(block) + 1) / 9
-  }
-
-  function getRenderedDepth (block) {
-    if (!block || block.type !== waterId) return -1
-    const meta = block.metadata
-    return meta >= 8 ? 0 : meta
-  }
-
-  function getFlow (block) {
-    const curlevel = getRenderedDepth(block)
-    const flow = new Vec3(0, 0, 0)
-    for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
-      const adjBlock = bot.blockAt(block.position.offset(dx, 0, dz))
-      const adjLevel = getRenderedDepth(adjBlock)
-      if (adjLevel < 0) {
-        if (adjBlock.boundingBox !== 'empty') {
-          const adjLevel = getRenderedDepth(bot.blockAt(block.position.offset(dx, -1, dz)))
-          if (adjLevel >= 0) {
-            const f = adjLevel - (curlevel - 8)
-            flow.x += dx * f
-            flow.z += dz * f
-          }
-        }
-      } else {
-        const f = adjLevel - curlevel
-        flow.x += dx * f
-        flow.z += dz * f
-      }
-    }
-
-    if (block.metadata >= 8) {
-      for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
-        const adjBlock = bot.blockAt(block.position.offset(dx, 0, dz))
-        const adjUpBlock = bot.blockAt(block.position.offset(dx, 1, dz))
-        if (adjBlock.boundingBox !== 'empty' || adjUpBlock.boundingBox !== 'empty') {
-          flow.normalize().translate(0, -6, 0)
-        }
-      }
-    }
-
-    return flow.normalize()
-  }
-
-  function isInWaterApplyCurrent (bb) {
-    let isInWater = false
-    const acceleration = new Vec3(0, 0, 0)
-    const cursor = new Vec3(0, 0, 0)
-    for (cursor.y = Math.floor(bb.minY); cursor.y <= Math.floor(bb.maxY); cursor.y++) {
-      for (cursor.z = Math.floor(bb.minZ); cursor.z <= Math.floor(bb.maxZ); cursor.z++) {
-        for (cursor.x = Math.floor(bb.minX); cursor.x <= Math.floor(bb.maxX); cursor.x++) {
-          const block = bot.blockAt(cursor)
-          if (block && block.type === waterId) {
-            const waterLevel = cursor.y + 1 - getLiquidHeightPcent(block)
-            if (Math.ceil(bb.maxY) >= waterLevel) {
-              isInWater = true
-              const flow = getFlow(block)
-              acceleration.add(flow)
-            }
-          }
-        }
-      }
-    }
-
-    const len = acceleration.norm()
-    if (len > 0) {
-      const vel = bot.entity.velocity
-      vel.x += acceleration.x / len * 0.014
-      vel.y += acceleration.y / len * 0.014
-      vel.z += acceleration.z / len * 0.014
-    }
-    return isInWater
-  }
-
-  function updatePlayer () {
-    const vel = bot.entity.velocity
-    const pos = bot.entity.position
-
-    const waterBB = getPlayerBB(pos).contract(0.001, 0.401, 0.001)
-    const lavaBB = getPlayerBB(pos).contract(0.1, 0.4, 0.1)
-
-    bot.entity.isInWater = isInWaterApplyCurrent(waterBB)
-    bot.entity.isInLava = isMaterialInBB(lavaBB, lavaId)
-
-    // Reset velocity component if it falls under the threshold
-    if (Math.abs(vel.x) < physics.negligeableVelocity) vel.x = 0
-    if (Math.abs(vel.y) < physics.negligeableVelocity) vel.y = 0
-    if (Math.abs(vel.z) < physics.negligeableVelocity) vel.z = 0
-
-    // Handle inputs
-    if (controlState.jump || jumpQueued) {
-      if (jumpTicks > 0) jumpTicks--
-      if (bot.entity.isInWater || bot.entity.isInLava) {
-        vel.y += 0.04
-      } else if (bot.entity.onGround && jumpTicks === 0) {
-        vel.y = 0.42
-        // TODO: jump potion effect
-        if (controlState.sprint) {
-          const yaw = PI - bot.entity.yaw
-          vel.x -= Math.sin(yaw) * 0.2
-          vel.z += Math.cos(yaw) * 0.2
-        }
-        jumpTicks = 10 // activate autojump cooldown (0.5s)
-      }
-    } else {
-      jumpTicks = 0 // reset autojump cooldown
-    }
-    jumpQueued = false
-
-    let strafe = (controlState.right - controlState.left) * 0.98
-    let forward = (controlState.forward - controlState.back) * 0.98
-
-    if (controlState.sneak) {
-      strafe *= 0.3
-      forward *= 0.3
-    }
-
-    moveEntityWithHeading(strafe, forward)
   }
 
   function sendPacketPosition (position, onGround) {
@@ -583,7 +152,7 @@ function inject (bot) {
     if (controlState[control] === state) return
     controlState[control] = state
     if (control === 'jump' && state) {
-      jumpQueued = true
+      bot.jumpQueued = true
     } else if (control === 'sprint') {
       bot._client.write('entity_action', {
         entityId: bot.entity.id,

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -15,30 +15,32 @@ const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000
 
 function inject (bot) {
   const mcData = require('minecraft-data')(bot.version)
+  const blocksByName = mcData.blocksByName
 
   // Block Slipperiness
   // https://www.mcpk.wiki/w/index.php?title=Slipperiness
   const blockSlipperiness = {}
-  if (mcData.blocksByName.slime_block) {
-    blockSlipperiness[mcData.blocksByName.slime_block.id] = 0.8
+  if (blocksByName.slime_block) {
+    blockSlipperiness[blocksByName.slime_block.id] = 0.8
   } else {
-    blockSlipperiness[mcData.blocksByName.slime.id] = 0.8
+    blockSlipperiness[blocksByName.slime.id] = 0.8
   }
-  blockSlipperiness[mcData.blocksByName.ice.id] = 0.98
-  blockSlipperiness[mcData.blocksByName.packed_ice.id] = 0.98
-  if (mcData.blocksByName.frosted_ice) { // 1.9+
-    blockSlipperiness[mcData.blocksByName.frosted_ice.id] = 0.98
+  blockSlipperiness[blocksByName.ice.id] = 0.98
+  blockSlipperiness[blocksByName.packed_ice.id] = 0.98
+  if (blocksByName.frosted_ice) { // 1.9+
+    blockSlipperiness[blocksByName.frosted_ice.id] = 0.98
   }
-  if (mcData.blocksByName.blue_ice) { // 1.13+
-    blockSlipperiness[mcData.blocksByName.blue_ice.id] = 0.989
+  if (blocksByName.blue_ice) { // 1.13+
+    blockSlipperiness[blocksByName.blue_ice.id] = 0.989
   }
 
   // Block ids
-  // const soulsandId = mcData.blocksByName.soul_sand.id
-  const waterId = mcData.blocksByName.water.id
-  const lavaId = mcData.blocksByName.lava.id
-  // const ladderId = mcData.blocksByName.ladder.id
-  // const vineId = mcData.blocksByName.vine.id
+  const soulsandId = blocksByName.soul_sand.id
+  const webId = blocksByName.cobweb ? blocksByName.cobweb.id : blocksByName.web.id
+  const waterId = blocksByName.water.id
+  const lavaId = blocksByName.lava.id
+  // const ladderId = blocksByName.ladder.id
+  // const vineId = blocksByName.vine.id
 
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
@@ -99,23 +101,11 @@ function inject (bot) {
     doPhysicsTimer = null
   }
 
-  function getPlayerBB () {
-    const pos = bot.entity.position
+  function getPlayerBB (pos) {
     return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
   }
 
-  function moveEntity () {
-    const entity = bot.entity
-    const vel = entity.velocity
-    const pos = entity.position
-
-    const oldVelX = vel.x
-    const oldVelY = vel.y
-    const oldVelZ = vel.z
-
-    const playerBB = getPlayerBB()
-    const queryBB = playerBB.clone().extend(vel.x, vel.y, vel.z)
-
+  function getSurroundingBBs (queryBB) {
     const surroundingBBs = []
     const cursor = new Vec3(0, 0, 0)
     for (cursor.y = Math.floor(queryBB.minY); cursor.y <= Math.floor(queryBB.maxY); cursor.y++) {
@@ -133,32 +123,88 @@ function inject (bot) {
         }
       }
     }
+    return surroundingBBs
+  }
+
+  physics.adjustPositionHeight = (pos) => {
+    const playerBB = getPlayerBB(pos)
+    const queryBB = playerBB.clone().extend(0, -1, 0)
+    const surroundingBBs = getSurroundingBBs(queryBB)
+
+    let dy = -1
+    for (const blockBB of surroundingBBs) {
+      dy = blockBB.computeOffsetY(playerBB, dy)
+    }
+    pos.y += dy
+  }
+
+  function moveEntity (dx, dy, dz) {
+    const entity = bot.entity
+    const vel = entity.velocity
+    const pos = entity.position
+
+    if (bot.entity.isInWeb) {
+      dx *= 0.25
+      dy *= 0.05
+      dz *= 0.25
+      vel.x = 0
+      vel.y = 0
+      vel.z = 0
+      bot.entity.isInWeb = false
+    }
+
+    const oldVelX = dx
+    const oldVelY = dy
+    const oldVelZ = dz
+
+    const playerBB = getPlayerBB(pos)
+    const queryBB = playerBB.clone().extend(dx, dy, dz)
+    const surroundingBBs = getSurroundingBBs(queryBB)
 
     for (const blockBB of surroundingBBs) {
-      vel.y = blockBB.computeOffsetY(playerBB, vel.y)
+      dy = blockBB.computeOffsetY(playerBB, dy)
     }
-    playerBB.offset(0, vel.y, 0)
-    pos.y += vel.y
+    playerBB.offset(0, dy, 0)
+    pos.y += dy
 
     for (const blockBB of surroundingBBs) {
-      vel.x = blockBB.computeOffsetX(playerBB, vel.x)
+      dx = blockBB.computeOffsetX(playerBB, dx)
     }
-    playerBB.offset(vel.x, 0, 0)
-    pos.x += vel.x
+    playerBB.offset(dx, 0, 0)
+    pos.x += dx
 
     for (const blockBB of surroundingBBs) {
-      vel.z = blockBB.computeOffsetZ(playerBB, vel.z)
+      dz = blockBB.computeOffsetZ(playerBB, dz)
     }
-    playerBB.offset(0, 0, vel.z)
-    pos.z += vel.z
+    playerBB.offset(0, 0, dz)
+    pos.z += dz
 
-    entity.isCollidedHorizontally = vel.x !== oldVelX || vel.z !== oldVelZ
-    entity.isCollidedVertically = vel.y !== oldVelY
+    entity.isCollidedHorizontally = dx !== oldVelX || dz !== oldVelZ
+    entity.isCollidedVertically = dy !== oldVelY
     entity.onGround = entity.isCollidedVertically && oldVelY < 0
 
-    if (vel.x !== oldVelX) vel.x = 0
-    if (vel.y !== oldVelY) vel.y = 0
-    if (vel.z !== oldVelZ) vel.z = 0
+    if (dx !== oldVelX) vel.x = 0
+    if (dy !== oldVelY) vel.y = 0
+    if (dz !== oldVelZ) vel.z = 0
+
+    // Finally, apply block collisions (web, soulsand...)
+    playerBB.contract(0.001, 0.001, 0.001)
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(playerBB.minY); cursor.y <= Math.floor(playerBB.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(playerBB.minZ); cursor.z <= Math.floor(playerBB.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(playerBB.minX); cursor.x <= Math.floor(playerBB.maxX); cursor.x++) {
+          const block = bot.blockAt(cursor)
+          if (block) {
+            if (block.type === soulsandId) {
+              vel.x *= 0.4
+              vel.z *= 0.4
+            } else if (block.type === webId) {
+              bot.entity.isInWeb = true
+            }
+          }
+        }
+      }
+    }
   }
 
   function applyHeading (strafe, forward, multiplier) {
@@ -196,7 +242,7 @@ function inject (bot) {
 
       applyHeading(strafe, forward, acceleration)
       // TODO: ladder handling
-      moveEntity()
+      moveEntity(vel.x, vel.y, vel.z)
 
       // Apply friction and gravity
       vel.y -= physics.gravity
@@ -209,7 +255,7 @@ function inject (bot) {
       const inertia = bot.entity.isInWater ? 0.8 : 0.5
       // TODO: depth strider enchantement (for water)
       applyHeading(strafe, forward, acceleration)
-      moveEntity()
+      moveEntity(vel.x, vel.y, vel.z)
       vel.y *= inertia
       vel.y -= 0.02
       vel.x *= inertia
@@ -236,9 +282,10 @@ function inject (bot) {
 
   function updatePlayer () {
     const vel = bot.entity.velocity
+    const pos = bot.entity.position
 
-    const waterBB = getPlayerBB().contract(0.001, 0.401, 0.001)
-    const lavaBB = getPlayerBB().contract(0.1, 0.4, 0.1)
+    const waterBB = getPlayerBB(pos).contract(0.001, 0.401, 0.001)
+    const lavaBB = getPlayerBB(pos).contract(0.1, 0.4, 0.1)
 
     bot.entity.isInWater = isMaterialInBB(waterBB, waterId) // TODO: liquid flow
     bot.entity.isInLava = isMaterialInBB(lavaBB, lavaId)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -44,8 +44,9 @@ function inject (bot) {
 
   const physics = {
     gravity: 0.08, // blocks/tick^2 https://minecraft.gamepedia.com/Entity#Motion_of_entities
-    yawSpeed: 3.0, // seems good
-    sprintSpeed: 1.3, // correct
+    yawSpeed: 3.0,
+    sprintSpeed: 1.3,
+    stepHeight: 0.6, // how much height can the bot step on without jump
     negligeableVelocity: 0.003 // actually 0.005 for 1.8, but seems fine
   }
 
@@ -105,6 +106,13 @@ function inject (bot) {
     return new AABB(-0.3, 0, -0.3, 0.3, 1.8, 0.3).offset(pos.x, pos.y, pos.z)
   }
 
+  function setPositionToBB (bb) {
+    const pos = bot.entity.position
+    pos.x = bb.minX + 0.3
+    pos.y = bb.minY
+    pos.z = bb.minZ + 0.3
+  }
+
   function getSurroundingBBs (queryBB) {
     const surroundingBBs = []
     const cursor = new Vec3(0, 0, 0)
@@ -157,28 +165,100 @@ function inject (bot) {
     const oldVelY = dy
     const oldVelZ = dz
 
-    const playerBB = getPlayerBB(pos)
+    let playerBB = getPlayerBB(pos)
     const queryBB = playerBB.clone().extend(dx, dy, dz)
     const surroundingBBs = getSurroundingBBs(queryBB)
+    const oldBB = playerBB.clone()
 
     for (const blockBB of surroundingBBs) {
       dy = blockBB.computeOffsetY(playerBB, dy)
     }
     playerBB.offset(0, dy, 0)
-    pos.y += dy
 
     for (const blockBB of surroundingBBs) {
       dx = blockBB.computeOffsetX(playerBB, dx)
     }
     playerBB.offset(dx, 0, 0)
-    pos.x += dx
 
     for (const blockBB of surroundingBBs) {
       dz = blockBB.computeOffsetZ(playerBB, dz)
     }
     playerBB.offset(0, 0, dz)
-    pos.z += dz
 
+    // Step on block if height < stepHeight
+    if (physics.stepHeight > 0 &&
+       (bot.entity.onGround || (dy !== oldVelY && oldVelY < 0)) &&
+       (dx !== oldVelX || dz !== oldVelZ)) {
+      const oldVelXCol = dx
+      const oldVelYCol = dy
+      const oldVelZCol = dz
+      const oldBBCol = playerBB.clone()
+
+      dy = physics.stepHeight
+      const queryBB = oldBB.clone().extend(oldVelX, dy, oldVelZ)
+      const surroundingBBs = getSurroundingBBs(queryBB)
+
+      const BB1 = oldBB.clone()
+      const BB2 = oldBB.clone()
+      const BB_XZ = BB1.clone().extend(dx, 0, dz)
+
+      let dy1 = dy
+      let dy2 = dy
+      for (const blockBB of surroundingBBs) {
+        dy1 = blockBB.computeOffsetY(BB_XZ, dy1)
+        dy2 = blockBB.computeOffsetY(BB2, dy2)
+      }
+      BB1.offset(0, dy1, 0)
+      BB2.offset(0, dy2, 0)
+
+      let dx1 = oldVelX
+      let dx2 = oldVelX
+      for (const blockBB of surroundingBBs) {
+        dx1 = blockBB.computeOffsetX(BB1, dx1)
+        dx2 = blockBB.computeOffsetX(BB2, dx2)
+      }
+      BB1.offset(dx1, 0, 0)
+      BB2.offset(dx2, 0, 0)
+
+      let dz1 = oldVelZ
+      let dz2 = oldVelZ
+      for (const blockBB of surroundingBBs) {
+        dz1 = blockBB.computeOffsetZ(BB1, dz1)
+        dz2 = blockBB.computeOffsetZ(BB2, dz2)
+      }
+      BB1.offset(0, 0, dz1)
+      BB2.offset(0, 0, dz2)
+
+      const norm1 = dx1 * dx1 + dz1 * dz1
+      const norm2 = dx2 * dx2 + dz2 * dz2
+
+      if (norm1 > norm2) {
+        dx = dx1
+        dy = -dy1
+        dz = dz1
+        playerBB = BB1
+      } else {
+        dx = dx2
+        dy = -dy2
+        dz = dz2
+        playerBB = BB2
+      }
+
+      for (const blockBB of surroundingBBs) {
+        dy = blockBB.computeOffsetY(playerBB, dy)
+      }
+      playerBB.offset(0, dy, 0)
+
+      if (oldVelXCol * oldVelXCol + oldVelZCol * oldVelZCol >= dx * dx + dz * dz) {
+        dx = oldVelXCol
+        dy = oldVelYCol
+        dz = oldVelZCol
+        playerBB = oldBBCol
+      }
+    }
+
+    // Update flags
+    setPositionToBB(playerBB)
     entity.isCollidedHorizontally = dx !== oldVelX || dz !== oldVelZ
     entity.isCollidedVertically = dy !== oldVelY
     entity.onGround = entity.isCollidedVertically && oldVelY < 0

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -360,6 +360,81 @@ function inject (bot) {
     return false
   }
 
+  function getLiquidHeightPcent (block) {
+    return (getRenderedDepth(block) + 1) / 9
+  }
+
+  function getRenderedDepth (block) {
+    if (!block || block.type !== waterId) return -1
+    const meta = block.metadata
+    return meta >= 8 ? 0 : meta
+  }
+
+  function getFlow (block) {
+    const curlevel = getRenderedDepth(block)
+    const flow = new Vec3(0, 0, 0)
+    for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
+      const adjBlock = bot.blockAt(block.position.offset(dx, 0, dz))
+      const adjLevel = getRenderedDepth(adjBlock)
+      if (adjLevel < 0) {
+        if (adjBlock.boundingBox !== 'empty') {
+          const adjLevel = getRenderedDepth(bot.blockAt(block.position.offset(dx, -1, dz)))
+          if (adjLevel >= 0) {
+            const f = adjLevel - (curlevel - 8)
+            flow.x += dx * f
+            flow.z += dz * f
+          }
+        }
+      } else {
+        const f = adjLevel - curlevel
+        flow.x += dx * f
+        flow.z += dz * f
+      }
+    }
+
+    if (block.metadata >= 8) {
+      for (const [dx, dz] of [[0, 1], [-1, 0], [0, -1], [1, 0]]) {
+        const adjBlock = bot.blockAt(block.position.offset(dx, 0, dz))
+        const adjUpBlock = bot.blockAt(block.position.offset(dx, 1, dz))
+        if (adjBlock.boundingBox !== 'empty' || adjUpBlock.boundingBox !== 'empty') {
+          flow.normalize().translate(0, -6, 0)
+        }
+      }
+    }
+
+    return flow.normalize()
+  }
+
+  function isInWaterApplyCurrent (bb) {
+    let isInWater = false
+    const acceleration = new Vec3(0, 0, 0)
+    const cursor = new Vec3(0, 0, 0)
+    for (cursor.y = Math.floor(bb.minY); cursor.y <= Math.floor(bb.maxY); cursor.y++) {
+      for (cursor.z = Math.floor(bb.minZ); cursor.z <= Math.floor(bb.maxZ); cursor.z++) {
+        for (cursor.x = Math.floor(bb.minX); cursor.x <= Math.floor(bb.maxX); cursor.x++) {
+          const block = bot.blockAt(cursor)
+          if (block && block.type === waterId) {
+            const waterLevel = cursor.y + 1 - getLiquidHeightPcent(block)
+            if (Math.ceil(bb.maxY) >= waterLevel) {
+              isInWater = true
+              const flow = getFlow(block)
+              acceleration.add(flow)
+            }
+          }
+        }
+      }
+    }
+
+    const len = acceleration.norm()
+    if (len > 0) {
+      const vel = bot.entity.velocity
+      vel.x += acceleration.x / len * 0.014
+      vel.y += acceleration.y / len * 0.014
+      vel.z += acceleration.z / len * 0.014
+    }
+    return isInWater
+  }
+
   function updatePlayer () {
     const vel = bot.entity.velocity
     const pos = bot.entity.position
@@ -367,7 +442,7 @@ function inject (bot) {
     const waterBB = getPlayerBB(pos).contract(0.001, 0.401, 0.001)
     const lavaBB = getPlayerBB(pos).contract(0.1, 0.4, 0.1)
 
-    bot.entity.isInWater = isMaterialInBB(waterBB, waterId) // TODO: liquid flow
+    bot.entity.isInWater = isInWaterApplyCurrent(waterBB)
     bot.entity.isInLava = isMaterialInBB(lavaBB, lavaId)
 
     // Reset velocity component if it falls under the threshold

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prismarine-windows": "^1.4.0",
     "protodef": "^1.7.1",
     "sprintf-js": "^1.1.1",
-    "vec3": "Karang/node-vec3#karang_vec3"
+    "vec3": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "minecraft-data": "^2.51.0",
+    "minecraft-data": "^2.52.0",
     "minecraft-protocol": "^1.12.0",
     "mojangson": "^0.2.1",
     "prismarine-biome": "^1.0.1",
-    "prismarine-block": "^1.3.0",
+    "prismarine-block": "^1.4.0",
     "prismarine-chunk": "^1.16.0",
     "prismarine-entity": "^1.0.0",
     "prismarine-item": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "minecraft-protocol": "^1.12.0",
     "mojangson": "^0.2.1",
     "prismarine-biome": "^1.0.1",
-    "prismarine-block": "^1.4.0",
+    "prismarine-block": "^1.5.0",
     "prismarine-chunk": "^1.16.0",
     "prismarine-entity": "^1.0.0",
     "prismarine-item": "^1.4.0",
@@ -33,7 +33,7 @@
     "prismarine-windows": "^1.4.0",
     "protodef": "^1.7.1",
     "sprintf-js": "^1.1.1",
-    "vec3": "^0.1.4"
+    "vec3": "Karang/node-vec3#karang_vec3"
   },
   "devDependencies": {
     "@types/node": "^14.0.1",

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -143,17 +143,13 @@ mineflayer.testedVersions.forEach((supportedVersion, i) => {
       const goldId = 41
       it('gravity + land on solid block + jump', (done) => {
         let y = 80
-        const terminal = 10
-        let hitTerminal = false
         bot.on('move', () => {
           assert.ok(bot.entity.position.y <= y)
           assert.ok(bot.entity.position.y >= pos.y)
           y = bot.entity.position.y
-          if (bot.entity.velocity.y > -terminal) hitTerminal = true
-          if (bot.entity.velocity.y === 0) {
-            assert.ok(hitTerminal)
-            assert.ok(bot.entity.onGround)
-            assert.ok(bot.entity.position.y, pos.y)
+          if (bot.entity.position.y <= pos.y + 1) {
+            assert.strictEqual(bot.entity.position.y, pos.y + 1)
+            assert.strictEqual(bot.entity.onGround, true)
             done()
           } else {
             assert.strictEqual(bot.entity.onGround, false)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -143,13 +143,16 @@ mineflayer.testedVersions.forEach((supportedVersion, i) => {
       const goldId = 41
       it('gravity + land on solid block + jump', (done) => {
         let y = 80
+        let landed = false
         bot.on('move', () => {
+          if (landed) return
           assert.ok(bot.entity.position.y <= y)
           assert.ok(bot.entity.position.y >= pos.y)
           y = bot.entity.position.y
           if (bot.entity.position.y <= pos.y + 1) {
             assert.strictEqual(bot.entity.position.y, pos.y + 1)
             assert.strictEqual(bot.entity.onGround, true)
+            landed = true
             done()
           } else {
             assert.strictEqual(bot.entity.onGround, false)


### PR DESCRIPTION
### The Physic Update

Complete rework of mineflayer's physic plugin to be closer to minecraft. This should fix some physic related issues. It makes the following modifications:
* Vanilla clients send a packet_position, packet_look or packet_position_and_look, depending on what was updated.
* The packet_position is sent every second if no update occured (not the packet_flying)
* Before 1.12, at least one position update must be sent every tick (packet_flying if no move). After 1.12 no need to spam the server.
* Vanilla yaw is not constrained to -PI, +PI. While it is easier to work with constrained yaw in code, anticheat could detect that. We keep track of the last sent yaw and use it to send an unconstrained value decoupled from the api.
* Unify physic updates and send position intervals, so they are executed in a deterministic order (and keep the code simpler to read).
* No need to redefine Math.sign
* Using min and max is a more efficient implementation of math.clamp
* Use flags to determine if position is absolute or relative Closes #993
* Add previous position in move events Closes #288
* entity_velocity set twice for the bot
* Fix the timestep! https://gafferongames.com/post/fix_your_timestep/ also because minecraft physic is computed in ticks and not in seconds
* Heading should not rotate the bot (moving left/right should strafe, not rotate the view)
* Minecraft time unit for physic is tick not seconds: simplify computations as deltaTime is now always 1 tick
* entity_velocity unit is 1/8000 block per server tick Closes #621
* Add a physic tick event emitted just after physic update (useful for pathfinder or other plugins that need to monitor movement)
* Correct slipperiness for slime, ice and blue ice https://www.mcpk.wiki/w/index.php?title=Slipperiness
* Implement collision with block shapes Closes #228 #778
* Blocks id shouldnt be hardcoded but instead taken from mcData
* Implement sprint + jump Closes #896
* Implement Water and lava movement Closes #814
* Multiple soulsand blocks can affect the bot (it cumulates)
* Implement webs slowdown
* add bot.physics.adjustPositionHeight function to apply gravity to a position
* Implement stepHeight
* Implement flowing water interactions Closes #788
* Implement slime block bounce
* Implement ladders and vines

To go with it, the pathfinder plugins need to be updated (I'll update mineflayer-pathfinder, but we need to decide what to do with mineflayer-navigate).
In particular:
* Use physicTick event to monitor movement
* Be aware of block height when setting targets
* Add swim moves
* Add ladder moves


Issues that should be closed, but need checking (close and reopen if needed):
* Random teleportation Closes #258
* Detected by anticheats Closes #835
* Get kicked for flying Closes #671

Sources:
* https://www.mcpk.wiki/wiki/Main_Page
* https://www.mcpk.wiki/wiki/SourceCode
* https://github.com/ddevault/TrueCraft/wiki/Entity-Movement-And-Physics