### PR TITLE
Emit chestLidMove only once

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,18 +59,21 @@ For example `version:"1.8"`.
 
 ### Echo Example
 ```js
-var mineflayer = require('mineflayer');
+var mineflayer = require('mineflayer')
+
 var bot = mineflayer.createBot({
-  host: "localhost", // optional
+  host: 'localhost', // optional
   port: 25565,       // optional
-  username: "email@example.com", // email and password are required only for
-  password: "12345678",          // online-mode=true servers
+  username: 'email@example.com', // email and password are required only for
+  password: '12345678',          // online-mode=true servers
   version: false                 // false corresponds to auto version detection (that's the default), put for example "1.8.8" if you need a specific version
-});
-bot.on('chat', function(username, message) {
-  if (username === bot.username) return;
-  bot.chat(message);
-});
+})
+
+bot.on('chat', function (username, message) {
+  if (username === bot.username) return
+  bot.chat(message)
+})
+
 bot.on('error', err => console.log(err))
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1113,9 +1113,10 @@ Fires when a note block goes off somewhere.
 
 #### "pistonMove" (block, isPulling, direction)
 
-#### "chestLidMove" (block, isOpen)
-* `block`: a Block instance, the block whose lid opened
+#### "chestLidMove" (block, isOpen, block2)
+* `block`: a Block instance, the block whose lid opened. The right block if it's a double chest
 * `isOpen`: number of players that have the chest open. 0 if it's closed
+* `block2`: a Block instance, the other half of the block whose lid opened. null if it's not a double chest
 
 #### "blockBreakProgressObserved" (block, destroyStage)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1114,6 +1114,8 @@ Fires when a note block goes off somewhere.
 #### "pistonMove" (block, isPulling, direction)
 
 #### "chestLidMove" (block, isOpen)
+* `block`: a Block instance, the block whose lid opened
+* `isOpen`: number of players that have the chest open. 0 if it's closed
 
 #### "blockBreakProgressObserved" (block, destroyStage)
 

--- a/lib/features.json
+++ b/lib/features.json
@@ -188,5 +188,10 @@
       "name": "dimensionIsAString",
       "description": "description is a string",
       "versions": ["1.16"]
+    },
+    {
+      "name": "doesntHaveChestType",
+      "description": "chests don't have a type property",
+      "versions": ["1.8", "1.9", "1.10", "1.11", "1.12"]
     }
   ]

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -2,13 +2,59 @@ const Vec3 = require('vec3').Vec3
 
 module.exports = inject
 
+const CARDINALS = {
+  north: new Vec3(0, 0, -1),
+  south: new Vec3(0, 0, 1),
+  west: new Vec3(-1, 0, 0),
+  east: new Vec3(1, 0, 0)
+}
+
 function inject (bot, { version }) {
   const { instruments, blocks } = require('minecraft-data')(version)
+
+  function parseChestMetadata (chestBlock) {
+    const chestTypes = ['single', 'right', 'left']
+
+    return bot.supportFeature('doesntHaveChestType')
+      ? { facing: Object.keys(CARDINALS)[chestBlock.metadata - 2] }
+      : {
+        waterlogged: !(chestBlock.metadata & 1),
+        type: chestTypes[(chestBlock.metadata >> 1) % 3],
+        facing: Object.keys(CARDINALS)[Math.floor(chestBlock.metadata / 6)]
+      }
+  }
+
+  function getChestType (chestBlock) { // Returns 'single', 'right' or 'left'
+    if (bot.supportFeature('doesntHaveChestType')) {
+      const facingMap = {
+        north: { west: 'right', east: 'left' },
+        south: { west: 'left', east: 'right' },
+        west: { north: 'left', south: 'right' },
+        east: { north: 'right', south: 'left' }
+      }
+
+      const facing = parseChestMetadata(chestBlock).facing
+
+      // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
+      const perpendicularCardinals = Object.keys(facingMap[facing])
+      for (const cardinal of perpendicularCardinals) {
+        const cardinalOffset = CARDINALS[cardinal]
+        if (bot.blockAt(chestBlock.position.plus(cardinalOffset)).type === chestBlock.type) {
+          return facingMap[cardinal][facing]
+        }
+      }
+
+      return 'single'
+    } else {
+      return parseChestMetadata(chestBlock).type
+    }
+  }
+
   bot._client.on('block_action', (packet) => {
-    // block action
     const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
     const block = bot.blockAt(pt)
     const blockName = blocks[packet.blockId].name
+
     if (blockName === 'noteblock') { // Pre 1.13
       bot.emit('noteHeard', block, instruments[packet.byte1], packet.byte2)
     } else if (blockName === 'note_block') { // 1.13 onward
@@ -16,7 +62,14 @@ function inject (bot, { version }) {
     } else if (blockName === 'sticky_piston' || blockName === 'piston') {
       bot.emit('pistonMove', block, packet.byte1, packet.byte2)
     } else {
-      bot.emit('chestLidMove', block, packet.byte2)
+      if (blockName === 'chest' || blockName === 'trapped_chest') {
+        const chestType = getChestType(block)
+        if (chestType === 'single' || chestType === 'right') { // Omit left so 'chestLidMove' doesn't emit twice when it's a double chest
+          bot.emit('chestLidMove', block, packet.byte2)
+        }
+      } else {
+        bot.emit('chestLidMove', block, packet.byte2)
+      }
     }
   })
 

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -9,6 +9,13 @@ const CARDINALS = {
   east: new Vec3(1, 0, 0)
 }
 
+const FACING_MAP = {
+  north: { west: 'right', east: 'left' },
+  south: { west: 'left', east: 'right' },
+  west: { north: 'left', south: 'right' },
+  east: { north: 'right', south: 'left' }
+}
+
 function inject (bot, { version }) {
   const { instruments, blocks } = require('minecraft-data')(version)
 
@@ -26,21 +33,14 @@ function inject (bot, { version }) {
 
   function getChestType (chestBlock) { // Returns 'single', 'right' or 'left'
     if (bot.supportFeature('doesntHaveChestType')) {
-      const facingMap = {
-        north: { west: 'right', east: 'left' },
-        south: { west: 'left', east: 'right' },
-        west: { north: 'left', south: 'right' },
-        east: { north: 'right', south: 'left' }
-      }
-
       const facing = parseChestMetadata(chestBlock).facing
 
       // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
-      const perpendicularCardinals = Object.keys(facingMap[facing])
+      const perpendicularCardinals = Object.keys(FACING_MAP[facing])
       for (const cardinal of perpendicularCardinals) {
         const cardinalOffset = CARDINALS[cardinal]
         if (bot.blockAt(chestBlock.position.plus(cardinalOffset)).type === chestBlock.type) {
-          return facingMap[cardinal][facing]
+          return FACING_MAP[cardinal][facing]
         }
       }
 
@@ -64,11 +64,16 @@ function inject (bot, { version }) {
     } else {
       if (blockName === 'chest' || blockName === 'trapped_chest') {
         const chestType = getChestType(block)
-        if (chestType === 'single' || chestType === 'right') { // Omit left so 'chestLidMove' doesn't emit twice when it's a double chest
-          bot.emit('chestLidMove', block, packet.byte2)
+        if (chestType === 'single') { // Omit left so 'chestLidMove' doesn't emit twice when it's a double chest
+          bot.emit('chestLidMove', block, packet.byte2, null)
+        } else if (chestType === 'right') {
+          const index = Object.values(FACING_MAP[parseChestMetadata(block).facing]).indexOf('left')
+          const cardinalBlock2 = Object.keys(FACING_MAP[parseChestMetadata(block).facing])[index]
+          const block2Position = block.position.plus(CARDINALS[cardinalBlock2])
+          bot.emit('chestLidMove', block, packet.byte2, bot.blockAt(block2Position))
         }
       } else {
-        bot.emit('chestLidMove', block, packet.byte2)
+        bot.emit('chestLidMove', block, packet.byte2, null)
       }
     }
   })

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -61,11 +61,20 @@ module.exports = () => (bot, done) => {
         let emitted = false
         const chest = bot.openChest(bot.blockAt(largeChestLocations[0]))
 
-        function handler (block, isOpen) {
+        function handler (block, isOpen, block2) {
           if (emitted) {
             assert.fail(new Error('chestLidMove emitted twice'))
           } else {
             emitted = true
+
+            let blockAssert = false; let block2Assert = false
+            for (const location of largeChestLocations) {
+              if (location.equals(block.position)) blockAssert = true
+              if (location.equals(block2.position)) block2Assert = true
+            }
+            assert(blockAssert && block2Assert, new Error('The block instance emitted by chestLidMove is not part of the chest oppened'))
+            assert.strictEqual(isOpen, 1, new Error('isOpen should be 1 when opened by one only player'))
+
             setTimeout(() => {
               bot.removeListener('chestLidMove', handler)
               chest.close()

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -57,6 +57,25 @@ module.exports = () => (bot, done) => {
         })
       },
       (cb) => {
+        // Test that "chestLidMove" is emitted only once when opening a double chest
+        let emitted = false
+        const chest = bot.openChest(bot.blockAt(largeChestLocations[0]))
+        
+        function handler (block, isOpen) {
+          if (emitted) {
+            assert.fail(new Error('chestLidMove emitted twice'))
+          } else {
+            emitted = true
+            setTimeout(() => {
+              bot.removeListener('chestLidMove', handler)
+              chest.close()
+              cb()
+            }, 500)
+          }
+        }
+        bot.on('chestLidMove', handler)
+      },
+      (cb) => {
         depositBones(smallChestLocation, 1, cb)
       },
       (cb) => {

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -60,7 +60,7 @@ module.exports = () => (bot, done) => {
         // Test that "chestLidMove" is emitted only once when opening a double chest
         let emitted = false
         const chest = bot.openChest(bot.blockAt(largeChestLocations[0]))
-        
+
         function handler (block, isOpen) {
           if (emitted) {
             assert.fail(new Error('chestLidMove emitted twice'))


### PR DESCRIPTION
I'm back!
This is a duplicate of #1068, unfortunately I deleted the other fork

> Even thought the vanilla server emits the event twice when it's a double chest, I think it's kind of confusing for a mineflayer user, so I think this change makes sense
> Not sure if this is the best approach, but it does the job!

I also ran `standard --fix` on the example of the README.md. Those semicolon have been bothering me for pretty long.

Closes #1064