### PR TITLE
More accurate blockInSight

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,7 @@
     - [Functions](#functions)
       - [bot.blockAt(point, extraInfos=true)](#botblockatpoint-extrainfostrue)
       - [bot.waitForChunksToLoad(cb)](#botwaitforchunkstoloadcb)
-      - [bot.blockInSight(maxSteps, vectorLength)](#botblockinsightmaxsteps-vectorlength)
+      - [bot.blockInSight(maxDistance=256)](#botblockinsightmaxdistance256)
       - [bot.canSeeBlock(block)](#botcanseeblockblock)
       - [bot.findBlocks(options)](#botfindblocksoptions)
       - [bot.findBlock(options)](#botfindblockoptions)
@@ -1268,11 +1268,10 @@ See `Block`.
 
 The cb gets called when many chunks have loaded.
 
-#### bot.blockInSight(maxSteps, vectorLength)
+#### bot.blockInSight(maxDistance=256)
 
 Returns the block at which bot is looking at or `null`
- * `maxSteps` - Number of steps to raytrace, defaults to 256.
- * `vectorLength` - Length of raytracing vector, defaults to `5/16`.
+ * `maxDistance` - The maximum distance the block can be from the eye, defaults to 256.
 
 #### bot.canSeeBlock(block)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,8 @@
     - [Functions](#functions)
       - [bot.blockAt(point, extraInfos=true)](#botblockatpoint-extrainfostrue)
       - [bot.waitForChunksToLoad(cb)](#botwaitforchunkstoloadcb)
-      - [bot.blockInSight(maxDistance=256)](#botblockinsightmaxdistance256)
+      - [bot.blockInSight(maxSteps, vectorLength)](#botblockinsightmaxsteps-vectorlength)
+      - [bot.blockAtCursor(maxDistance=256)](#botblockatcursormaxdistance256)
       - [bot.canSeeBlock(block)](#botcanseeblockblock)
       - [bot.findBlocks(options)](#botfindblocksoptions)
       - [bot.findBlock(options)](#botfindblockoptions)
@@ -1268,7 +1269,15 @@ See `Block`.
 
 The cb gets called when many chunks have loaded.
 
-#### bot.blockInSight(maxDistance=256)
+#### bot.blockInSight(maxSteps, vectorLength)
+
+Deprecated, use `blockAtCursor` instead.
+
+Returns the block at which bot is looking at or `null`
+ * `maxSteps` - Number of steps to raytrace, defaults to 256.
+ * `vectorLength` - Length of raytracing vector, defaults to `5/16`.
+
+#### bot.blockAtCursor(maxDistance=256)
 
 Returns the block at which bot is looking at or `null`
  * `maxDistance` - The maximum distance the block can be from the eye, defaults to 256.

--- a/lib/iterators.js
+++ b/lib/iterators.js
@@ -1,4 +1,4 @@
-const Vec3 = require('vec3').Vec3
+const { Vec3 } = require('vec3')
 
 // 2D spiral iterator, useful to iterate on
 // columns that are centered on bot position
@@ -99,29 +99,29 @@ const BlockFace = {
   EAST: 5
 }
 
-// This iterate along a ray starting at (x,y,z) in (dx,dy,dz) direction
+// This iterate along a ray starting at `pos` in `dir` direction
 // It steps exactly 1 block at a time, returning the block coordinates
 // and the face by which the ray entered the block.
 class RaycastIterator {
-  constructor (x, y, z, dx, dy, dz, maxDistance) {
+  constructor (pos, dir, maxDistance) {
     this.block = {
-      x: Math.floor(x),
-      y: Math.floor(y),
-      z: Math.floor(z),
+      x: Math.floor(pos.x),
+      y: Math.floor(pos.y),
+      z: Math.floor(pos.z),
       face: BlockFace.UNKNOWN
     }
 
-    this.stepX = Math.sign(dx)
-    this.stepY = Math.sign(dy)
-    this.stepZ = Math.sign(dz)
+    this.stepX = Math.sign(dir.x)
+    this.stepY = Math.sign(dir.y)
+    this.stepZ = Math.sign(dir.z)
 
-    this.tDeltaX = (dx === 0) ? Number.MAX_VALUE : Math.abs(1 / dx)
-    this.tDeltaY = (dy === 0) ? Number.MAX_VALUE : Math.abs(1 / dy)
-    this.tDeltaZ = (dz === 0) ? Number.MAX_VALUE : Math.abs(1 / dz)
+    this.tDeltaX = (dir.x === 0) ? Number.MAX_VALUE : Math.abs(1 / dir.x)
+    this.tDeltaY = (dir.y === 0) ? Number.MAX_VALUE : Math.abs(1 / dir.y)
+    this.tDeltaZ = (dir.z === 0) ? Number.MAX_VALUE : Math.abs(1 / dir.z)
 
-    this.tMaxX = (dx === 0) ? Number.MAX_VALUE : Math.abs((this.block.x + (dx > 0 ? 1 : 0) - x) / dx)
-    this.tMaxY = (dy === 0) ? Number.MAX_VALUE : Math.abs((this.block.y + (dy > 0 ? 1 : 0) - y) / dy)
-    this.tMaxZ = (dz === 0) ? Number.MAX_VALUE : Math.abs((this.block.z + (dz > 0 ? 1 : 0) - z) / dz)
+    this.tMaxX = (dir.x === 0) ? Number.MAX_VALUE : Math.abs((this.block.x + (dir.x > 0 ? 1 : 0) - pos.x) / dir.x)
+    this.tMaxY = (dir.y === 0) ? Number.MAX_VALUE : Math.abs((this.block.y + (dir.y > 0 ? 1 : 0) - pos.y) / dir.y)
+    this.tMaxZ = (dir.z === 0) ? Number.MAX_VALUE : Math.abs((this.block.z + (dir.z > 0 ? 1 : 0) - pos.z) / dir.z)
 
     this.maxDistance = maxDistance
   }
@@ -158,5 +158,6 @@ class RaycastIterator {
 module.exports = {
   ManathanIterator,
   OctahedronIterator,
-  RaycastIterator
+  RaycastIterator,
+  BlockFace
 }

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -10,7 +10,12 @@ module.exports = (bot) => {
     return new Vec3(-snYaw * csPitch, snPitch, -csYaw * csPitch)
   }
 
-  bot.blockInSight = (maxDistance = 256) => {
+  bot.blockInSight = (maxSteps = 256, vectorLength = 5 / 16) => {
+    console.warn('[deprecated] use bot.blockAtCursor instead')
+    bot.blockAtCursor(maxSteps * vectorLength)
+  }
+
+  bot.blockAtCursor = (maxDistance = 256) => {
     const { position, height, pitch, yaw } = bot.entity
 
     const eyePosition = position.offset(0, height, 0)

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -1,28 +1,30 @@
-const Vec3 = require('vec3')
+const { Vec3 } = require('vec3')
+const { RaycastIterator } = require('../iterators')
 
-module.exports = inject
+module.exports = (bot) => {
+  function getViewDirection (pitch, yaw) {
+    const csPitch = Math.cos(pitch)
+    const snPitch = Math.sin(pitch)
+    const csYaw = Math.cos(yaw)
+    const snYaw = Math.sin(yaw)
+    return new Vec3(-snYaw * csPitch, snPitch, -csYaw * csPitch)
+  }
 
-function inject (bot) {
-  const rayTraceBlock = (maxSteps = 256, vectorLength = 5 / 16) => {
-    const { height, position, yaw, pitch } = bot.entity
-    const cursor = position.offset(0, height, 0)
+  bot.blockInSight = (maxDistance = 256) => {
+    const { position, height, pitch, yaw } = bot.entity
 
-    const x = -Math.sin(yaw) * Math.cos(pitch)
-    const y = Math.sin(pitch)
-    const z = -Math.cos(yaw) * Math.cos(pitch)
+    const eyePosition = position.offset(0, height, 0)
+    const viewDirection = getViewDirection(pitch, yaw)
 
-    const step = new Vec3(x, y, z).scaled(vectorLength)
-
-    for (let i = 0; i < maxSteps; ++i) {
-      cursor.add(step)
-
-      // TODO: Check boundingBox of block
-      const block = bot.blockAt(cursor)
+    const iter = new RaycastIterator(eyePosition, viewDirection, maxDistance)
+    let pos = iter.next()
+    while (pos) {
+      const block = bot.blockAt(new Vec3(pos.x, pos.y, pos.z))
       if (block && block.type !== 0) {
         return block
       }
+      pos = iter.next()
     }
+    return null
   }
-
-  bot.blockInSight = rayTraceBlock
 }

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -12,7 +12,8 @@ module.exports = (bot) => {
 
   bot.blockInSight = (maxSteps = 256, vectorLength = 5 / 16) => {
     console.warn('[deprecated] use bot.blockAtCursor instead')
-    bot.blockAtCursor(maxSteps * vectorLength)
+    const block = bot.blockAtCursor(maxSteps * vectorLength)
+    if (block) return block
   }
 
   bot.blockAtCursor = (maxDistance = 256) => {
@@ -25,6 +26,7 @@ module.exports = (bot) => {
     let pos = iter.next()
     while (pos) {
       const block = bot.blockAt(new Vec3(pos.x, pos.y, pos.z))
+      // TODO: Check boundingBox of block
       if (block && block.type !== 0) {
         return block
       }

--- a/test/externalTests/rayTrace.js
+++ b/test/externalTests/rayTrace.js
@@ -4,7 +4,7 @@ module.exports = () => (bot, done) => {
   const { position } = bot.entity
   bot.lookAt(position.offset(0, 3, 0), true, () => {
     const block = bot.blockInSight()
-    assert.strictEqual(block, undefined)
+    assert.strictEqual(block, null)
 
     bot.lookAt(position.offset(0, -3, 0), true, () => {
       const block = bot.blockInSight()

--- a/test/externalTests/rayTrace.js
+++ b/test/externalTests/rayTrace.js
@@ -3,14 +3,21 @@ const assert = require('assert')
 module.exports = () => (bot, done) => {
   const { position } = bot.entity
   bot.lookAt(position.offset(0, 3, 0), true, () => {
-    const block = bot.blockAtCursor()
+    let block = bot.blockAtCursor()
     assert.strictEqual(block, null)
 
+    block = bot.blockInSight()
+    assert.strictEqual(block, undefined)
+
     bot.lookAt(position.offset(0, -3, 0), true, () => {
-      const block = bot.blockAtCursor()
+      let block = bot.blockAtCursor()
       const relBlock = bot.blockAt(position.offset(0, -1, 0))
 
       assert.deepStrictEqual(block, relBlock)
+
+      block = bot.blockInSight()
+      assert.deepStrictEqual(block, relBlock)
+
       done()
     })
   })

--- a/test/externalTests/rayTrace.js
+++ b/test/externalTests/rayTrace.js
@@ -3,11 +3,11 @@ const assert = require('assert')
 module.exports = () => (bot, done) => {
   const { position } = bot.entity
   bot.lookAt(position.offset(0, 3, 0), true, () => {
-    const block = bot.blockInSight()
+    const block = bot.blockAtCursor()
     assert.strictEqual(block, null)
 
     bot.lookAt(position.offset(0, -3, 0), true, () => {
-      const block = bot.blockInSight()
+      const block = bot.blockAtCursor()
       const relBlock = bot.blockAt(position.offset(0, -1, 0))
 
       assert.deepStrictEqual(block, relBlock)


### PR DESCRIPTION
Use RayTracingIterator to find the block in sight. It checks all blocks on the ray exactly once. 

Replaced maxStep and vectorLength by maxDistance that is easier to reason about.