### PR TITLE
Fast findBlocks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -198,6 +198,7 @@
       - [bot.blockAt(point, extraInfos=true)](#botblockatpoint-extrainfostrue)
       - [bot.blockInSight(maxSteps, vectorLength)](#botblockinsightmaxsteps-vectorlength)
       - [bot.canSeeBlock(block)](#botcanseeblockblock)
+      - [bot.findBlocks(options)](#botfindblocksoptions)
       - [bot.findBlock(options)](#botfindblockoptions)
       - [bot.canDigBlock(block)](#botcandigblockblock)
       - [bot.recipesFor(itemType, metadata, minResultCount, craftingTable)](#botrecipesforitemtype-metadata-minresultcount-craftingtable)
@@ -1194,16 +1195,20 @@ Returns the block at which bot is looking at or `null`
 
 Returns true or false depending on whether the bot can see the specified `block`.
 
+#### bot.findBlocks(options)
+
+Finds blocks arround the given point.
+ * `options` - Options for the search:
+   - `point` - The start position of the search (center). Default is the bot position.
+   - `matching` - A function that returns true if the given block is a match. Also supports this value being a block id or array of block ids.
+   - `maxDistance` - The furthest distance for the search, defaults to 16.
+   - `minCount` - Minimum blocks to find before returning the search. Default to 1. Can return less if not enough blocks are found exploring the whole area. Can return more due to some optimisations.
+
+Returns an array (possibly empty) with the found block coordinates (not the blocks)
+
 #### bot.findBlock(options)
 
-Finds the nearest block to the given point.
- * `options` - Additional options for the search:
-   - `point` - The start position of the search.
-   - `matching` - A function that returns true if the given block is a match.  Also supports this value being a block id or array of block ids.
-   - `maxDistance` - The furthest distance for the search, defaults to 16.
-
-This is a simple function, to be used for simple things, for a more complete search using more optimals algorithm,
- use [mineflayer-blockfinder](https://github.com/Darthfett/mineflayer-blockfinder) instead which have a very similar API.
+Alias for `bot.findBlock(options)[0]`. Return a single block or `null`.
 
 #### bot.canDigBlock(block)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1197,14 +1197,14 @@ Returns true or false depending on whether the bot can see the specified `block`
 
 #### bot.findBlocks(options)
 
-Finds blocks arround the given point.
+Finds the closest blocks from the given point.
  * `options` - Options for the search:
    - `point` - The start position of the search (center). Default is the bot position.
    - `matching` - A function that returns true if the given block is a match. Also supports this value being a block id or array of block ids.
    - `maxDistance` - The furthest distance for the search, defaults to 16.
    - `minCount` - Minimum blocks to find before returning the search. Default to 1. Can return less if not enough blocks are found exploring the whole area. Can return more due to some optimisations.
 
-Returns an array (possibly empty) with the found block coordinates (not the blocks)
+Returns an array (possibly empty) with the found block coordinates (not the blocks). The array is sorted (closest first)
 
 #### bot.findBlock(options)
 

--- a/examples/blockfinder.js
+++ b/examples/blockfinder.js
@@ -1,0 +1,35 @@
+/*
+ * This simple bot will help you find any block
+ */
+const mineflayer = require('mineflayer')
+
+const { performance } = require('perf_hooks')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node blockfinder.js <host> <port> [<name>] [<password>]')
+  process.exit(1)
+}
+
+const bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4] ? process.argv[4] : 'finder',
+  password: process.argv[5]
+})
+
+bot.on('chat', (username, message) => {
+  if (username === bot.username) return
+
+  const mcData = require('minecraft-data')(bot.version)
+
+  if (message.startsWith('find')) {
+    const name = message.split(' ')[1]
+    const ids = [mcData.blocksByName[name].id]
+
+    const startTime = performance.now()
+    const blocks = bot.findBlocks({ matching: ids, maxDistance: 128, minCount: 10 })
+    const time = (performance.now() - startTime).toFixed(2)
+
+    bot.chat(`I found ${blocks.length} ${name} blocks in ${time} ms`)
+  }
+})

--- a/lib/iterators.js
+++ b/lib/iterators.js
@@ -1,0 +1,162 @@
+const Vec3 = require('vec3').Vec3
+
+// 2D spiral iterator, useful to iterate on
+// columns that are centered on bot position
+class ManathanIterator {
+  constructor (x, y, maxDistance) {
+    this.maxDistance = maxDistance
+    this.startx = x
+    this.starty = y
+    this.x = 2
+    this.y = -1
+    this.layer = 1
+    this.leg = -1
+  }
+
+  next () {
+    if (this.leg === -1) {
+      // use -1 as the center
+      this.leg = 0
+      return { x: this.startx, y: this.starty }
+    } else if (this.leg === 0) {
+      if (this.maxDistance === 1) return null
+      this.x--
+      this.y++
+      if (this.x === 0) this.leg = 1
+    } else if (this.leg === 1) {
+      this.x--
+      this.y--
+      if (this.y === 0) this.leg = 2
+    } else if (this.leg === 2) {
+      this.x++
+      this.y--
+      if (this.x === 0) this.leg = 3
+    } else if (this.leg === 3) {
+      this.x++
+      this.y++
+      if (this.y === 0) {
+        this.x++
+        this.leg = 0
+        this.layer++
+        if (this.layer === this.maxDistance) {
+          return null
+        }
+      }
+    }
+    return new Vec3(this.startx + this.x, 0, this.starty + this.y)
+  }
+}
+
+class OctahedronIterator {
+  constructor (start, maxDistance) {
+    this.start = start.floored()
+    this.maxDistance = maxDistance
+    this.apothem = 1
+    this.x = -1
+    this.y = -1
+    this.z = -1
+    this.L = this.apothem
+    this.R = this.L + 1
+  }
+
+  next () {
+    if (this.apothem > this.maxDistance) return null
+    this.R -= 1
+    if (this.R < 0) {
+      this.L -= 1
+      if (this.L < 0) {
+        this.z += 2
+        if (this.z > 1) {
+          this.y += 2
+          if (this.y > 1) {
+            this.x += 2
+            if (this.x > 1) {
+              this.apothem += 1
+              this.x = -1
+            }
+            this.y = -1
+          }
+          this.z = -1
+        }
+        this.L = this.apothem
+      }
+      this.R = this.L
+    }
+    const X = this.x * this.R
+    const Y = this.y * (this.apothem - this.L)
+    const Z = this.z * (this.apothem - (Math.abs(X) + Math.abs(Y)))
+    return this.start.offset(X, Y, Z)
+  }
+}
+
+const BlockFace = {
+  UNKNOWN: -999,
+  BOTTOM: 0,
+  TOP: 1,
+  NORTH: 2,
+  SOUTH: 3,
+  WEST: 4,
+  EAST: 5
+}
+
+// This iterate along a ray starting at (x,y,z) in (dx,dy,dz) direction
+// It steps exactly 1 block at a time, returning the block coordinates
+// and the face by which the ray entered the block.
+class RaycastIterator {
+  constructor (x, y, z, dx, dy, dz, maxDistance) {
+    this.block = {
+      x: Math.floor(x),
+      y: Math.floor(y),
+      z: Math.floor(z),
+      face: BlockFace.UNKNOWN
+    }
+
+    this.stepX = Math.sign(dx)
+    this.stepY = Math.sign(dy)
+    this.stepZ = Math.sign(dz)
+
+    this.tDeltaX = (dx === 0) ? Number.MAX_VALUE : Math.abs(1 / dx)
+    this.tDeltaY = (dy === 0) ? Number.MAX_VALUE : Math.abs(1 / dy)
+    this.tDeltaZ = (dz === 0) ? Number.MAX_VALUE : Math.abs(1 / dz)
+
+    this.tMaxX = (dx === 0) ? Number.MAX_VALUE : Math.abs((this.block.x + (dx > 0 ? 1 : 0) - x) / dx)
+    this.tMaxY = (dy === 0) ? Number.MAX_VALUE : Math.abs((this.block.y + (dy > 0 ? 1 : 0) - y) / dy)
+    this.tMaxZ = (dz === 0) ? Number.MAX_VALUE : Math.abs((this.block.z + (dz > 0 ? 1 : 0) - z) / dz)
+
+    this.maxDistance = maxDistance
+  }
+
+  next () {
+    if (Math.min(Math.min(this.tMaxX, this.tMaxY), this.tMaxZ) > this.maxDistance) { return null }
+
+    if (this.tMaxX < this.tMaxY) {
+      if (this.tMaxX < this.tMaxZ) {
+        this.block.x += this.stepX
+        this.tMaxX += this.tDeltaX
+        this.block.face = this.stepX > 0 ? BlockFace.WEST : BlockFace.EAST
+      } else {
+        this.block.z += this.stepZ
+        this.tMaxZ += this.tDeltaZ
+        this.block.face = this.stepZ > 0 ? BlockFace.NORTH : BlockFace.SOUTH
+      }
+    } else {
+      if (this.tMaxY < this.tMaxZ) {
+        this.block.y += this.stepY
+        this.tMaxY += this.tDeltaY
+        this.block.face = this.stepY > 0 ? BlockFace.BOTTOM : BlockFace.TOP
+      } else {
+        this.block.z += this.stepZ
+        this.tMaxZ += this.tDeltaZ
+        this.block.face = this.stepZ > 0 ? BlockFace.NORTH : BlockFace.SOUTH
+      }
+    }
+
+    return this.block
+  }
+}
+
+module.exports = {
+  ManathanIterator,
+  OctahedronIterator,
+  RaycastIterator
+}

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -144,8 +144,9 @@ function inject (bot, { version }) {
     // the octahedron iterator can sometime go through the same section again
     // we use a set to keep track of visited sections
     const visitedSections = new Set()
+    let startedLayer = 0
     let next = start
-    while (next && blocks.length < minCount) {
+    while (next) {
       const column = columns[columnKeyXZ(next.x * 16, next.z * 16)]
       if (next.y >= 0 && next.y < 16 && column && !visitedSections.has(next.toString())) {
         const section = column.sections[next.y]
@@ -162,8 +163,16 @@ function inject (bot, { version }) {
         }
         visitedSections.add(next.toString())
       }
+      // If we started a layer, we have to finish it otherwise we might miss closer blocks
+      if (startedLayer !== it.apothem && blocks.length >= minCount) {
+        break
+      }
+      startedLayer = it.apothem
       next = it.next()
     }
+    blocks.sort((a, b) => {
+      return a.distanceTo(start) - b.distanceTo(start)
+    })
     return blocks
   }
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -3,6 +3,8 @@ const assert = require('assert')
 const Painting = require('../painting')
 const Location = require('../location')
 
+const { OctahedronIterator } = require('../iterators')
+
 module.exports = inject
 
 const paintingFaceToVec = [
@@ -14,6 +16,7 @@ const paintingFaceToVec = [
 
 function inject (bot, { version }) {
   const nbt = require('prismarine-nbt')
+  const Block = require('prismarine-block')(version)
   const Chunk = require('prismarine-chunk')(version)
   const ChatMessage = require('../chat_message')(version)
   let columns = {}
@@ -99,14 +102,73 @@ function inject (bot, { version }) {
     bot.emit('chunkColumnLoad', columnCorner)
   }
 
-  function findBlock (options) {
-    let check
-    if (typeof (options.matching) !== 'function') {
-      if (!Array.isArray(options.matching)) {
-        options.matching = [options.matching]
+  function getMatchingFunction (matching) {
+    if (typeof (matching) !== 'function') {
+      if (!Array.isArray(matching)) {
+        matching = [matching]
       }
-      check = isMatchingType
-    } else check = options.matching
+      return isMatchingType
+    }
+    return matching
+
+    function isMatchingType (block) {
+      return block === null ? false : matching.indexOf(block.type) >= 0
+    }
+  }
+
+  function isBlockInSection (section, matcher) {
+    if (!section) return false // section is empty, skip it (yay!)
+    // If the chunk use a palette we can speed up the search by first
+    // checking the palette which usually contains less than 20 ids
+    // vs checking the 4096 block of the section. If we don't have a
+    // match in the palette, we can skip this section.
+    if (section.palette) {
+      for (const stateId of section.palette) {
+        if (matcher(Block.fromStateId(stateId, 0))) {
+          return true // the block is in the palette
+        }
+      }
+      return false // skip
+    }
+    return true // global palette, the block might be in there
+  }
+
+  bot.findBlocks = (options) => {
+    const matcher = getMatchingFunction(options.matching)
+    let start = (options.point || bot.entity.position).floored()
+    const maxDistance = Math.ceil((options.maxDistance || 16) / 16)
+    const minCount = options.minCount || 1
+    const blocks = []
+    start = new Vec3(Math.floor(start.x / 16), Math.floor(start.y / 16), Math.floor(start.z / 16))
+    const it = new OctahedronIterator(start, maxDistance)
+    // the octahedron iterator can sometime go through the same section again
+    // we use a set to keep track of visited sections
+    const visitedSections = new Set()
+    let next = start
+    while (next && blocks.length < minCount) {
+      const column = columns[columnKeyXZ(next.x * 16, next.z * 16)]
+      if (next.y >= 0 && next.y < 16 && column && !visitedSections.has(next.toString())) {
+        const section = column.sections[next.y]
+        if (isBlockInSection(section, matcher)) {
+          const cursor = new Vec3(0, 0, 0)
+          for (cursor.x = next.x * 16; cursor.x < next.x * 16 + 16; cursor.x++) {
+            for (cursor.y = next.y * 16; cursor.y < next.y * 16 + 16; cursor.y++) {
+              for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
+                const found = bot.blockAt(cursor, false)
+                if (matcher(found)) blocks.push(cursor.clone())
+              }
+            }
+          }
+        }
+        visitedSections.add(next.toString())
+      }
+      next = it.next()
+    }
+    return blocks
+  }
+
+  function findBlock (options) {
+    const check = getMatchingFunction(options.matching)
     options.point = options.point || bot.entity.position
     options.maxDistance = options.maxDistance || 16
     const point = options.point
@@ -121,10 +183,6 @@ function inject (bot, { version }) {
       }
     }
     return null
-
-    function isMatchingType (block) {
-      return block === null ? false : options.matching.indexOf(block.type) >= 0
-    }
   }
 
   function posInChunk (pos) {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -168,21 +168,9 @@ function inject (bot, { version }) {
   }
 
   function findBlock (options) {
-    const check = getMatchingFunction(options.matching)
-    options.point = options.point || bot.entity.position
-    options.maxDistance = options.maxDistance || 16
-    const point = options.point
-    const max = options.maxDistance
-    const cursor = new Vec3(0, 0, 0)
-    for (cursor.x = point.x - max; cursor.x < point.x + max; cursor.x++) {
-      for (cursor.y = point.y - max; cursor.y < point.y + max; cursor.y++) {
-        for (cursor.z = point.z - max; cursor.z < point.z + max; cursor.z++) {
-          const found = bot.blockAt(cursor)
-          if (check(found)) return found
-        }
-      }
-    }
-    return null
+    const blocks = bot.findBlocks(options)
+    if (blocks.length === 0) return null
+    return bot.blockAt(blocks[0])
   }
 
   function posInChunk (pos) {


### PR DESCRIPTION
Finding blocks may seems a trivial task, but finding them in a reasonable amount of time may be challenging. Mineflayer expose a bot.findBlock function that return the first matched block in a cube arround the player: this will be our baseline. We also need some benchmark to compare the baseline to new solutions, with the player located on the surface we search for:

* find diamond_ore (maxDistance = 128, minCount = 1) : diamond ores are usually near bedrock (y<13)
* find crafting_table (maxDistance = 128, minCount = 1) : we placed a crafting table just in front of the player
* find diamond_block (maxDistance = 128, minCount = 1) : there is no diamond block arround the player (worst case scenario)

So, let's see how the baseline behave:

* find diamond_ore: 35.59 ms (less than a tick, its very good. this is because the algorithm start searching at y=0 and go up, so it is faster at finding blocks near bedrock)
* find crafting_table: 2572.27 ms (2.5 seconds! that's a lot :( the crafting table was just in front of the player, but we checked all blocks at the bottom of the world first)
* find diamond_block: 5290.04 ms (very bad. we just tested every block in a 128x128x128 cube and found nothing)

A third party plugin was created to improve the search algorithm: https://github.com/Darthfett/mineflayer-blockfinder it has gone through a lot of iterations and came up with a clever algorithm to return in priority the blocks closer to the player. The algorithm is based on an Octahedron iterator (3D diamond shape) that goes layer by layer arround the player. Let's see how it behaves on the benchmark:

* find diamond_ore: 196.79 ms (slower than the baseline, but 4 ticks is acceptable for a block that is far from the player)
* find crafting_table: 0.25 ms (very good, it finds blocks near the player almost instantly)
* find diamond_block: 1036.72 ms (worst case of 1s, that's still a bit slow, but 5x faster than the baseline)

The octahedron approach is very good at finding blocks near the player. In fact, it guarantees that the returned block will always be the closest one. But when the block is far or not present, we sill go through a lot of blocks.

Can we do better ?

To do better, we need to test less blocks. In minecraft, the world is divided in columns (16x256x16 blocks) and these columns are themselves divided in sections of (16x16x16 = 4096 blocks). If a section is `null`, we know that all the blocks in it are blocks of air, so we don't need to check them (unless you are searching for air, but why would you ?). In this case we can skip the whole section. Let's modify the octahedron iterator to iterate on sections instead of blocks and search in the section using a simple cube loop but only if the section is not `null`:

* find diamond_ore: 153.52 ms (a bit faster)
* find crafting_table: 8.8 ms (slightly slower, but still very fast)
* find diamond_block: 666.8 ms (x1.5 faster)

This allowed to improve the worst case, but empty sections are not that common (unless you are in the sky).

The last modification takes advantage of the palette system which was introduced in 1.13. Each section contains a palette that map the block id local to the section to the global stateId. This palette is usually quite small (<20 ids) and allow to test if a certain block is present in the section. We modify our previous version to first test the palette:

* find diamond_ore: 5.80 ms (x6 faster than baseline)
* find crafting_table: 1.82 ms (x1413 faster than baseline)
* find diamond_block: 7.27 ms (x727 faster than baseline)

This allows to speed the search significantly.

This MR adds the faster version. Closes #813

I also added 2 other iterators (Manathan and Raycast that I think might be useful for mineflayer)