### PR TITLE
Fixed attack cooldown bug

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -514,12 +514,12 @@ function inject (bot, { version }) {
     useEntity(target, 0)
   }
 
-  function attack (target, swing) {
+  function attack (target, swing = true) {
+    useEntity(target, 1)
+
     if (swing) {
       swingArm()
     }
-
-    useEntity(target, 1)
   }
 
   function mount (target) {


### PR DESCRIPTION
This is a fix for https://github.com/PrismarineJS/mineflayer/issues/791

In the vanilla client, the swing arm packet is sent after the attack packet. This is used to reset the attack timer, apparently. Without this, the attack indicator is always assumed to be empty and the bot deals minimal damage with each attack, regardless of the time passed.

Swapping the order fixes this bug.