### PR TITLE
Fixed broken documentation link.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ The most updated and useful are :
  * See [docs/history.md](history.md).
  * See [examples/](https://github.com/PrismarineJS/mineflayer/tree/master/examples).
  * See [docs/unstable_api.md](unstable_api.md).
- * See [docs/contribute.md](CONTRIBUTING.md).
+ * See [docs/CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Contribute
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -126,7 +126,7 @@ The most updated and useful are :
  * See [docs/history.md](history.md).
  * See [examples/](https://github.com/PrismarineJS/mineflayer/tree/master/examples).
  * See [docs/unstable_api.md](unstable_api.md).
- * See [docs/contribute.md](contribute.md).
+ * See [docs/contribute.md](CONTRIBUTING.md).
 
 ## Contribute
 


### PR DESCRIPTION
The contributing link on the readme pointed to a file that didn't exist. Updated link to correctly point to the contributing page.