### PR TITLE
Add type validation to bot.chat

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -74,6 +74,9 @@ function inject (bot, options) {
   })
 
   function chatWithHeader (header, message) {
+    if(typeof message != "string") {
+      throw new Error("Incorrect type! Should be a string.")
+    }
     const lengthLimit = CHAT_LENGTH_LIMIT - header.length
     message.split('\n').forEach((subMessage) => {
       if (!subMessage) return

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -75,7 +75,7 @@ function inject (bot, options) {
 
   function chatWithHeader (header, message) {
     if (typeof message !== 'string') {
-      throw new Error("Incorrect type! Should be a string.")
+      throw new Error('Incorrect type! Should be a string.')
     }
     const lengthLimit = CHAT_LENGTH_LIMIT - header.length
     message.split('\n').forEach((subMessage) => {

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -74,7 +74,7 @@ function inject (bot, options) {
   })
 
   function chatWithHeader (header, message) {
-    if(typeof message != "string") {
+    if (typeof message !== 'string') {
       throw new Error("Incorrect type! Should be a string.")
     }
     const lengthLimit = CHAT_LENGTH_LIMIT - header.length

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -77,6 +77,7 @@ function inject (bot, options) {
     if (typeof message !== 'string') {
       throw new Error('Incorrect type! Should be a string.')
     }
+    
     const lengthLimit = CHAT_LENGTH_LIMIT - header.length
     message.split('\n').forEach((subMessage) => {
       if (!subMessage) return

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -77,7 +77,7 @@ function inject (bot, options) {
     if (typeof message !== 'string') {
       throw new Error('Incorrect type! Should be a string.')
     }
-    
+
     const lengthLimit = CHAT_LENGTH_LIMIT - header.length
     message.split('\n').forEach((subMessage) => {
       if (!subMessage) return


### PR DESCRIPTION
This is a simple change that adds type validation to `bot.chat`.

Fixes #1366 