### PR TITLE
Added tool plugin to readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -180,6 +180,7 @@ The most updated and useful are :
  * [Dashboard](https://github.com/wvffle/mineflayer-dashboard) - Frontend dashboard for mineflayer bot
  * [PVP](https://github.com/TheDudeFromCI/mineflayer-pvp) - Easy API for basic PVP and PVE.
  * [auto-eat](https://github.com/LINKdiscordd/mineflayer-auto-eat) - Automatic eating of food.
+ * [Tool](https://github.com/TheDudeFromCI/mineflayer-tool) - A utility for automatic tool/weapon selection with a high level API.
 
 
  But also check out :


### PR DESCRIPTION
Created a small utility plugin for handling tool (and eventually weapon) selection.

Currently allows for selecting the fastest tool to mine a block within your inventory, and an optional flag for automatically walking to a chest in order to collect the tool if it doesn't have a suitable one in its inventory.