### PR TITLE
Update physics.js

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -104,8 +104,8 @@ function inject (bot) {
     bot._client.write('position_look', lastSent)
     bot.emit('move', oldPos)
   }
-  
-  let deltaYaw;
+
+  let deltaYaw
   function updatePosition (dt) {
     // If you're dead, you're probably on the ground though ...
     if (!bot.isAlive) bot.entity.onGround = true
@@ -195,8 +195,7 @@ function inject (bot) {
 
   let lookAtCb = noop
   function checkYaw () {
-        
-    if (Math.abs(deltaYaw)<0.001) {
+    if (Math.abs(deltaYaw) < 0.001) {
       lookAtCb()
       lookAtCb = noop
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -194,7 +194,10 @@ function inject (bot) {
 
   let lookAtCb = noop
   function checkYaw () {
-    if (Math.abs(((lastSentYaw % PI_2) - bot.entity.yaw) % PI_2) < 0.001) {
+    
+    const delta = Math.abs(((lastSentYaw % PI_2) - bot.entity.yaw) % PI_2);
+    
+    if (delta < 0.001 || PI_2 - delta < 0.001) {
       lookAtCb()
       lookAtCb = noop
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -105,19 +105,24 @@ function inject (bot) {
     bot.emit('move', oldPos)
   }
 
-  let deltaYaw
+  function deltaYaw (yaw1, yaw2) {
+    let dYaw = (yaw1 - yaw2) % PI_2
+    if (dYaw < -PI) dYaw += PI_2
+    else if (dYaw > PI) dYaw -= PI_2
+
+    return dYaw
+  }
+
   function updatePosition (dt) {
     // If you're dead, you're probably on the ground though ...
     if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
-    deltaYaw = (bot.entity.yaw - lastSentYaw) % PI_2
-    if (deltaYaw < -PI) deltaYaw += PI_2
-    else if (deltaYaw > PI) deltaYaw -= PI_2
+    const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
     const maxDeltaYaw = dt * physics.yawSpeed
-    lastSentYaw += math.clamp(-maxDeltaYaw, deltaYaw, maxDeltaYaw)
+    lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
 
     const yaw = conv.toNotchianYaw(lastSentYaw)
     const pitch = conv.toNotchianPitch(bot.entity.pitch)
@@ -195,7 +200,7 @@ function inject (bot) {
 
   let lookAtCb = noop
   function checkYaw () {
-    if (Math.abs(deltaYaw) < 0.001) {
+    if (Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001) {
       lookAtCb()
       lookAtCb = noop
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -104,13 +104,14 @@ function inject (bot) {
     bot._client.write('position_look', lastSent)
     bot.emit('move', oldPos)
   }
-
+  
+  let deltaYaw;
   function updatePosition (dt) {
     // If you're dead, you're probably on the ground though ...
     if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
-    let deltaYaw = (bot.entity.yaw - lastSentYaw) % PI_2
+    deltaYaw = (bot.entity.yaw - lastSentYaw) % PI_2
     if (deltaYaw < -PI) deltaYaw += PI_2
     else if (deltaYaw > PI) deltaYaw -= PI_2
 
@@ -194,10 +195,8 @@ function inject (bot) {
 
   let lookAtCb = noop
   function checkYaw () {
-    
-    const delta = Math.abs(((lastSentYaw % PI_2) - bot.entity.yaw) % PI_2);
-    
-    if (delta < 0.001 || PI_2 - delta < 0.001) {
+        
+    if (Math.abs(deltaYaw)<0.001) {
       lookAtCb()
       lookAtCb = noop
     }


### PR DESCRIPTION
Fix to issue #1096: The statement
`((lastSentYaw % PI_2) - bot.entity.yaw)`
can yield a result which approaches PI_2, which messes with the second modulo operation. Thus, the statement will not be less than 0.001, even though it should be.