### PR TITLE
add objectUUID e.g. for items

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -189,6 +189,7 @@ function inject (bot, { version }) {
     }
 
     entity.uuid = packet.entityUUID
+    if(packet.objectUUID) entity.uuid = packet.objectUUID
     entity.yaw = conv.fromNotchianYawByte(packet.yaw)
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
     entity.objectData = packet.objectData


### PR DESCRIPTION
for entities like items, sent with 'spawn_entity', objectUUID is sent instead of entityUUID. this pr sets the entity.uuid to objectUUID if available