### PR TITLE
Made point field optional in FindBlockOptions in header file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -626,7 +626,7 @@ export interface Instrument {
 }
 
 export interface FindBlockOptions {
-  point: Vec3;
+  point?: Vec3;
   matching: (block: Block) => boolean | number | Array<number>;
   maxDistance?: number;
 }


### PR DESCRIPTION
The `point` field is optional in the FindBlockOptions, defaulting to the bot position if not specified, as defined [here](https://github.com/PrismarineJS/mineflayer/blob/625beed9bd6cb66850c4ae87f59b07e894af5279/lib/plugins/blocks.js#L139).