### PR TITLE
Update saver.js

### DIFF
--- a/examples/anvil_saver/saver.js
+++ b/examples/anvil_saver/saver.js
@@ -18,6 +18,7 @@ const bot = mineflayer.createBot({
   password: process.argv[5],
   storageBuilder: ({ version, worldName }) => {
     const Anvil = require('prismarine-provider-anvil').Anvil(version)
+    worldName = worldName.replace(/:/g,'_')
     fs.mkdirSync(worldName)
     return new Anvil(worldName)
   }

--- a/examples/anvil_saver/saver.js
+++ b/examples/anvil_saver/saver.js
@@ -18,7 +18,7 @@ const bot = mineflayer.createBot({
   password: process.argv[5],
   storageBuilder: ({ version, worldName }) => {
     const Anvil = require('prismarine-provider-anvil').Anvil(version)
-    worldName = worldName.replace(/:/g,'_')
+    worldName = worldName.replace(/:/g, '_')
     fs.mkdirSync(worldName)
     return new Anvil(worldName)
   }


### PR DESCRIPTION
Changing of the semicolon to underscore in worldName to avoid forbidden directory name in Windows.

Avoids the following error:
`Error: ENOENT: no such file or directory, mkdir 'minecraft:overworld'`