### PR TITLE
Fix lookAt and setQuickBarSlot

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -595,9 +595,9 @@ function inject (bot, { version }) {
 
   bot._client.on('held_item_slot', (packet) => {
     // held item change
-    bot.quickBarSlot = packet.slot
-    updateHeldItem()
+    bot.setQuickBarSlot(packet.slot)
   })
+
   bot._client.on('open_window', (packet) => {
     // open window
     bot.currentWindow = windows.createWindow(packet.windowId,
@@ -660,11 +660,8 @@ function inject (bot, { version }) {
     }
 
     // set window items
-    let i
-
-    let item
-    for (i = 0; i < packet.items.length; ++i) {
-      item = Item.fromNotch(packet.items[i])
+    for (let i = 0; i < packet.items.length; ++i) {
+      const item = Item.fromNotch(packet.items[i])
       window.updateSlot(i, item)
     }
     updateHeldItem()

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -192,19 +192,24 @@ function inject (bot) {
     if (err) throw err
   }
 
+  let lookAtCb = noop
+  function checkYaw () {
+    if (Math.abs(((lastSentYaw % PI_2) - bot.entity.yaw) % PI_2) < 0.001) {
+      lookAtCb()
+      lookAtCb = noop
+    }
+  }
+  bot.on('move', checkYaw)
+
   bot.look = (yaw, pitch, force, cb) => {
-    const haveCb = !!cb
-    cb = cb || noop
     bot.entity.yaw = yaw
     bot.entity.pitch = pitch
-    if (force) lastSentYaw = yaw
-    function checkYaw () {
-      if (Math.abs(((lastSentYaw % PI_2) - yaw) % PI_2) < 0.001) {
-        bot.removeListener('move', checkYaw)
-        cb()
-      }
+    if (force) {
+      lastSentYaw = yaw
+      lookAtCb()
+    } else {
+      lookAtCb = cb || noop
     }
-    if (haveCb) bot.on('move', checkYaw)
   }
 
   bot.lookAt = (point, force, cb) => {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -206,7 +206,8 @@ function inject (bot) {
     bot.entity.pitch = pitch
     if (force) {
       lastSentYaw = yaw
-      lookAtCb()
+      lookAtCb = noop
+      cb()
     } else {
       lookAtCb = cb || noop
     }


### PR DESCRIPTION
First bug is related to digging and lookAt:
When you call bot.stopDigging() while the bot hasn't finished the lookAt in bot.dig(), it doesnt cancel the digging. As a result multiple digging can be started at once, resulting in crashs.
The problem is more general: when you call multiple lookAt it doesn't cancels the one already there.
Fix: allow only one lookAt to execute at once.

The second bug caused problems with the equip() function that relies on the setQuickBarSlot() function:
* Set quickbar slot to 1
* Disconnect the bot
* Reconnect
* The server will set the quickbar slot to 1, but other players and the server will see the bot having the slot 0 set
* try to set the quickbar slot to 1 will fail because the bot thinks it's already set
fix: when the server set a quickbar slot, answer with the same slot to keep it in sync