### PR TITLE
Converted block finder to use square distance.

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -137,6 +137,7 @@ function inject (bot, { version }) {
     const matcher = getMatchingFunction(options.matching)
     const point = (options.point || bot.entity.position).floored()
     const maxDistance = options.maxDistance || 16
+    const maxDistanceSq = maxDistance * maxDistance
     const minCount = options.minCount || 1
     const useExtraInfo = options.useExtraInfo || false
     const blocks = []
@@ -157,7 +158,15 @@ function inject (bot, { version }) {
             for (cursor.y = next.y * 16; cursor.y < next.y * 16 + 16; cursor.y++) {
               for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
                 const found = bot.blockAt(cursor, useExtraInfo)
-                if (matcher(found) && cursor.distanceTo(point) <= maxDistance) blocks.push(cursor.clone())
+                if (matcher(found)) {
+                  // Calculate distance squared
+                  let dx = cursor.x - point.x
+                  let dy = cursor.y - point.y
+                  let dz = cursor.z - point.z
+                  let distSq = dx * dx + dy * dy + dz * dz
+                  if (distSq <= maxDistanceSq)
+                    blocks.push(cursor.clone())
+                }
               }
             }
           }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -145,9 +145,9 @@ function inject (bot, { version }) {
     const it = new OctahedronIterator(start, Math.ceil(maxDistance / 16))
 
     function distanceSquared(a, b) {
-      let dx = a.x - b.x
-      let dy = a.y - b.y
-      let dz = a.z - b.z
+      const dx = a.x - b.x
+      const dy = a.y - b.y
+      const dz = a.z - b.z
       return (dx ** 2) + (dy ** 2) + (dz ** 2)
     }
 
@@ -167,9 +167,9 @@ function inject (bot, { version }) {
               for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
                 const found = bot.blockAt(cursor, useExtraInfo)
                 if (matcher(found)) {
-                  let dist = distanceSquared(cursor, point)
+                  const dist = distanceSquared(cursor, point)
                   if (dist <= maxDistanceSq) {
-                    let c = cursor.clone()
+                    const c = cursor.clone()
                     c.distanceToPlayer = dist
                     blocks.push(c)
                   }
@@ -192,8 +192,9 @@ function inject (bot, { version }) {
     })
 
     // Clean cache
-    for (let block of blocks)
+    for (let block of blocks) {
       block.distanceToPlayer = undefined
+    }
 
     return blocks
   }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -144,7 +144,7 @@ function inject (bot, { version }) {
     const start = new Vec3(Math.floor(point.x / 16), Math.floor(point.y / 16), Math.floor(point.z / 16))
     const it = new OctahedronIterator(start, Math.ceil(maxDistance / 16))
 
-    function distanceSquared(a, b) {
+    function distanceSquared (a, b) {
       const dx = a.x - b.x
       const dy = a.y - b.y
       const dz = a.z - b.z
@@ -192,7 +192,7 @@ function inject (bot, { version }) {
     })
 
     // Clean cache
-    for (let block of blocks) {
+    for (const block of blocks) {
       block.distanceToPlayer = undefined
     }
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -137,7 +137,7 @@ function inject (bot, { version }) {
     const matcher = getMatchingFunction(options.matching)
     const point = (options.point || bot.entity.position).floored()
     const maxDistance = options.maxDistance || 16
-    const maxDistanceSq = maxDistance * maxDistance
+    const maxDistanceSq = maxDistance ** 2
     const minCount = options.minCount || 1
     const useExtraInfo = options.useExtraInfo || false
     const blocks = []

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -158,15 +158,7 @@ function inject (bot, { version }) {
             for (cursor.y = next.y * 16; cursor.y < next.y * 16 + 16; cursor.y++) {
               for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
                 const found = bot.blockAt(cursor, useExtraInfo)
-                if (matcher(found)) {
-                  // Calculate distance squared
-                  let dx = cursor.x - point.x
-                  let dy = cursor.y - point.y
-                  let dz = cursor.z - point.z
-                  let distSq = dx * dx + dy * dy + dz * dz
-                  if (distSq <= maxDistanceSq)
-                    blocks.push(cursor.clone())
-                }
+                if (matcher(found) && cursor.distanceSquared(point) <= maxDistanceSq) blocks.push(cursor.clone())
               }
             }
           }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -143,6 +143,14 @@ function inject (bot, { version }) {
     const blocks = []
     const start = new Vec3(Math.floor(point.x / 16), Math.floor(point.y / 16), Math.floor(point.z / 16))
     const it = new OctahedronIterator(start, Math.ceil(maxDistance / 16))
+
+    function distanceSquared(a, b) {
+      let dx = a.x - b.x
+      let dy = a.y - b.y
+      let dz = a.z - b.z
+      return (dx ** 2) + (dy ** 2) + (dz ** 2)
+    }
+
     // the octahedron iterator can sometime go through the same section again
     // we use a set to keep track of visited sections
     const visitedSections = new Set()
@@ -158,7 +166,14 @@ function inject (bot, { version }) {
             for (cursor.y = next.y * 16; cursor.y < next.y * 16 + 16; cursor.y++) {
               for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
                 const found = bot.blockAt(cursor, useExtraInfo)
-                if (matcher(found) && cursor.distanceSquared(point) <= maxDistanceSq) blocks.push(cursor.clone())
+                if (matcher(found)) {
+                  let dist = distanceSquared(cursor, point)
+                  if (dist <= maxDistanceSq) {
+                    let c = cursor.clone()
+                    c.distanceToPlayer = dist
+                    blocks.push(c)
+                  }
+                }
               }
             }
           }
@@ -173,8 +188,13 @@ function inject (bot, { version }) {
       next = it.next()
     }
     blocks.sort((a, b) => {
-      return a.distanceTo(point) - b.distanceTo(point)
+      return a.distanceToPlayer - b.distanceToPlayer
     })
+
+    // Clean cache
+    for (let block of blocks)
+      block.distanceToPlayer = undefined
+
     return blocks
   }
 


### PR DESCRIPTION
A standard distance function uses a square root operation which can be slow when called in extremely high quantities. By swapping this out by a distance squared comparison, several orders of performance can be gained. As there is no distance squared function within the vec3 library, (at the time of writing) I inlined this. The syntax can be cleaned up back to a single line if this function is added to the library.

This patch should yield the exact same behavior as the original implementation but without the need for a costly square root operation for each block.

This PR requires https://github.com/andrewrk/node-vec3/pull/7 to work and should be merged after vec3 is updated to the newest version.