### PR TITLE
Adding options for main hand selection.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,12 +28,14 @@ export interface BotOptions extends ClientOptions {
   chat?: ChatLevel;
   colorsEnabled?: boolean;
   viewDistance?: ViewDistance;
+  mainHand?: MainHands;
   difficulty?: number;
   chatLengthLimit?: number;
 }
 
 export type ChatLevel = "enabled" | "commandsOnly" | "disabled";
 export type ViewDistance = "far" | "normal" | "short" | "tiny";
+export type MainHands = "left" | "right";
 
 export interface PluginOptions {
   [plugin: string]: boolean | Plugin;
@@ -449,6 +451,7 @@ export interface GameSettings {
   viewDistance: ViewDistance;
   difficulty: number;
   skinParts: SkinParts;
+  mainHand: MainHands;
 }
 
 export interface Experience {

--- a/lib/plugins/settings.js
+++ b/lib/plugins/settings.js
@@ -8,6 +8,11 @@ const chatToBits = {
   disabled: 2
 }
 
+const handToBits = {
+  left: 0,
+  right: 1
+}
+
 const viewDistanceToBits = {
   far: 12,
   normal: 10,
@@ -22,6 +27,8 @@ function inject (bot, options) {
     assert.ok(chatBits != null, `invalid chat setting: ${bot.settings.chat}`)
     const viewDistanceBits = viewDistanceToBits[bot.settings.viewDistance]
     assert.ok(viewDistanceBits != null, `invalid view distance setting: ${bot.settings.viewDistance}`)
+    const handBits = handToBits[bot.settings.mainHand]
+    assert.ok(handBits != null, `invalid main hand: ${bot.settings.mainHand}`)
     bot.settings.showCape = !!bot.settings.showCape
     const skinParts = bot.settings.skinParts.showCape << 0 |
           bot.settings.skinParts.showJacket << 1 |
@@ -35,7 +42,8 @@ function inject (bot, options) {
       viewDistance: viewDistanceBits,
       chatFlags: chatBits,
       chatColors: bot.settings.colorsEnabled,
-      skinParts: skinParts
+      skinParts: skinParts,
+      mainHand: handBits
     })
   }
 
@@ -52,7 +60,8 @@ function inject (bot, options) {
       showLeftPants: true,
       showRightPants: true,
       showHat: true
-    } : options.skinParts
+    } : options.skinParts,
+    mainHand: options.mainHand || 'right'
   }
 
   bot._client.once('login', () => {


### PR DESCRIPTION
Was wondering why my bots always held items in the "wrong" hand. Wasn't wrong hand. Was just left hand main is default.