### PR TITLE
Added shulkers to chest type list

### DIFF
--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -12,7 +12,8 @@ function inject (bot, { version }) {
       assert.ok(chestToOpen.type === mcData.blocksByName.chest.id ||
                 chestToOpen.type === mcData.blocksByName.ender_chest.id ||
                 chestToOpen.type === mcData.blocksByName.trapped_chest.id ||
-                (mcData.blocksByName.barrel && chestToOpen.type === mcData.blocksByName.barrel.id))
+                (mcData.blocksByName.barrel && chestToOpen.type === mcData.blocksByName.barrel.id) ||
+                (mcData.blocks[chestToOpen.type].name.endsWith('_shulker_box')))
       chest = bot.openBlock(chestToOpen, Chest)
     } else if (chestToOpen.constructor.name === 'Entity') {
       assert.strictEqual(chestToOpen.entityType, mcData.entitiesByName.chest_minecart.id)


### PR DESCRIPTION
It was reported in the Discord that Shulkers were not part of the chest list, so I quickly added that.
Since each Shulker color has a different ID, I'm just checking the name instead.