### PR TITLE
Fix bot.setCommandBlock() for versions 1.13-1.16 and add tests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@
       - [bot.openEnchantmentTable(enchantmentTableBlock)](#botopenenchantmenttableenchantmenttableblock)
       - [bot.openVillager(villagerEntity)](#botopenvillagervillagerentity)
       - [bot.trade(villagerInstance, tradeIndex, [times], [cb])](#bottradevillagerinstance-tradeindex-times-cb)
-      - [bot.setCommandBlock(pos, command, track_output, [flags])](#botsetcommandblockpos-command-track_output-flags)
+      - [bot.setCommandBlock(pos, command, track_output, [mode])](#botsetcommandblockpos-command-track_output-mode)
     - [Lower level inventory methods](#lower-level-inventory-methods)
       - [bot.clickWindow(slot, mouseButton, mode, cb)](#botclickwindowslot-mousebutton-mode-cb)
       - [bot.putSelectedItemRange(start, end, window, slot, cb)](#botputselecteditemrangestart-end-window-slot-cb)
@@ -1608,7 +1608,7 @@ Returns an `Villager` instance which represents the trading window you are openi
 
 Uses the open `villagerInstance` to trade.
 
-#### bot.setCommandBlock(pos, command, track_output, [flags])
+#### bot.setCommandBlock(pos, command, track_output, [mode])
 
 Set a command block `command` at `pos`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -265,7 +265,7 @@
       - [bot.openEnchantmentTable(enchantmentTableBlock)](#botopenenchantmenttableenchantmenttableblock)
       - [bot.openVillager(villagerEntity)](#botopenvillagervillagerentity)
       - [bot.trade(villagerInstance, tradeIndex, [times], [cb])](#bottradevillagerinstance-tradeindex-times-cb)
-      - [bot.setCommandBlock(pos, command, track_output)](#botsetcommandblockpos-command-track_output)
+      - [bot.setCommandBlock(pos, command, track_output, [flags])](#botsetcommandblockpos-command-track_output-flags)
     - [Lower level inventory methods](#lower-level-inventory-methods)
       - [bot.clickWindow(slot, mouseButton, mode, cb)](#botclickwindowslot-mousebutton-mode-cb)
       - [bot.putSelectedItemRange(start, end, window, slot, cb)](#botputselecteditemrangestart-end-window-slot-cb)
@@ -1608,7 +1608,7 @@ Returns an `Villager` instance which represents the trading window you are openi
 
 Uses the open `villagerInstance` to trade.
 
-#### bot.setCommandBlock(pos, command, track_output)
+#### bot.setCommandBlock(pos, command, track_output, [flags])
 
 Set a command block `command` at `pos`.
 

--- a/lib/features.json
+++ b/lib/features.json
@@ -198,5 +198,10 @@
       "name": "usesAdvCdm",
       "description": "Packet MC|AdvCmd was incorrectly spelled in 1.8 as MC|AdvCdm",
       "versions": ["1.8"]
+    },
+    {
+      "name": "usesAdvCmd",
+      "description": "Uses MC|AdvCmd to set command block information",
+      "versions": ["1.9", "1.10", "1.11", "1.12"]
     }
-  ]
+]

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -5,9 +5,10 @@ const ProtoDef = require('protodef').ProtoDef
 module.exports = inject
 
 function inject (bot) {
-  function setCommandBlock (pos, command, trackOutput, flags) {
+  function setCommandBlock (pos, command, trackOutput, mode) {
     assert.notStrictEqual(pos, null)
     assert.notStrictEqual(command, null)
+    trackOutput = trackOutput || 2
     if (bot.supportFeature('usesAdvCmd') || bot.supportFeature('usesAdvCdm')) {
       const pluginChannelName = bot.supportFeature('usesAdvCdm') ? 'MC|AdvCdm' : 'MC|AdvCmd'
 
@@ -105,8 +106,8 @@ function inject (bot) {
       bot._client.write('update_command_block', {
         location: pos,
         command,
-        mode: trackOutput,
-        flags
+        mode,
+        flags: trackOutput
       })
     }
   }

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -1,101 +1,114 @@
+const assert = require('assert')
+
 const ProtoDef = require('protodef').ProtoDef
 
 module.exports = inject
 
 function inject (bot) {
-  function setCommandBlock (pos, command, trackOutput) {
-    const pluginChannelName = bot.supportFeature('usesAdvCdm') ? 'MC|AdvCdm' : 'MC|AdvCmd'
+  function setCommandBlock (pos, command, trackOutput, flags) {
+    assert.notStrictEqual(pos, null)
+    assert.notStrictEqual(command, null)
+    if (bot.supportFeature('usesAdvCmd') || bot.supportFeature('usesAdvCdm')) {
+      const pluginChannelName = bot.supportFeature('usesAdvCdm') ? 'MC|AdvCdm' : 'MC|AdvCmd'
 
-    const proto = new ProtoDef()
+      const proto = new ProtoDef()
 
-    proto.addType('string', [
-      'pstring',
-      {
-        countType: 'varint'
-      }])
+      proto.addType('string', [
+        'pstring',
+        {
+          countType: 'varint'
+        }])
 
-    proto.addType(pluginChannelName, [
-      'container',
-      [
-        {
-          name: 'mode',
-          type: 'i8'
-        },
-        {
-          name: 'x',
-          type: [
-            'switch',
-            {
-              compareTo: 'mode',
-              fields: {
-                0: 'i32'
-              },
-              default: 'void'
-            }
-          ]
-        },
-        {
-          name: 'y',
-          type: [
-            'switch',
-            {
-              compareTo: 'mode',
-              fields: {
-                0: 'i32'
-              },
-              default: 'void'
-            }
-          ]
-        },
-        {
-          name: 'z',
-          type: [
-            'switch',
-            {
-              compareTo: 'mode',
-              fields: {
-                0: 'i32'
-              },
-              default: 'void'
-            }
-          ]
-        },
-        {
-          name: 'eid',
-          type: [
-            'switch',
-            {
-              compareTo: 'mode',
-              fields: {
-                1: 'i32'
-              },
-              default: 'void'
-            }
-          ]
-        },
-        {
-          name: 'command',
-          type: 'string'
-        },
-        {
-          name: 'trackOutput',
-          type: 'bool'
-        }
-      ]
-    ])
+      proto.addType(pluginChannelName, [
+        'container',
+        [
+          {
+            name: 'mode',
+            type: 'i8'
+          },
+          {
+            name: 'x',
+            type: [
+              'switch',
+              {
+                compareTo: 'mode',
+                fields: {
+                  0: 'i32'
+                },
+                default: 'void'
+              }
+            ]
+          },
+          {
+            name: 'y',
+            type: [
+              'switch',
+              {
+                compareTo: 'mode',
+                fields: {
+                  0: 'i32'
+                },
+                default: 'void'
+              }
+            ]
+          },
+          {
+            name: 'z',
+            type: [
+              'switch',
+              {
+                compareTo: 'mode',
+                fields: {
+                  0: 'i32'
+                },
+                default: 'void'
+              }
+            ]
+          },
+          {
+            name: 'eid',
+            type: [
+              'switch',
+              {
+                compareTo: 'mode',
+                fields: {
+                  1: 'i32'
+                },
+                default: 'void'
+              }
+            ]
+          },
+          {
+            name: 'command',
+            type: 'string'
+          },
+          {
+            name: 'trackOutput',
+            type: 'bool'
+          }
+        ]
+      ])
 
-    const buffer = proto.createPacketBuffer(pluginChannelName, {
-      mode: 0,
-      x: pos.x,
-      y: pos.y,
-      z: pos.z,
-      command,
-      trackOutput
-    })
-    bot._client.write('custom_payload', {
-      channel: pluginChannelName,
-      data: buffer
-    })
+      const buffer = proto.createPacketBuffer(pluginChannelName, {
+        mode: 0,
+        x: pos.x,
+        y: pos.y,
+        z: pos.z,
+        command,
+        trackOutput
+      })
+      bot._client.write('custom_payload', {
+        channel: pluginChannelName,
+        data: buffer
+      })
+    } else {
+      bot._client.write('update_command_block', {
+        location: pos,
+        command,
+        mode: trackOutput,
+        flags
+      })
+    }
   }
 
   bot.setCommandBlock = setCommandBlock

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -21,7 +21,8 @@ const propOverrides = {
   'online-mode': 'false',
   gamemode: '1',
   'spawn-monsters': 'false',
-  'generate-structures': 'false'
+  'generate-structures': 'false',
+  'enable-command-block': 'true'
 }
 
 const Wrap = require('minecraft-wrap').Wrap

--- a/test/externalTests/commandBlock.js
+++ b/test/externalTests/commandBlock.js
@@ -1,0 +1,30 @@
+const assert = require('assert')
+const vec3 = require('vec3')
+
+function sleep (ms) {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+module.exports = () => async (bot, done) => {
+  const command = `/say ${Math.floor(Math.random()*1000)}`
+  const commandBlockPos = vec3(1, 5, 1)
+  const commandBlockPosText = commandBlockPos.toArray().join(' ')
+  const redstoneBlockPosText = commandBlockPos.offset(0, 1, 0).toArray().join(' ')
+
+  function onMessage (message) {
+    if (message.json.translate === 'advMode.setCommand.success' && message.json.with[0] === command) done()
+  }
+
+  bot.on('message', onMessage)
+
+  // Put and activate the command block
+  bot.test.sayEverywhere(`/setblock ${commandBlockPosText} minecraft:command_block`)
+  await sleep(100)
+  bot.setCommandBlock(commandBlockPos, command, false)
+  await sleep(100)
+  bot.test.sayEverywhere(`/setblock ${redstoneBlockPosText} minecraft:redstone_block`)
+  await sleep(100)
+  bot.test.sayEverywhere(`/setblock ${redstoneBlockPosText} minecraft:air`)
+}

--- a/test/externalTests/commandBlock.js
+++ b/test/externalTests/commandBlock.js
@@ -1,4 +1,3 @@
-const assert = require('assert')
 const vec3 = require('vec3')
 
 function sleep (ms) {
@@ -8,13 +7,12 @@ function sleep (ms) {
 }
 
 module.exports = () => async (bot, done) => {
-  const command = `/say ${Math.floor(Math.random()*1000)}`
+  const command = `/say ${Math.floor(Math.random() * 1000)}`
   const commandBlockPos = vec3(1, 5, 1)
   const commandBlockPosText = commandBlockPos.toArray().join(' ')
-  const redstoneBlockPosText = commandBlockPos.offset(0, 1, 0).toArray().join(' ')
 
   function onMessage (message) {
-    if (message.json.translate === 'advMode.setCommand.success' && message.json.with[0] === command) done()
+    if (message.json.translate === 'advMode.setCommand.success' && message.json.with[0] === command) { done() }
   }
 
   bot.on('message', onMessage)
@@ -23,8 +21,4 @@ module.exports = () => async (bot, done) => {
   bot.test.sayEverywhere(`/setblock ${commandBlockPosText} minecraft:command_block`)
   await sleep(100)
   bot.setCommandBlock(commandBlockPos, command, false)
-  await sleep(100)
-  bot.test.sayEverywhere(`/setblock ${redstoneBlockPosText} minecraft:redstone_block`)
-  await sleep(100)
-  bot.test.sayEverywhere(`/setblock ${redstoneBlockPosText} minecraft:air`)
 }


### PR DESCRIPTION
Related to #1325

I dont know why `standard --fix` did such a mess, sorry