### PR TITLE
Fix 'Fishing cancelled due to calling bot.fish() again' when calling bot.fish() inside the callback

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -53,20 +53,18 @@ function inject (bot, { version }) {
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
-      let cb = lastFishing
-      lastFishing = undefined
-      cb()
       lastFloat = undefined
+      setImmediate(lastFishing)
+      lastFishing = undefined
     }
   })
 
   bot._client.on('entity_destroy', (packet) => {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
-      let cb = lastFishing
-      lastFishing = undefined
-      cb(new Error('Fishing cancelled'))
       lastFloat = undefined
+      setImmediate(lastFishing, new Error('Fishing cancelled'))
+      lastFishing = undefined
     }
   })
 
@@ -86,9 +84,8 @@ function inject (bot, { version }) {
 
   function fish (cb) {
     if (lastFishing) {
-      let fishingEndCb = lastFishing
+      setImmediate(lastFishing, new Error('Fishing cancelled due to calling bot.fish() again'))
       lastFishing = undefined
-      fishingEndCb(new Error('Fishing cancelled due to calling bot.fish() again'))
       return
     }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -53,8 +53,9 @@ function inject (bot, { version }) {
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
-      lastFishing()
+      let cb = lastFishing
       lastFishing = undefined
+      cb()
       lastFloat = undefined
     }
   })
@@ -62,8 +63,9 @@ function inject (bot, { version }) {
   bot._client.on('entity_destroy', (packet) => {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
-      lastFishing(new Error('Fishing cancelled'))
+      let cb = lastFishing
       lastFishing = undefined
+      cb(new Error('Fishing cancelled'))
       lastFloat = undefined
     }
   })
@@ -84,8 +86,9 @@ function inject (bot, { version }) {
 
   function fish (cb) {
     if (lastFishing) {
-      lastFishing(new Error('Fishing cancelled due to calling bot.fish() again'))
+      let fishingEndCb = lastFishing
       lastFishing = undefined
+      fishingEndCb(new Error('Fishing cancelled due to calling bot.fish() again'))
       return
     }
 


### PR DESCRIPTION
I've tested, there's no such problem for bot.consume()