### PR TITLE
Fixed typo for findBlock/findBlocks in Typescript file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -518,7 +518,7 @@ export interface Instrument {
 
 export interface FindBlockOptions {
   point?: Vec3;
-  matching: (block: Block) => boolean | number | Array<number>;
+  matching: number | Array<number> | (block: Block) => boolean;
   maxDistance?: number;
 }
 


### PR DESCRIPTION
The line `(block: Block) => boolean | number | Array<number>` was being parsed as "always a function which could return one of these three things" instead of "a number, a number array, or a function that returns a boolean."

I switched the union order which should fix this.