### PR TITLE
typings(FindBlockOptions): add missing options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -528,6 +528,10 @@ export interface FindBlockOptions {
   point?: Vec3;
   matching: number | Array<number> | ((block: Block) => boolean);
   maxDistance?: number;
+  count?: number;
+  point?: Vec3;
+  useExtraInfo?: boolean;
+  start?: { x: number, y: number, z: number };
 }
 
 export type EquipmentDestination = "hand" | "head" | "torso" | "legs" | "feet" | "off-hand";


### PR DESCRIPTION
the `FindBlockOptions` in the typings was missing several properties, this PR amends that

Its worth noting the typings for this project, minecraft-data, and several others (i believe all maintained by the same people) are extremely inaccurate, im not trying to be annoying but this makes it very difficult for TypeScript users as we have to constantly check the source code to make sure things are working properly, aswell as create custom types for most things

I would volunteer to fix these typings myself but i'm not in the right headspace to go through the source code for every package and completely redo the typings, however if the maintainers would like to open an issue or add it to their TODO lists that would be much appreciated!