### PR TITLE
Added better handling for automatic dependency resolution between plugins

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -38,7 +38,15 @@ Enabled debug mode https://github.com/PrismarineJS/mineflayer#debug
 One way is to increase the [checkTimeoutInterval](https://github.com/PrismarineJS/node-minecraft-protocol/blob/master/docs/API.md#mccreateclientoptions) option (to set in createBot) to an higher value (for example `300*1000` which is 5min instead of the default 30s). If you still get disconnected, you can auto reconnect using something like this example https://github.com/PrismarineJS/mineflayer/blob/master/examples/reconnector.js
 
 ### How to get the lore / text of an item ?
+
 You can use the .nbt property of an item. prismarine-nbt nbt.simplify method may be useful
 
 ### How can I send message from the console to the server?
+
 You can use a library like `repl` to read the console input and use `bot.chat` to send it. You can find an example [here.](https://github.com/PrismarineJS/mineflayer/blob/master/examples/repl.js)
+
+### When creating a plugin, how can I specify another plugin as a dependency?
+
+In the `inject()` function for your plugin, you can safely call `bot.loadPlugin(anotherPlugin)` to make sure that plugin is loaded. If the plugin was already loaded before, nothing happens.
+
+Note that the order in which plugins are loaded is dynamic, so you should never call another plugin in your `inject()` function.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1378,13 +1378,15 @@ function somePlugin(bot, options) {
   function someFunction() {
     bot.chat('Yay!');
   }
-  bot.someFunction = someFunction;
+
+  bot.myPlugin = {} // Good practice to namespace plugin API
+  bot.myPlugin.someFunction = someFunction;
 }
 
 var bot = mineflayer.createBot(...);
 bot.loadPlugin(somePlugin);
 bot.once('login', function() {
-  bot.someFunction(); // Yay!
+  bot.myPlugin.someFunction(); // Yay!
 });
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1369,7 +1369,8 @@ See the `bot.settings` property.
 
 #### bot.loadPlugin(plugin)
 
-Injects a Plugin.
+Injects a Plugin. Does nothing if the plugin is already loaded.
+
  * `plugin` - function
 
 ```js
@@ -1391,6 +1392,10 @@ bot.once('login', function() {
 
 Injects plugins see `bot.loadPlugin`.
  * `plugins` - array of functions
+
+#### bot.hasPlugin(plugin)
+
+Checks if the given plugin is loaded (or scheduled to be loaded) on this bot.
 
 #### bot.sleep(bedBlock, [cb])
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -225,6 +225,8 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   loadPlugins(plugins: Array<Plugin>): void;
 
+  hasPlugin(plugin: Plugin): boolean;
+
   sleep(bedBlock: Block, cb?: (err?: Error) => void): void;
 
   isABed(bedBlock: Block): void;

--- a/lib/plugin_loader.js
+++ b/lib/plugin_loader.js
@@ -4,29 +4,49 @@ module.exports = inject
 
 function inject (bot, options) {
   let loaded = false
-  let pluginsToBeAdded = []
+  let pluginList = []
   bot.once('inject_allowed', onInjectAllowed)
 
   function onInjectAllowed () {
     loaded = true
-    injectPlugins(pluginsToBeAdded)
+    injectPlugins()
   }
+
   function loadPlugin (plugin) {
     assert.ok(typeof plugin === 'function', 'plugin needs to be a function')
-    if (!loaded) pluginsToBeAdded.push(plugin)
-    else plugin(bot, options)
+
+    if (hasPlugin(plugin)) {
+      return
+    }
+
+    pluginList.push(plugin)
+
+    if (loaded) {
+      plugin(bot, options)
+    }
   }
+
   function loadPlugins (plugins) {
+    // While type checking if already done in the other function, it's useful to do
+    // it here to prevent situations where only half the plugin list is loaded.
     assert.ok(plugins.filter(plugin => typeof plugin === 'function').length === plugins.length, 'plugins need to be an array of functions')
-    if (loaded) return injectPlugins(plugins)
-    pluginsToBeAdded = pluginsToBeAdded.concat(plugins)
-  }
-  function injectPlugins (plugins) {
+
     plugins.forEach((plugin) => {
+      loadPlugin(plugin)
+    })
+  }
+
+  function injectPlugins () {
+    pluginList.forEach((plugin) => {
       plugin(bot, options)
     })
   }
 
+  function hasPlugin (plugin) {
+    return pluginList.indexOf(plugin) >= 0
+  }
+
   bot.loadPlugin = loadPlugin
   bot.loadPlugins = loadPlugins
+  bot.hasPlugin = hasPlugin
 }

--- a/lib/plugin_loader.js
+++ b/lib/plugin_loader.js
@@ -4,7 +4,7 @@ module.exports = inject
 
 function inject (bot, options) {
   let loaded = false
-  let pluginList = []
+  const pluginList = []
   bot.once('inject_allowed', onInjectAllowed)
 
   function onInjectAllowed () {


### PR DESCRIPTION
In sitations where Plugin A relies on Plugin B to work, it's useful for plugin A to automatically trigger plugin B to load if the user does not specify this directly. This allows for better API compatibility. (A plugin can add a new plugin dependency to the bot without breaking existing bots that don't load plugin B by default.)

This also makes it much easier to load plugin trees that contain several nested plugins, all by simply loading the parent plugin.

This PR works by safely allowing the `bot.loadPlugin` to be called more than once without actually loading the plugin twice.

Bot:
```js
const { pluginA } = require('mineflayer-plugin-a')
const bot = mineflayer.createBot({...})
bot.loadPlugin(pluginA)
```

Plugin A:
```js
const { pluginB } = require('mineflayer-plugin-b')

function pluginA (bot) {
  bot.loadPlugin(pluginB)

  bot.pluginA = {}
  bot.pluginA.someFunction = function () {}
}

module.exports = {
  pluginA
}
```

Using this, Plugin A can safely load Plugin B when injected. If the user already has PluginB loaded, nothing happens.