### PR TITLE
Emit chestLidMove only once

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1077,6 +1077,8 @@ Fires when a note block goes off somewhere.
 #### "pistonMove" (block, isPulling, direction)
 
 #### "chestLidMove" (block, isOpen)
+* `block`: a Block instance, the block whose lid opened
+* `isOpen`: number of players that have the chest open. 0 if it's closed
 
 #### "blockBreakProgressObserved" (block, destroyStage)
 

--- a/lib/features.json
+++ b/lib/features.json
@@ -178,5 +178,10 @@
       "name": "doesntHaveOffHandSlot",
       "description": "doesn't have an off-hand slot",
       "versions": ["1.8"]
+    },
+    {
+      "name": "doesntHaveChestType",
+      "description": "chests don't have a type property",
+      "versions": ["1.8", "1.9", "1.10", "1.11", "1.12"]
     }
   ]

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -2,19 +2,77 @@ const Vec3 = require('vec3').Vec3
 
 module.exports = inject
 
+const CARDINALS = {
+  north: new Vec3(0, 0, -1),
+  south: new Vec3(0, 0, 1),
+  west: new Vec3(-1, 0, 0),
+  east: new Vec3(1, 0, 0)
+}
+
 function inject (bot, { version }) {
   const { instruments, blocks } = require('minecraft-data')(version)
+
+  function parseChestMetadata (chestBlock) {
+    const chestTypes = ['single', 'right', 'left']
+    let data
+
+    if (bot.supportFeature('doesntHaveChestType')) {
+      data = {
+        facing: Object.keys(CARDINALS)[chestBlock.metadata - 2]
+      }
+    } else {
+      data = {
+        waterlogged: !(chestBlock.metadata & 1),
+        type: chestTypes[(chestBlock.metadata >> 1) % 3],
+        facing: Object.keys(CARDINALS)[Math.floor(chestBlock.metadata / 6)]
+      }
+    }
+    return data
+  }
+
+  function getChestType (chestBlock) { // Returns 'single', 'right' or 'left'
+    if (bot.supportFeature('doesntHaveChestType')) {
+      const facing = parseChestMetadata(chestBlock).facing
+
+      // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
+      if (facing === 'north' || facing === 'south') {
+        if (bot.blockAt(chestBlock.position.plus(CARDINALS.west)).name === chestBlock.name) {
+          return facing === 'north' ? 'left' : 'right'
+        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.east)).name === chestBlock.name) {
+          return facing === 'north' ? 'right' : 'left'
+        }
+      } else if (facing === 'west' || facing === 'east') {
+        if (bot.blockAt(chestBlock.position.plus(CARDINALS.north)).name === chestBlock.name) {
+          return facing === 'west' ? 'right' : 'left'
+        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.south)).name === chestBlock.name) {
+          return facing === 'west' ? 'left' : 'right'
+        }
+      }
+
+      return 'single'
+    } else {
+      return parseChestMetadata(chestBlock).type
+    }
+  }
+
   bot._client.on('block_action', (packet) => {
-    // block action
     const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
     const block = bot.blockAt(pt)
     const blockName = blocks[packet.blockId].name
+
     if (blockName === 'noteblock' || blockName === 'note_block') {
       bot.emit('noteHeard', block, instruments[packet.byte1], packet.byte2)
     } else if (blockName === 'sticky_piston' || blockName === 'piston') {
       bot.emit('pistonMove', block, packet.byte1, packet.byte2)
     } else {
-      bot.emit('chestLidMove', block, packet.byte2)
+      if (blockName === 'chest' || blockName === 'trapped_chest') {
+        const chestType = getChestType(block)
+        if (chestType === 'single' || chestType === 'right') { // Omit left so 'chestLidMove' doesn't emit twice when it's a double chest
+          bot.emit('chestLidMove', block, packet.byte2)
+        }
+      } else {
+        bot.emit('chestLidMove', block, packet.byte2)
+      }
     }
   })
 

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -14,38 +14,33 @@ function inject (bot, { version }) {
 
   function parseChestMetadata (chestBlock) {
     const chestTypes = ['single', 'right', 'left']
-    let data
 
-    if (bot.supportFeature('doesntHaveChestType')) {
-      data = {
-        facing: Object.keys(CARDINALS)[chestBlock.metadata - 2]
-      }
-    } else {
-      data = {
+    return bot.supportFeature('doesntHaveChestType')
+      ? { facing: Object.keys(CARDINALS)[chestBlock.metadata - 2] }
+      : {
         waterlogged: !(chestBlock.metadata & 1),
         type: chestTypes[(chestBlock.metadata >> 1) % 3],
         facing: Object.keys(CARDINALS)[Math.floor(chestBlock.metadata / 6)]
       }
-    }
-    return data
   }
 
   function getChestType (chestBlock) { // Returns 'single', 'right' or 'left'
     if (bot.supportFeature('doesntHaveChestType')) {
+      const facingMap = {
+        north: { west: 'right', east: 'left' },
+        south: { west: 'left', east: 'right' },
+        west: { north: 'left', south: 'right' },
+        east: { north: 'right', south: 'left' }
+      }
+
       const facing = parseChestMetadata(chestBlock).facing
 
       // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
-      if (facing === 'north' || facing === 'south') {
-        if (bot.blockAt(chestBlock.position.plus(CARDINALS.west)).id === chestBlock.id) {
-          return facing === 'north' ? 'left' : 'right'
-        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.east)).id === chestBlock.id) {
-          return facing === 'north' ? 'right' : 'left'
-        }
-      } else if (facing === 'west' || facing === 'east') {
-        if (bot.blockAt(chestBlock.position.plus(CARDINALS.north)).id === chestBlock.id) {
-          return facing === 'west' ? 'right' : 'left'
-        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.south)).id === chestBlock.id) {
-          return facing === 'west' ? 'left' : 'right'
+      const perpendicularCardinals = Object.keys(facingMap[facing])
+      for (const cardinal of perpendicularCardinals) {
+        const cardinalOffset = CARDINALS[cardinal]
+        if (bot.blockAt(chestBlock.position.plus(cardinalOffset)).type === chestBlock.type) {
+          return facingMap[cardinal][facing]
         }
       }
 

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -36,15 +36,15 @@ function inject (bot, { version }) {
 
       // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
       if (facing === 'north' || facing === 'south') {
-        if (bot.blockAt(chestBlock.position.plus(CARDINALS.west)).name === chestBlock.name) {
+        if (bot.blockAt(chestBlock.position.plus(CARDINALS.west)).id === chestBlock.id) {
           return facing === 'north' ? 'left' : 'right'
-        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.east)).name === chestBlock.name) {
+        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.east)).id === chestBlock.id) {
           return facing === 'north' ? 'right' : 'left'
         }
       } else if (facing === 'west' || facing === 'east') {
-        if (bot.blockAt(chestBlock.position.plus(CARDINALS.north)).name === chestBlock.name) {
+        if (bot.blockAt(chestBlock.position.plus(CARDINALS.north)).id === chestBlock.id) {
           return facing === 'west' ? 'right' : 'left'
-        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.south)).name === chestBlock.name) {
+        } else if (bot.blockAt(chestBlock.position.plus(CARDINALS.south)).id === chestBlock.id) {
           return facing === 'west' ? 'left' : 'right'
         }
       }

--- a/test/externalTests/chestEvents.js
+++ b/test/externalTests/chestEvents.js
@@ -1,0 +1,34 @@
+const assert = require('assert')
+
+module.exports = () => (bot, done) => {
+  const mcData = require('minecraft-data')(bot.version)
+  const Item = require('prismarine-item')(bot.version)
+
+  let blockItemsByName
+  if (bot.supportFeature('itemsAreNotBlocks')) {
+    blockItemsByName = 'itemsByName'
+  } else if (bot.supportFeature('itemsAreAlsoBlocks')) {
+    blockItemsByName = 'blocksByName'
+  }
+
+  const chestSlot = 36
+  const chestLocation1 = bot.entity.position.offset(0, 0, -1)
+  const chestLocation2 = bot.entity.position.offset(1, 0, -1)
+
+  bot.test.setInventorySlot(chestSlot, new Item(mcData[blockItemsByName].chest.id, 2, 0), (err) => {
+    assert.ifError(err)
+    bot.test.placeBlock(chestSlot, chestLocation1, (err) => {
+      assert.ifError(err)
+      bot.test.placeBlock(chestSlot, chestLocation2, (err) => {
+        assert.ifError(err)
+
+        bot.openChest(bot.blockAt(chestLocation2))
+
+        bot.on('chestLidMove', (block, isOpen) => {
+          assert.strictEqual(isOpen, 1)
+          done() // If 'chestLidMove' is emitted twice, done() would be called twice and thus failing tests
+        })
+      })
+    })
+  })
+}


### PR DESCRIPTION
Even thought the vanilla server emits the event twice when it's a double chest, I think it's kind of confusing for a mineflayer user, so I think this change makes sense

Not sure if this is the best approach, but it does the job!

Closes #1064