### PR TITLE
Open the craft window only once

### DIFF
--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -14,20 +14,8 @@ function inject (bot, { version }) {
       cb(new Error('recipe requires craftingTable'))
       return
     }
-    next()
-    function next (err) {
-      if (err) {
-        cb(err)
-      } else if (count > 0) {
-        count -= 1
-        craftOnce(recipe, craftingTable, next)
-      } else {
-        cb()
-      }
-    }
-  }
 
-  function craftOnce (recipe, craftingTable, cb) {
+    let craftWindow
     if (craftingTable) {
       bot.activateBlock(craftingTable)
       bot.once('windowOpen', (window) => {
@@ -35,8 +23,31 @@ function inject (bot, { version }) {
           cb(new Error('crafting: non craftingTable used as craftingTable'))
           return
         }
-        startClicking(window, 3, 3)
+        craftWindow = window
+        next()
       })
+    } else {
+      next()
+    }
+
+    function next (err) {
+      if (err) {
+        // Make sure to close the window
+        if (craftWindow && bot.currentWindow && craftWindow.id === bot.currentWindow.id) bot.closeWindow(craftWindow)
+        cb(err)
+      } else if (count > 0) {
+        count -= 1
+        craftOnce(recipe, craftWindow, next)
+      } else {
+        if (craftWindow) bot.closeWindow(craftWindow)
+        cb()
+      }
+    }
+  }
+
+  function craftOnce (recipe, window, cb) {
+    if (window) {
+      startClicking(window, 3, 3)
     } else {
       startClicking(bot.inventory, 2, 2)
     }
@@ -166,7 +177,7 @@ function inject (bot, { version }) {
           for (let i = 1; i <= w * h; i++) {
             window.updateSlot(i, null)
           }
-          closeTheWindow()
+          cb()
           return
         }
         const slotsToClick = []
@@ -192,7 +203,7 @@ function inject (bot, { version }) {
         function next () {
           const theSlot = slotsToClick.pop()
           if (!theSlot) {
-            closeTheWindow()
+            cb()
             return
           }
           bot.putAway(theSlot, (err) => {
@@ -203,11 +214,6 @@ function inject (bot, { version }) {
             }
           })
         }
-      }
-
-      function closeTheWindow () {
-        bot.closeWindow(window)
-        cb()
       }
 
       function slot (x, y) {


### PR DESCRIPTION
Right now the bot opens and closes the crafting table for every craft count that it wants to do. This opens the crafting table only once for all the crafts.