### PR TITLE
Exposed getDestSlot function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -278,6 +278,7 @@
       - [bot.openEntity(entity, Class)](#botopenentityentity-class)
       - [bot.moveSlotItem(sourceSlot, destSlot, cb)](#botmoveslotitemsourceslot-destslot-cb)
       - [bot.updateHeldItem()](#botupdatehelditem)
+      - [bot.getEquipmentDestSlot(destination)](#botgetequipmentdestslot-destination)
     - [bot.creative](#botcreative)
       - [bot.creative.setInventorySlot(slot, item, [callback])](#botcreativesetinventoryslotslot-item-callback)
       - [bot.creative.flyTo(destination, [cb])](#botcreativeflytodestination-cb)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1677,6 +1677,10 @@ Move an item from `sourceSlot` to `destSlot` in the current window.
 
 Update `bot.heldItem`.
 
+#### bot.getEquipmentDestSlot(destination)
+
+Gets the inventory equipment slot id for the given equipment destination name.
+
 ### bot.creative
 
 This collection of apis is useful in creative mode.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1681,6 +1681,14 @@ Update `bot.heldItem`.
 
 Gets the inventory equipment slot id for the given equipment destination name.
 
+Available destinations are:
+* head
+* torso
+* legs
+* feet
+* hand
+* off-hand
+
 ### bot.creative
 
 This collection of apis is useful in creative mode.

--- a/index.d.ts
+++ b/index.d.ts
@@ -367,6 +367,8 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   updateHeldItem();
 
+  getEquipmentDestSlot(destination: string): number;
+
 }
 
 export interface GameState {

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -152,6 +152,7 @@ function inject (bot) {
   bot.toss = toss
   bot.tossStack = tossStack
   bot.setQuickBarSlot = setQuickBarSlot
+  bot.getEquipmentDestSlot = getDestSlot
 
   // constants
   bot.QUICK_BAR_START = QUICK_BAR_START


### PR DESCRIPTION
This utility is useful for converting named inventory slots into raw slot IDs. I believe it would be useful to add this as a future-proof way to safely access raw inventory slots.

```js
const helmet = bot.inventory.slots[bot.getEquipmentDestSlot('helmet')]
const hand = bot.inventory.slots[bot.getEquipmentDestSlot('hand')]
const offHand = bot.inventory.slots[bot.getEquipmentDestSlot('off-hand')]
// etc
```
I believe it would be better to also keep the return type an integer value as it works smoother with the other low-level inventory functions like moving items to specific slots and such.