### PR TITLE
Added off-hand to EquipmentDestination enum.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -626,7 +626,7 @@ export interface FindBlockOptions {
   maxDistance?: number;
 }
 
-export type EquipmentDestination = "hand" | "head" | "torso" | "legs" | "feet";
+export type EquipmentDestination = "hand" | "head" | "torso" | "legs" | "feet" | "off-hand";
 
 export interface TransferOptions {
   window: Window;


### PR DESCRIPTION
The off-hand option is supported, as seen [here.](https://github.com/PrismarineJS/mineflayer/blob/3e22c753f34706cec63f199ae62390b93c9f2e76/lib/plugins/simple_inventory.js#L22)

While off-handedness may be disabled in some situations, as shown in the code, having some IntelliSense opportunities is nice.