### PR TITLE
Add support for Barrel

### DIFF
--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -11,7 +11,8 @@ function inject (bot, { version }) {
     if (chestToOpen.constructor.name === 'Block') {
       assert.ok(chestToOpen.type === mcData.blocksByName.chest.id ||
                 chestToOpen.type === mcData.blocksByName.ender_chest.id ||
-                chestToOpen.type === mcData.blocksByName.trapped_chest.id)
+                chestToOpen.type === mcData.blocksByName.trapped_chest.id ||
+                (mcData.blocksByName.barrel && chestToOpen.type === mcData.blocksByName.barrel.id))
       chest = bot.openBlock(chestToOpen, Chest)
     } else if (chestToOpen.constructor.name === 'Entity') {
       assert.strictEqual(chestToOpen.entityType, mcData.entitiesByName.chest_minecart.id)


### PR DESCRIPTION
It works just like a chest (except it doesn't matter if there's a block above) so I don't think any more modifications are needed