### PR TITLE
Improve blockAt speed

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -195,7 +195,7 @@
       - ["bossBarDeleted" (bossBar)](#bossbardeleted-bossbar)
       - ["bossBarUpdated" (bossBar)](#bossbarupdated-bossbar)
     - [Functions](#functions)
-      - [bot.blockAt(point)](#botblockatpoint)
+      - [bot.blockAt(point, extraInfos=true)](#botblockatpoint-extrainfostrue)
       - [bot.blockInSight(maxSteps, vectorLength)](#botblockinsightmaxsteps-vectorlength)
       - [bot.canSeeBlock(block)](#botcanseeblockblock)
       - [bot.findBlock(options)](#botfindblockoptions)
@@ -1179,9 +1179,9 @@ Fires when new boss bar is updated.
 
 ### Functions
 
-#### bot.blockAt(point)
+#### bot.blockAt(point, extraInfos=true)
 
-Returns the block at `point` or `null` if that point is not loaded.
+Returns the block at `point` or `null` if that point is not loaded. If `extraInfos` set to true, also returns informations about signs, paintings and block entities (slower).
 See `Block`.
 
 #### bot.blockInSight(maxSteps, vectorLength)

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -1,5 +1,4 @@
-const vec3 = require('vec3')
-const Vec3 = vec3.Vec3
+const Vec3 = require('vec3').Vec3
 const assert = require('assert')
 const Painting = require('../painting')
 const Location = require('../location')
@@ -110,14 +109,13 @@ function inject (bot, { version }) {
     } else check = options.matching
     options.point = options.point || bot.entity.position
     options.maxDistance = options.maxDistance || 16
-    const cursor = vec3()
     const point = options.point
     const max = options.maxDistance
-    let found
+    const cursor = new Vec3(0, 0, 0)
     for (cursor.x = point.x - max; cursor.x < point.x + max; cursor.x++) {
       for (cursor.y = point.y - max; cursor.y < point.y + max; cursor.y++) {
         for (cursor.z = point.z - max; cursor.z < point.z + max; cursor.z++) {
-          found = bot.blockAt(cursor)
+          const found = bot.blockAt(cursor)
           if (check(found)) return found
         }
       }
@@ -130,10 +128,13 @@ function inject (bot, { version }) {
   }
 
   function posInChunk (pos) {
-    return pos.floored().modulus(new Vec3(16, 256, 16))
+    pos = pos.floored()
+    pos.x &= 15
+    pos.z &= 15
+    return pos
   }
 
-  function blockAt (absolutePoint) {
+  function blockAt (absolutePoint, extraInfos = true) {
     const loc = new Location(absolutePoint)
     const key = columnKeyXZ(loc.chunkCorner.x, loc.chunkCorner.z)
 
@@ -143,9 +144,11 @@ function inject (bot, { version }) {
 
     const block = column.getBlock(posInChunk(absolutePoint))
     block.position = loc.floored
-    block.signText = signs[loc.floored]
-    block.painting = paintingsByPos[loc.floored]
-    block.blockEntity = blockEntities[loc.floored]
+    if (extraInfos) {
+      block.signText = signs[loc.floored]
+      block.painting = paintingsByPos[loc.floored]
+      block.blockEntity = blockEntities[loc.floored]
+    }
 
     return block
   }
@@ -297,9 +300,10 @@ function inject (bot, { version }) {
 
   bot._client.on('explosion', (packet) => {
     // explosion
+    const p = new Vec3(packet.x, packet.y, packet.z)
     packet.affectedBlockOffsets.forEach((offset) => {
-      const pt = vec3(offset).offset(packet.x, packet.y, packet.z)
-      updateBlockState(pt.floor(), 0)
+      const pt = p.offset(offset.x, offset.y, offset.z)
+      updateBlockState(pt, 0)
     })
   })
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -130,6 +130,7 @@ function inject (bot, { version }) {
   function posInChunk (pos) {
     pos = pos.floored()
     pos.x &= 15
+    pos.y &= 255
     pos.z &= 15
     return pos
   }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -16,7 +16,7 @@ const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000
 function inject (bot) {
   const mcData = require('minecraft-data')(bot.version)
 
-  const world = { getBlock: (pos) => { return bot.blockAt(pos) } }
+  const world = { getBlock: (pos) => { return bot.blockAt(pos, false) } }
   const physics = Physics(mcData, world)
 
   bot.jumpQueued = false


### PR DESCRIPTION
I found that the main bottleneck of blockAt, was in the 3 lines:
```javascript
block.signText = signs[loc.floored]
block.painting = paintingsByPos[loc.floored]
block.blockEntity = blockEntities[loc.floored]
```
I added a way to disable them when they are not needed (enabled by default, so it don't break compatibility)

With this simple modification (and calling blockAt without extraInfos), mineflayer-pathfinder can find the same path in 3 time less time:
```
Before:
I can get there in 101 moves. Computation took 1786.30 ms.
After:
I can get there in 101 moves. Computation took 573.75 ms.
```
