### PR TITLE
Added boolean type to TypeScript header, for finding recipes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,13 +194,13 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     itemType: number,
     metadata: number | null,
     minResultCount: number | null,
-    craftingTable: Block | null
+    craftingTable: Block | boolean | null
   ): Array<Recipe>;
 
   recipesAll(
     itemType: number,
     metadata: number | null,
-    craftingTable: Block | null
+    craftingTable: Block | boolean | null
   ): Array<Recipe>;
 
   quit(reason?: string): void;


### PR DESCRIPTION
In the `recipeFor` and `recipeAll` functions, there is an optional parameter, taking in the crafting table block, which can be used to determine what recipes are available depending on whether or not a crafting table is present. In the TypeScript header, this only takes in a block variable, (The crafting table itself) while in the JS version, you can also supply a boolean which would work the same way.

This should make it a bit easier to look for recipes for an item without an actual crafting table needing to be present. It also matches the JS version a lot smoother.