### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: 1.8
         java-package: jre


### PR DESCRIPTION
This removes some warnings that were appearing in CI
More info: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/