### PR TITLE
Removed Hawkeye dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -181,6 +181,7 @@ The most updated and useful are :
  * [PVP](https://github.com/TheDudeFromCI/mineflayer-pvp) - Easy API for basic PVP and PVE.
  * [auto-eat](https://github.com/LINKdiscordd/mineflayer-auto-eat) - Automatic eating of food.
  * [Tool](https://github.com/TheDudeFromCI/mineflayer-tool) - A utility for automatic tool/weapon selection with a high level API.
+ * [Hawkeye](https://github.com/sefirosweb/minecraftHawkEye) - A utility for using auto-aim with bows.
 
 
  But also check out :

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "minecraft-data": "^2.67.0",
     "minecraft-protocol": "^1.17.0",
-    "minecrafthawkeye": "^1.0.7",
     "prismarine-biome": "^1.1.0",
     "prismarine-block": "^1.6.0",
     "prismarine-chat": "^1.0.0",


### PR DESCRIPTION
It seems at some point this was accidentally added as a dependency. Removed it.

Should we add plugins as dev dependencies for example bots, though? If so, we have a few of them we should add.