### PR TITLE
Fix trade tests

### DIFF
--- a/lib/features.json
+++ b/lib/features.json
@@ -203,5 +203,10 @@
       "name": "usesAdvCmd",
       "description": "Uses MC|AdvCmd to set command block information",
       "versions": ["1.9", "1.10", "1.11", "1.12"]
+    },
+    {
+      "name": "indexesVillagerRecipes",
+      "description": "Gives a index for each trade in a villagers metadata",
+      "versions": ["1.8", "1.9", "1.10", "1.11"]
     }
 ]

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -124,7 +124,7 @@ function inject (bot, { version }) {
     const itemCount1 = villager.window.count(Trade.inputItem1.type, Trade.inputItem1.metadata)
     const hasEnoughItem1 = itemCount1 >= Trade.inputItem1.count * count
     let hasEnoughItem2 = true
-    if (Trade.inputItem2) {
+    if (Trade.inputItem2 && Trade.inputItem2.type && Trade.inputItem2.count) {
       const itemCount2 = villager.window.count(Trade.inputItem2.type, Trade.inputItem2.metadata)
       hasEnoughItem2 = itemCount2 >= Trade.inputItem2.count * count
     }

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -11,9 +11,7 @@ module.exports = () => (bot, done) => {
     : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:7,buy:{id:"minecraft:emerald",Count:2},sell:{id:"minecraft:wheat",Count:2}, uses:1}]}}`
 
   const commandBlockPos = bot.entity.position.offset(0.5, 0, 0.5)
-  const commandBlockPosTxt = commandBlockPos.toArray().join(' ')
   const redstoneBlockPos = commandBlockPos.offset(1, 0, 0)
-  const redstoneBlockPosTxt = redstoneBlockPos.toArray().join(' ')
 
   function onEntitySpawn (entity) {
     if (entity.name !== villagerType) return
@@ -58,8 +56,8 @@ module.exports = () => (bot, done) => {
     bot.on('entitySpawn', onEntitySpawn)
 
     // A command block is needed to spawn the villager due to the chat's character limit in some versions
-    bot.test.sayEverywhere(`/setblock ${commandBlockPosTxt} command_block`)
+    bot.test.sayEverywhere(`/setblock ${commandBlockPos.toArray().join(' ')} command_block`)
     bot.setCommandBlock(commandBlockPos, summonCommand, 1, 2)
-    bot.test.sayEverywhere(`/setblock ${redstoneBlockPosTxt} redstone_block`) // Activate the command block
+    bot.test.sayEverywhere(`/setblock ${redstoneBlockPos.toArray().join(' ')} redstone_block`) // Activate the command block
   })
 }

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -1,27 +1,50 @@
-// const assert = require('assert')
+const assert = require('assert')
 
 module.exports = () => (bot, done) => {
-  done()
-  // TODO fix unreliable trading/trading test
-  /*
   const mcData = require('minecraft-data')(bot.version)
   const Item = require('prismarine-item')(bot.version)
 
   const villagerType = mcData.entitiesByName.villager ? 'villager' : 'Villager'
 
+  const summonCommand = bot.supportFeature('indexesVillagerRecipes')
+    ? `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[0:{maxUses:7,buy:{id:"minecraft:emerald",Count:2},sell:{id:"minecraft:wheat",Count:2}, uses:1}]}}`
+    : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:7,buy:{id:"minecraft:emerald",Count:2},sell:{id:"minecraft:wheat",Count:2}, uses:1}]}}`
+
+  const commandBlockPos = bot.entity.position.offset(0.5, 0, 0.5)
+  const commandBlockPosTxt = commandBlockPos.toArray().join(' ')
+  const redstoneBlockPos = commandBlockPos.offset(1, 0, 0)
+  const redstoneBlockPosTxt = redstoneBlockPos.toArray().join(' ')
+
   function onEntitySpawn (entity) {
     if (entity.name !== villagerType) return
     bot.removeListener('entitySpawn', onEntitySpawn)
+
     bot.openVillager(entity, (err, villager) => {
-      const sell = villager.trades[0].inputItem1
-      const buy = villager.trades[0].outputItem
+      assert.ifError(err)
+      const trade = villager.trades[0]
+      const sell = trade.inputItem1
+      const buy = trade.outputItem
+
       assert.notStrictEqual(sell, null)
       assert.notStrictEqual(buy, null)
+      assert.strictEqual(trade.nbTradeUses, 1)
+      assert.strictEqual(trade.maximumNbTradeUses, 7)
+      assert.strictEqual(trade.tradeDisabled, false)
+      assert(trade.inputItem2 === null || (trade.inputItem2.type === undefined && trade.inputItem2.count === undefined)) // In some versions it returns null in others it returns an empty Item instance
+      assert.strictEqual(sell.name, 'emerald')
+      assert.strictEqual(sell.count, 2)
+      assert.strictEqual(buy.name, 'wheat')
+      assert.strictEqual(buy.count, 2)
+
+      bot.test.sayEverywhere(`I have ${bot.currentWindow.count(mcData.itemsByName.emerald.id)} emeralds`)
       bot.test.sayEverywhere(`I can trade ${sell.count}x ${sell.displayName} for ${buy.count}x ${buy.displayName}`)
-      bot.trade(villager, 0, 1, (err) => {
+      bot.trade(villager, 0, 6, (err) => {
         assert.ifError(err)
-        assert.strictEqual(bot.currentWindow.count(mcData.itemsByName.emerald.id, 0), 0)
-        assert.strictEqual(bot.currentWindow.count(mcData.itemsByName.bread.id, 0), 1)
+        assert.strictEqual(bot.currentWindow.count(mcData.itemsByName.emerald.id), 64 - 12)
+        assert.strictEqual(bot.currentWindow.count(mcData.itemsByName.wheat.id), 12)
+
+        assert.throws(() => bot.trade(villager, 0, 1)) // Shouldn't be able, the trade is blocked!
+
         villager.close(() => {
           bot.test.sayEverywhere(`/kill @e[type=${villagerType}]`)
           done()
@@ -30,10 +53,13 @@ module.exports = () => (bot, done) => {
     })
   }
 
-  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 1, 0), (err) => {
+  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 64, 0), (err) => {
     assert.ifError(err)
     bot.on('entitySpawn', onEntitySpawn)
-    // The command is callibrated to be under the 100 character limit of 1.8 - 1.10:
-    bot.test.sayEverywhere(`/summon ${villagerType} 1 5 1 {Offers:{Recipes:[{buy:{id:emerald,Count:1},sell:{id:bread,Count:1}}]}}`)
-  }) */
+
+    // A command block is needed to spawn the villager due to the chat's character limit in some versions
+    bot.test.sayEverywhere(`/setblock ${commandBlockPosTxt} command_block`)
+    bot.setCommandBlock(commandBlockPos, summonCommand, 1, 2)
+    bot.test.sayEverywhere(`/setblock ${redstoneBlockPosTxt} redstone_block`) // Activate the command block
+  })
 }


### PR DESCRIPTION
- Fixes trading tests by using a command block to spawn the villager
- Fixes a litle bug in lib/plugins/villager.js: In some versions inputItem2 is an Item instance with no atributes so the old condition tought the trade had a inputItem2 and throwed

Closes #973
Related to #1323