### PR TITLE
Fix block sorting in findblocks

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -135,7 +135,8 @@ function inject (bot, { version }) {
 
   bot.findBlocks = (options) => {
     const matcher = getMatchingFunction(options.matching)
-    let start = (options.point || bot.entity.position).floored()
+    const point = options.point || bot.entity.position
+    let start = point.floored()
     const maxDistance = Math.ceil((options.maxDistance || 16) / 16)
     const minCount = options.minCount || 1
     const blocks = []
@@ -171,7 +172,7 @@ function inject (bot, { version }) {
       next = it.next()
     }
     blocks.sort((a, b) => {
-      return a.distanceTo(start) - b.distanceTo(start)
+      return a.distanceTo(point) - b.distanceTo(point)
     })
     return blocks
   }


### PR DESCRIPTION
Sort with respect to the distance to the given point, not the section it is in.