### PR TITLE
Add 'itemDrop' event

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -159,6 +159,7 @@
       - ["entityEquipmentChange" (entity)](#entityequipmentchange-entity)
       - ["entitySleep" (entity)](#entitysleep-entity)
       - ["entitySpawn" (entity)](#entityspawn-entity)
+      - ["itemDrop" (entity)](#itemDrop-entity)
       - ["playerCollect" (collector, collected)](#playercollect-collector-collected)
       - ["entityGone" (entity)](#entitygone-entity)
       - ["entityMoved" (entity)](#entitymoved-entity)
@@ -1035,6 +1036,7 @@ Fires when your hp or food change.
 #### "entityEquipmentChange" (entity)
 #### "entitySleep" (entity)
 #### "entitySpawn" (entity)
+#### "itemDrop" (entity)
 #### "playerCollect" (collector, collected)
 
 An entity picked up an item.

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,7 @@ interface BotEvents {
   entityEquip: (entity: Entity) => void;
   entitySleep: (entity: Entity) => void;
   entitySpawn: (entity: Entity) => void;
+  itemDrop: (entity: Entity) => void;
   playerCollect: (collector: Entity, collected: Entity) => void;
   entityGone: (entity: Entity) => void;
   entityMoved: (entity: Entity) => void;

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -324,8 +324,10 @@ function inject (bot, { version }) {
   bot._client.on('entity_metadata', (packet) => {
     // entity metadata
     const entity = fetchEntity(packet.entityId)
-    entity.metadata = parseMetadata(packet.metadata, entity.metadata)
+    const metadata = parseMetadata(packet.metadata, entity.metadata)
+    entity.metadata = metadata
     bot.emit('entityUpdate', entity)
+    if (entity.type === 'object' && metadata[6]) bot.emit('itemDrop', entity)
   })
 
   bot._client.on('entity_effect', (packet) => {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -327,7 +327,7 @@ function inject (bot, { version }) {
     const metadata = parseMetadata(packet.metadata, entity.metadata)
     entity.metadata = metadata
     bot.emit('entityUpdate', entity)
-    if (entity.type === 'object' && metadata[6]) bot.emit('itemDrop', entity)
+    if (entity.name === 'item' && metadata[6]) bot.emit('itemDrop', entity)
   })
 
   bot._client.on('entity_effect', (packet) => {


### PR DESCRIPTION
Instead of the user listening to 'entitySpawn' and then waiting an arbitrary amount of time for the item's metadata to be set, it would be good to have an 'itemDrop' event. Related to #1171 