### PR TITLE
Optimize bot.trade()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,7 @@
       - [villager "ready"](#villager-ready)
       - [villager.close()](#villagerclose)
       - [villager.trades](#villagertrades)
+      - [villager.trade(tradeIndex, [times], [cb])](#villagertradetradeindex-times-cb)
     - [mineflayer.ScoreBoard](#mineflayerscoreboard)
       - [ScoreBoard.name](#scoreboardname)
       - [ScoreBoard.title](#scoreboardtitle)
@@ -649,6 +650,9 @@ Looks like:
   }
 ]
 ```
+
+#### villager.trade(tradeIndex, [times], [cb])
+Is the same as [bot.trade(villagerInstance, tradeIndex, [times], [cb])](#bottradevillagerinstance-tradeindex-times-cb)
 
 ### mineflayer.ScoreBoard
 

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -120,8 +120,10 @@ function inject (bot, { version }) {
     count = count || Trade.maximumNbTradeUses - Trade.nbTradeUses
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses > 0, 'trade blocked')
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses >= count)
-    if (villager.window.count(Trade.inputItem1.type) < Trade.inputItem1.count * count ||
-    (Trade.inputItem2 && villager.window.count(Trade.inputItem2.type) < Trade.inputItem2.count * count)) {
+
+    const hasEnoughItem1 = villager.window.count(Trade.inputItem1.type) >= Trade.inputItem1.count * count
+    const hasEnoughItem2 = !Trade.inputItem2 || villager.window.count(Trade.inputItem2.type) >= Trade.inputItem2.count * count
+    if (!hasEnoughItem1 || !hasEnoughItem2) {
       return cb(new Error('Not enough items to trade'))
     }
 
@@ -145,19 +147,23 @@ function inject (bot, { version }) {
               if (err) {
                 cb(err)
               } else {
-                if (villager.window.slots[0]) {
-                  assert.strictEqual(villager.window.slots[0].type, Trade.inputItem1.type)
-                  let slot1 = villager.window.slots[0]
-                  slot1.count -= Trade.inputItem1.count
-                  if (slot1.count <= 0) slot1 = null
-                  villager.window.updateSlot(0, slot1)
+                const slot1 = villager.window.slots[0]
+                if (slot1) {
+                  assert.strictEqual(slot1.type, Trade.inputItem1.type)
+                  const updatedCount1 = slot1.count - Trade.inputItem1.count
+                  const updatedSlot1 = updatedCount1 <= 0
+                    ? null
+                    : { ...slot1, count: updatedCount1 }
+                  villager.window.updateSlot(0, updatedSlot1)
                 }
-                if (villager.window.slots[1]) {
-                  assert.strictEqual(villager.window.slots[1].type, Trade.inputItem2.type)
-                  let slot2 = villager.window.slots[1]
-                  slot2.count -= Trade.inputItem2.count
-                  if (slot2.count <= 0) slot2 = null
-                  villager.window.updateSlot(1, slot2)
+                const slot2 = villager.window.slots[1]
+                if (slot2) {
+                  assert.strictEqual(slot2.type, Trade.inputItem2.type)
+                  const updatedCount2 = slot2.count - Trade.inputItem2.count
+                  const updatedSlot2 = updatedCount2 <= 0
+                    ? null
+                    : { ...slot2, count: updatedCount2 }
+                  villager.window.updateSlot(1, updatedSlot2)
                 }
                 Trade.nbTradeUses++
                 count--
@@ -171,20 +177,24 @@ function inject (bot, { version }) {
   }
 
   function putRequirements (window, Trade, count, cb) {
-    let input1 = 0
-    if (!window.slots[0] || window.slots[0].count < Trade.inputItem1.count) {
-      input1 = Math.min(Trade.inputItem1.stackSize, Trade.inputItem1.count * count)
-      if (window.slots[0]) input1 -= window.slots[0].count
-    }
+    const slot1 = window.slots[0]
+    const { count: tradeCount1, stackSize: stackSize1 } = Trade.inputItem1
+    const needCount1 = Math.min(stackSize1, tradeCount1 * count)
+
+    const input1 = !slot1
+      ? needCount1
+      : (slot1.count < tradeCount1 ? needCount1 - slot1.count : 0)
     deposit(window, Trade.inputItem1.type, Trade.inputItem1.metadata, input1, 0, (err) => {
       if (err) {
         cb(err)
       } else if (Trade.hasItem2) {
-        let input2 = 0
-        if (!window.slots[1] || window.slots[1].count < Trade.inputItem2.count) {
-          input2 = Math.min(Trade.inputItem2.stackSize, Trade.inputItem2.count * count)
-          if (window.slots[1]) input2 -= window.slots[1].count
-        }
+        const slot2 = window.slots[1]
+        const { count: tradeCount2, stackSize: stackSize2 } = Trade.inputItem2
+        const needCount2 = Math.min(stackSize2, tradeCount2 * count)
+
+        const input2 = !slot2
+          ? needCount2
+          : (slot2.count < tradeCount2 ? needCount2 - slot2.count : 0)
         deposit(window, Trade.inputItem2.type, Trade.inputItem2.metadata, input2, 1, (err) => {
           if (err) {
             cb(err)

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -122,9 +122,12 @@ function inject (bot, { version }) {
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses >= count)
 
     const itemCount1 = villager.window.count(Trade.inputItem1.type, Trade.inputItem1.metadata)
-    const itemCount2 = !Trade.inputItem2 || villager.window.count(Trade.inputItem2.type, Trade.inputItem2.metadata)
     const hasEnoughItem1 = itemCount1 >= Trade.inputItem1.count * count
-    const hasEnoughItem2 = itemCount2 >= Trade.inputItem2.count * count
+    let hasEnoughItem2 = true
+    if (Trade.inputItem2) {
+      const itemCount2 = villager.window.count(Trade.inputItem2.type, Trade.inputItem2.metadata)
+      hasEnoughItem2 = itemCount2 >= Trade.inputItem2.count * count
+    }
     if (!hasEnoughItem1 || !hasEnoughItem2) {
       return cb(new Error('Not enough items to trade'))
     }

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -121,8 +121,10 @@ function inject (bot, { version }) {
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses > 0, 'trade blocked')
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses >= count)
 
-    const hasEnoughItem1 = villager.window.count(Trade.inputItem1.type) >= Trade.inputItem1.count * count
-    const hasEnoughItem2 = !Trade.inputItem2 || villager.window.count(Trade.inputItem2.type) >= Trade.inputItem2.count * count
+    const itemCount1 = villager.window.count(Trade.inputItem1.type, Trade.inputItem1.metadata)
+    const itemCount2 = !Trade.inputItem2 || villager.window.count(Trade.inputItem2.type, Trade.inputItem2.metadata)
+    const hasEnoughItem1 = itemCount1 >= Trade.inputItem1.count * count
+    const hasEnoughItem2 = itemCount2 >= Trade.inputItem2.count * count
     if (!hasEnoughItem1 || !hasEnoughItem2) {
       return cb(new Error('Not enough items to trade'))
     }
@@ -147,7 +149,7 @@ function inject (bot, { version }) {
               if (err) {
                 cb(err)
               } else {
-                const slot1 = villager.window.slots[0]
+                const [slot1, slot2] = villager.window.slots
                 if (slot1) {
                   assert.strictEqual(slot1.type, Trade.inputItem1.type)
                   const updatedCount1 = slot1.count - Trade.inputItem1.count
@@ -156,7 +158,7 @@ function inject (bot, { version }) {
                     : { ...slot1, count: updatedCount1 }
                   villager.window.updateSlot(0, updatedSlot1)
                 }
-                const slot2 = villager.window.slots[1]
+
                 if (slot2) {
                   assert.strictEqual(slot2.type, Trade.inputItem2.type)
                   const updatedCount2 = slot2.count - Trade.inputItem2.count
@@ -167,6 +169,7 @@ function inject (bot, { version }) {
                 }
                 Trade.nbTradeUses++
                 count--
+
                 next()
               }
             })
@@ -177,25 +180,24 @@ function inject (bot, { version }) {
   }
 
   function putRequirements (window, Trade, count, cb) {
-    const slot1 = window.slots[0]
-    const { count: tradeCount1, stackSize: stackSize1 } = Trade.inputItem1
-    const needCount1 = Math.min(stackSize1, tradeCount1 * count)
+    const [slot1, slot2] = window.slots
+    const { count: tradeCount1, stackSize: stackSize1, type: type1, metadata: metadata1 } = Trade.inputItem1
+    const neededCount1 = Math.min(stackSize1, tradeCount1 * count)
 
     const input1 = !slot1
-      ? needCount1
-      : (slot1.count < tradeCount1 ? needCount1 - slot1.count : 0)
-    deposit(window, Trade.inputItem1.type, Trade.inputItem1.metadata, input1, 0, (err) => {
+      ? neededCount1
+      : (slot1.count < tradeCount1 ? neededCount1 - slot1.count : 0)
+    deposit(window, type1, metadata1, input1, 0, (err) => {
       if (err) {
         cb(err)
       } else if (Trade.hasItem2) {
-        const slot2 = window.slots[1]
-        const { count: tradeCount2, stackSize: stackSize2 } = Trade.inputItem2
+        const { count: tradeCount2, stackSize: stackSize2, type: type2, metadata: metadata2 } = Trade.inputItem2
         const needCount2 = Math.min(stackSize2, tradeCount2 * count)
 
         const input2 = !slot2
           ? needCount2
           : (slot2.count < tradeCount2 ? needCount2 - slot2.count : 0)
-        deposit(window, Trade.inputItem2.type, Trade.inputItem2.metadata, input2, 1, (err) => {
+        deposit(window, type2, metadata2, input2, 1, (err) => {
           if (err) {
             cb(err)
           } else {

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -90,6 +90,10 @@ function inject (bot, { version }) {
       bot._client.removeListener(tradeListPacket, gotTrades)
     })
 
+    villager.trade = (index, count, cb = noop) => {
+      bot.trade(villager, index, count, cb)
+    }
+
     return villager
 
     function gotTrades (packet) {
@@ -116,6 +120,10 @@ function inject (bot, { version }) {
     count = count || Trade.maximumNbTradeUses - Trade.nbTradeUses
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses > 0, 'trade blocked')
     assert.ok(Trade.maximumNbTradeUses - Trade.nbTradeUses >= count)
+    if (villager.window.count(Trade.inputItem1.type) < Trade.inputItem1.count * count ||
+    (Trade.inputItem2 && villager.window.count(Trade.inputItem2.type) < Trade.inputItem2.count * count)) {
+      return cb(new Error('Not enough items to trade'))
+    }
 
     selectTrade(choice)
 
@@ -128,8 +136,7 @@ function inject (bot, { version }) {
         }
         cb()
       } else {
-        count--
-        putRequirements(villager.window, Trade, (err) => {
+        putRequirements(villager.window, Trade, count, (err) => {
           if (err) {
             cb(err)
           } else {
@@ -138,9 +145,22 @@ function inject (bot, { version }) {
               if (err) {
                 cb(err)
               } else {
-                villager.window.updateSlot(0, null)
-                villager.window.updateSlot(1, null)
+                if (villager.window.slots[0]) {
+                  assert.strictEqual(villager.window.slots[0].type, Trade.inputItem1.type)
+                  let slot1 = villager.window.slots[0]
+                  slot1.count -= Trade.inputItem1.count
+                  if (slot1.count <= 0) slot1 = null
+                  villager.window.updateSlot(0, slot1)
+                }
+                if (villager.window.slots[1]) {
+                  assert.strictEqual(villager.window.slots[1].type, Trade.inputItem2.type)
+                  let slot2 = villager.window.slots[1]
+                  slot2.count -= Trade.inputItem2.count
+                  if (slot2.count <= 0) slot2 = null
+                  villager.window.updateSlot(1, slot2)
+                }
                 Trade.nbTradeUses++
+                count--
                 next()
               }
             })
@@ -150,12 +170,22 @@ function inject (bot, { version }) {
     }
   }
 
-  function putRequirements (window, Trade, cb) {
-    deposit(window, Trade.inputItem1.type, Trade.inputItem1.metadata, Trade.inputItem1.count, 0, (err) => {
+  function putRequirements (window, Trade, count, cb) {
+    let input1 = 0
+    if (!window.slots[0] || window.slots[0].count < Trade.inputItem1.count) {
+      input1 = Math.min(Trade.inputItem1.stackSize, Trade.inputItem1.count * count)
+      if (window.slots[0]) input1 -= window.slots[0].count
+    }
+    deposit(window, Trade.inputItem1.type, Trade.inputItem1.metadata, input1, 0, (err) => {
       if (err) {
         cb(err)
       } else if (Trade.hasItem2) {
-        deposit(window, Trade.inputItem2.type, Trade.inputItem2.metadata, Trade.inputItem2.count, 1, (err) => {
+        let input2 = 0
+        if (!window.slots[1] || window.slots[1].count < Trade.inputItem2.count) {
+          input2 = Math.min(Trade.inputItem2.stackSize, Trade.inputItem2.count * count)
+          if (window.slots[1]) input2 -= window.slots[1].count
+        }
+        deposit(window, Trade.inputItem2.type, Trade.inputItem2.metadata, input2, 1, (err) => {
           if (err) {
             cb(err)
           } else {


### PR DESCRIPTION
* Check that the bot has enough item to fullfill the trade count

* Adds the option to use villager.trade(...) instead of bot.trade(villager, ...)

* Instead of putting as many items as the bot needs for 1 trade, it puts as many items as it needs for all trades (count) to be done, this way we avoid the bot putting back in the inventory the items it's going to need for the next trades (avoids some clicks)