### PR TITLE
Fixed Typescript compile error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -518,7 +518,7 @@ export interface Instrument {
 
 export interface FindBlockOptions {
   point?: Vec3;
-  matching: number | Array<number> | (block: Block) => boolean;
+  matching: number | Array<number> | ((block: Block) => boolean);
   maxDistance?: number;
 }
 


### PR DESCRIPTION
Apparently, functions should be in parenthesis here, otherwise, Typescript can throw some compile errors when trying to load Mineflayer.