### PR TITLE
Simplify setCommandBlock arguments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1621,9 +1621,20 @@ Returns an `Villager` instance which represents the trading window you are openi
 
 Uses the open `villagerInstance` to trade.
 
-#### bot.setCommandBlock(pos, command, track_output, [mode])
+#### bot.setCommandBlock(pos, command, [options])
 
-Set a command block `command` at `pos`.
+Set a command block's properties at `pos`.
+Example `options` argument:
+```js
+{
+  mode: 2,
+  trackOutput: true,
+  conditional: false,
+  alwaysActive: true
+}
+```
+options.mode can have 3 values: 0 (SEQUENCE), 1 (AUTO), 2 (REDSTONE)
+All options attributes are false by default, except mode which is 2 (as to replicate the default command block in Minecraft).
 
 ### Lower level inventory methods
 

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -17,9 +17,9 @@ function inject (bot) {
     options.mode = options.mode || 2 // Possible values: 0: SEQUENCE, 1: AUTO and 2: REDSTONE
 
     let flags = 0
-    if (!options.trackOutput) flags += 1
-    if (options.conditional) flags += 2
-    if (options.alwaysActive) flags += 4
+    flags |= +options.trackOutput << 0 // 0x01
+    flags |= +options.conditional << 1 // 0x02
+    flags |= +options.alwaysActive << 2 // 0x04
 
     if (bot.supportFeature('usesAdvCmd') || bot.supportFeature('usesAdvCdm')) {
       const pluginChannelName = bot.supportFeature('usesAdvCdm') ? 'MC|AdvCdm' : 'MC|AdvCmd'

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -1,14 +1,26 @@
 const assert = require('assert')
-
 const ProtoDef = require('protodef').ProtoDef
 
 module.exports = inject
 
 function inject (bot) {
-  function setCommandBlock (pos, command, trackOutput, mode) {
+  function setCommandBlock (pos, command, options = {}) {
+    assert.strictEqual(bot.player.gamemode, 1, new Error('The bot has to be in creative mode to open the command block window'))
     assert.notStrictEqual(pos, null)
     assert.notStrictEqual(command, null)
-    trackOutput = trackOutput || 2
+    assert.strictEqual(bot.blockAt(pos).name, 'command_block', new Error("The block isn't a command block"))
+
+    // Default values when a command block is placed in vanilla minecraft
+    options.trackOutput = options.trackOutput || false
+    options.conditional = options.conditional || false
+    options.alwaysActive = options.alwaysActive || false
+    options.mode = options.mode || 2 // Possible values: 0: SEQUENCE, 1: AUTO and 2: REDSTONE
+
+    let flags = 0
+    if (!options.trackOutput) flags += 1
+    if (options.conditional) flags += 2
+    if (options.alwaysActive) flags += 4
+
     if (bot.supportFeature('usesAdvCmd') || bot.supportFeature('usesAdvCdm')) {
       const pluginChannelName = bot.supportFeature('usesAdvCdm') ? 'MC|AdvCdm' : 'MC|AdvCmd'
 
@@ -96,7 +108,7 @@ function inject (bot) {
         y: pos.y,
         z: pos.z,
         command,
-        trackOutput
+        trackOutput: options.trackOutput
       })
       bot._client.write('custom_payload', {
         channel: pluginChannelName,
@@ -106,8 +118,8 @@ function inject (bot) {
       bot._client.write('update_command_block', {
         location: pos,
         command,
-        mode,
-        flags: trackOutput
+        mode: options.mode,
+        flags
       })
     }
   }

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -1,5 +1,11 @@
 const assert = require('assert')
 
+function sleep (ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms)
+  })
+}
+
 module.exports = () => (bot, done) => {
   const mcData = require('minecraft-data')(bot.version)
   const Item = require('prismarine-item')(bot.version)
@@ -51,13 +57,14 @@ module.exports = () => (bot, done) => {
     })
   }
 
-  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 64, 0), (err) => {
+  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 64, 0), async (err) => {
     assert.ifError(err)
     bot.on('entitySpawn', onEntitySpawn)
 
     // A command block is needed to spawn the villager due to the chat's character limit in some versions
     bot.test.sayEverywhere(`/setblock ${commandBlockPos.toArray().join(' ')} command_block`)
-    bot.setCommandBlock(commandBlockPos, summonCommand, 1, 2)
+    await sleep(500)
+    bot.setCommandBlock(commandBlockPos, summonCommand)
     bot.test.sayEverywhere(`/setblock ${redstoneBlockPos.toArray().join(' ')} redstone_block`) // Activate the command block
   })
 }

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -1,11 +1,5 @@
 const assert = require('assert')
 
-function sleep (ms) {
-  return new Promise(resolve => {
-    setTimeout(resolve, ms)
-  })
-}
-
 module.exports = () => (bot, done) => {
   const mcData = require('minecraft-data')(bot.version)
   const Item = require('prismarine-item')(bot.version)
@@ -57,14 +51,15 @@ module.exports = () => (bot, done) => {
     })
   }
 
-  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 64, 0), async (err) => {
+  bot.test.setInventorySlot(36, new Item(mcData.itemsByName.emerald.id, 64, 0), (err) => {
     assert.ifError(err)
     bot.on('entitySpawn', onEntitySpawn)
 
     // A command block is needed to spawn the villager due to the chat's character limit in some versions
     bot.test.sayEverywhere(`/setblock ${commandBlockPos.toArray().join(' ')} command_block`)
-    await sleep(500)
-    bot.setCommandBlock(commandBlockPos, summonCommand)
-    bot.test.sayEverywhere(`/setblock ${redstoneBlockPos.toArray().join(' ')} redstone_block`) // Activate the command block
+    setTimeout(() => {
+      bot.setCommandBlock(commandBlockPos, summonCommand)
+      bot.test.sayEverywhere(`/setblock ${redstoneBlockPos.toArray().join(' ')} redstone_block`) // Activate the command block
+    }, 500)
   })
 }


### PR DESCRIPTION
- Simplify setCommandBlock arguments by replacing trackOutput and mode arguments to a options argument
- options argument is more friendly as now the user doesn't have to guess what number does it need to replicate the behavior
- Also adds checks: the bot shouldn't be able to open/edit the command block when it's in survival mode, and the block at `pos` should be a command block

`flags` values and the command block properties output:
 - 0:  Unconditional - Needs Redstone - Tracks Output
 - 1:  Unconditional - Needs Redstone - Doesn't track output
 - 2:  Conditional   - Needs Redstone - Tracks Output
 - 3:  Conditional   - Needs Redstone - Doesn't track output
 - 4:  Unconditional - Always Active  - Tracks Output
 - 5:  Unconditional - Always Active  - Doesn't track output
 - 6:  Conditional   - Always Active  - Tracks Output
 - 7:  Conditional   - Always Active  - Doesn't track output

Related to #1327 where I wasn't sure what `flags` was.

There are still things missing but it's pretty complete for the latests minecraft versions