### PR TITLE
delColumn returning NaN (chunk memory leak) fix

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -74,14 +74,14 @@ function inject (bot, { version }) {
 
   function delColumn (chunkX, chunkY) {
     const columnCorner = new Vec3(chunkX * 16, 0, chunkY * 16)
-    const key = columnKeyXZ(columnCorner.x, columnCorner.z)
+    const key = columnKeyXZ(columnCorner.chunkX || columnCorner.x, columnCorner.chunkZ || columnCorner.z)
     delete columns[key]
     bot.emit('chunkColumnUnload', columnCorner)
   }
 
   function addColumn (args) {
     const columnCorner = new Vec3(args.x * 16, 0, args.z * 16)
-    const key = columnKeyXZ(columnCorner.x, columnCorner.z)
+    const key = columnKeyXZ(columnCorner.chunkX || columnCorner.x, columnCorner.chunkZ || columnCorner.z)
     if (!args.bitMap) {
       // stop storing the chunk column
       delColumn(args.x, args.z)


### PR DESCRIPTION
columnCorner in delColumn fix.
Expected: { x: Number, x: Number }
Got: { chunkX: Number, chunkZ: Number }
Weird bug, but fixed.
Added the same fix to addColumn just in case.
Issue #1123 