### PR TITLE
Added entity height and width.

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -30,6 +30,7 @@ function inject (bot, { version }) {
   const entitiesArray = require('minecraft-data')(version).entitiesArray
   const Item = require('prismarine-item')(version)
   const ChatMessage = require('prismarine-chat')(version)
+  const entitiesByName = require('minecraft-data')(version).entitiesByName
 
   bot.findPlayer = bot.findPlayers = (filter) => {
     const filterFn = (entity) => {
@@ -133,7 +134,7 @@ function inject (bot, { version }) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
       entity.height = NAMED_ENTITY_HEIGHT
-      entity.width = entitiesArray[packet.type].width
+      entity.width = entitiesByName.player.width
       entity.metadata = parseMetadata(packet.metadata, entity.metadata)
       if (bot.players[entity.username] !== undefined && !bot.players[entity.username].entity) {
         bot.players[entity.username].entity = entity

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -2,6 +2,7 @@ const Vec3 = require('vec3').Vec3
 const Entity = require('prismarine-entity')
 const conv = require('../conversions')
 const NAMED_ENTITY_HEIGHT = 1.62
+const NAMED_ENTITY_WIDTH = 0.6
 const CROUCH_HEIGHT = NAMED_ENTITY_HEIGHT - 0.08
 
 module.exports = inject
@@ -30,7 +31,6 @@ function inject (bot, { version }) {
   const entitiesArray = require('minecraft-data')(version).entitiesArray
   const Item = require('prismarine-item')(version)
   const ChatMessage = require('prismarine-chat')(version)
-  const entitiesByName = require('minecraft-data')(version).entitiesByName
 
   bot.findPlayer = bot.findPlayers = (filter) => {
     const filterFn = (entity) => {
@@ -134,7 +134,7 @@ function inject (bot, { version }) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
       entity.height = NAMED_ENTITY_HEIGHT
-      entity.width = entitiesByName.player.width
+      entity.width = NAMED_ENTITY_WIDTH
       entity.metadata = parseMetadata(packet.metadata, entity.metadata)
       if (bot.players[entity.username] !== undefined && !bot.players[entity.username].entity) {
         bot.players[entity.username].entity = entity

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -133,7 +133,7 @@ function inject (bot, { version }) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
       entity.height = NAMED_ENTITY_HEIGHT
-      entity.width = objects[packet.type].width
+      entity.width = entitiesArray[packet.type].width
       entity.metadata = parseMetadata(packet.metadata, entity.metadata)
       if (bot.players[entity.username] !== undefined && !bot.players[entity.username].entity) {
         bot.players[entity.username].entity = entity

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -133,6 +133,7 @@ function inject (bot, { version }) {
       entity.yaw = conv.fromNotchianYawByte(packet.yaw)
       entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
       entity.height = NAMED_ENTITY_HEIGHT
+      entity.width = objects[packet.type].width
       entity.metadata = parseMetadata(packet.metadata, entity.metadata)
       if (bot.players[entity.username] !== undefined && !bot.players[entity.username].entity) {
         bot.players[entity.username].entity = entity
@@ -172,6 +173,8 @@ function inject (bot, { version }) {
       entity.entityType = entityData.id
       entity.name = entityData.name
       entity.kind = entityData.category
+      entity.height = entityData.height
+      entity.width = entityData.width
     } else {
       // unknown entity
       entity.type = 'other'
@@ -228,6 +231,8 @@ function inject (bot, { version }) {
       entity.entityType = entityData.id
       entity.name = entityData.name
       entity.kind = entityData.category
+      entity.height = entityData.height
+      entity.width = entityData.width
     }
 
     if (bot.supportFeature('fixedPointPosition')) {


### PR DESCRIPTION
Closes https://github.com/PrismarineJS/mineflayer/issues/1383

Also pushed a PR (https://github.com/PrismarineJS/prismarine-entity/pull/7) to prismarine-entity to add the default height and width flags. Once that and this PR are merged, height and width should be defined for all entities where possible.