### PR TITLE
Remove double installation of require-self

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "mocha --reporter spec --exit",
-    "pretest": "require-self",
+    "pretest": "npm run lint && require-self",
     "lint": "standard",
     "fix": "standard --fix",
-    "prepare": "npm install require-self && require-self",
+    "prepare": "require-self",
     "prepublishOnly": "cp docs/README.md README.md"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "test": "mocha --reporter spec --exit",
-    "pretest": "npm run lint && require-self",
+    "pretest": "require-self",
     "lint": "standard",
     "fix": "standard --fix",
     "prepare": "npm install require-self && require-self",


### PR DESCRIPTION
As stated in [usage of require-self](https://www.npmjs.com/package/require-self#usage) it's not required to install it in `prepare` script anymore. Dev dependencies are enough.

Current approach breaks test env if modules are installed using yarn and generates both `package-lock.json` and `yarn.lock` which is highly not recommended.