### PR TITLE
Promisify

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -407,12 +407,16 @@ Fires when the chest you are looking at is updated.
 
 #### chest.deposit(itemType, metadata, count, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
  * `itemType` - numerical item id
  * `metadata` - numerical value. `null` means match anything.
  * `count` - how many to deposit. `null` is an alias to 1.
  * `callback(err)` - (optional) - called when done depositing
 
 #### chest.withdraw(itemType, metadata, count, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `itemType` - numerical item id
  * `metadata` - numerical value. `null` means match anything.
@@ -454,19 +458,29 @@ Fires when a slot in the furnace you have open has updated.
 
 #### furnace.takeInput([callback])
 
+This function also returns a `Promise`, with `item` as its argument upon completion.
+
  * `callback(err, item)`
 
 #### furnace.takeFuel([callback])
+
+This function also returns a `Promise`, with `item` as its argument upon completion.
 
  * `callback(err, item)`
 
 #### furnace.takeOutput([callback])
 
+This function also returns a `Promise`, with `item` as its argument upon completion.
+
  * `callback(err, item)`
 
 #### furnace.putInput(itemType, metadata, count, [cb])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 #### furnace.putFuel(itemType, metadata, count, [cb])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 #### furnace.inputItem()
 
@@ -512,12 +526,16 @@ Returns a list of `Item` instances from the dispenser.
 
 #### dispenser.deposit(itemType, metadata, count, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
  * `itemType` - numerical item id
  * `metadata` - numerical value. `null` means match anything.
  * `count` - how many to deposit. `null` is an alias to 1.
  * `callback(err)` - (optional) - called when done depositing
 
 #### dispenser.withdraw(itemType, metadata, count, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `itemType` - numerical item id
  * `metadata` - numerical value. `null` means match anything.
@@ -582,14 +600,26 @@ Looks like:
 
 #### enchantmentTable.enchant(choice, [callback])
 
+This function also returns a `Promise`, with `item` as its argument upon completion.
+
  * `choice` - [0-2], the index of the enchantment you want to pick.
  * `callback(err, item)` - (optional) called when the item has been enchanted
 
 #### enchantmentTable.takeTargetItem([callback])
 
+This function also returns a `Promise`, with `item` as its argument upon completion.
+
  * `callback(err, item)`
 
 #### enchantmentTable.putTargetItem(item, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
+ * `callback(err)`
+
+ #### enchantmentTable.putLapis(item, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `callback(err)`
 
@@ -1275,6 +1305,8 @@ See `Block`.
 
 #### bot.waitForChunksToLoad(cb)
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 The cb gets called when many chunks have loaded.
 
 #### bot.blockInSight(maxSteps, vectorLength)
@@ -1341,6 +1373,8 @@ Gracefully disconnect from the server with the given reason (defaults to 'discon
 
 #### bot.tabComplete(str, cb, [assumeCommand], [sendBlockInSight])
 
+This function also returns a `Promise`, with `matches` as its argument upon completion.
+
 Requests chat completion from the server.
  * `str` - String to complete.
  * `callback(matches)`
@@ -1401,6 +1435,8 @@ Checks if the given plugin is loaded (or scheduled to be loaded) on this bot.
 
 #### bot.sleep(bedBlock, [cb])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Sleep in a bed. `bedBlock` should be a `Block` instance which is a bed. `cb` can have an err parameter if the bot cannot sleep.
 
 #### bot.isABed(bedBlock)
@@ -1408,6 +1444,8 @@ Sleep in a bed. `bedBlock` should be a `Block` instance which is a bed. `cb` can
 Return true if `bedBlock` is a bed
 
 #### bot.wake([cb])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Get out of bed. `cb` can have an err parameter if the bot cannot wake up.
 
@@ -1426,11 +1464,15 @@ Sets all controls to off.
 
 #### bot.lookAt(point, [force], [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
  * `point` [Vec3](https://github.com/andrewrk/node-vec3) instance - tilts your head so that it is directly facing this point.
  * `force` - See `force` in `bot.look`
  * `callback()` optional, called when you are looking at `point`
 
 #### bot.look(yaw, pitch, [force], [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Set the direction your head is facing.
 
@@ -1450,6 +1492,8 @@ Changes the text on the sign.
 
 #### bot.equip(item, destination, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Equips an item from your inventory.
 
  * `item` - `Item` instance. See `window.items()`.
@@ -1465,15 +1509,21 @@ Equips an item from your inventory.
 
 #### bot.unequip(destination, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Remove an article of equipment.
 
 #### bot.tossStack(item, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `item` - the stack of items you wish to toss
  * `callback(error)` - optional, called when tossing is done. if error is
    truthy, you were not able to complete the toss.
 
 #### bot.toss(itemType, metadata, count, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `itemType` - numerical id of the item you wish to toss
  * `metadata` - metadata of the item you wish to toss. Use `null`
@@ -1482,6 +1532,8 @@ Remove an article of equipment.
  * `callback(err)` - (optional) called once tossing is complete
 
 #### bot.dig(block, [forceLook = true], [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Begin digging into `block` with the currently equipped item.
 See also "diggingCompleted" and "diggingAborted" events.
@@ -1503,6 +1555,8 @@ Tells you how long it will take to dig the block, in milliseconds.
 
 #### bot.placeBlock(referenceBlock, faceVector, cb)
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
  * `referenceBlock` - the block you want to place a new block next to
  * `faceVector` - one of the six cardinal directions, such as `new Vec3(0, 1, 0)` for the top face,
    indicating which face of the `referenceBlock` to place the block against.
@@ -1512,6 +1566,8 @@ The new block will be placed at `referenceBlock.position.plus(faceVector)`.
 
 #### bot.activateBlock(block, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Punch a note block, open a door, etc.
 
  * `block` - the block to activate
@@ -1519,12 +1575,16 @@ Punch a note block, open a door, etc.
 
 #### bot.activateEntity(entity, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Activate an entity, useful for villager for example.
 
  * `entity` - the entity to activate
  * `callback(err)` - (optional) called when the entity has been activated
 
 #### bot.activateEntityAt(entity, position, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Activate an entity at the given position, useful for armor stands.
 
@@ -1534,11 +1594,15 @@ Activate an entity at the given position, useful for armor stands.
 
 #### bot.consume(callback)
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Eat / drink currently held item
 
  * `callback(error)` - called when consume ends
 
 #### bot.fish(callback)
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Use fishing rod
 
@@ -1591,6 +1655,8 @@ All the direction are relative to where the bot is looking at
 
 #### bot.craft(recipe, count, craftingTable, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
  * `recipe` - A `Recipe` instance. See `bot.recipesFor`.
  * `count` - How many times you wish to perform the operation.
    If you want to craft planks into `8` sticks, you would set
@@ -1602,6 +1668,8 @@ All the direction are relative to where the bot is looking at
    inventory is updated.
 
 #### bot.writeBook(slot, pages, [callback])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
  * `slot` is in inventory window coordinates (where 36 is the first quickbar slot, etc.).
  * `pages` is an array of strings represents the pages.
@@ -1659,13 +1727,19 @@ These are lower level methods for the inventory, they can be useful sometimes bu
 
 #### bot.clickWindow(slot, mouseButton, mode, cb)
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Click on the current window. See details at https://wiki.vg/Protocol#Click_Window
 
 #### bot.putSelectedItemRange(start, end, window, slot, cb)
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Put the item at `slot` in the specified range.
 
 #### bot.putAway(slot, cb)
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Put the item at `slot` in the inventory.
 
@@ -1674,6 +1748,8 @@ Put the item at `slot` in the inventory.
 Close the `window`.
 
 #### bot.transfer(options, cb)
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Transfer some kind of item from one range to an other. `options` is an object containing :
 
@@ -1698,6 +1774,8 @@ Open an entity with an inventory, for example a villager.
  * `Class` is the type of window that will be opened
 
 #### bot.moveSlotItem(sourceSlot, destSlot, cb)
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Move an item from `sourceSlot` to `destSlot` in the current window.
 
@@ -1725,6 +1803,8 @@ but it is assumed and often required that the bot be in creative mode for these 
 
 #### bot.creative.setInventorySlot(slot, item, [callback])
 
+This function also returns a `Promise`, with `void` as its argument upon completion.
+
 Gives the bot the specified item in the specified inventory slot.
 If called twice on the same slot before first callback exceeds, first callback will have an error parameter
 
@@ -1736,6 +1816,8 @@ If called twice on the same slot before first callback exceeds, first callback w
 If this method changes anything, you can be notified via `bot.inventory.on("windowUpdate")`.
 
 #### bot.creative.flyTo(destination, [cb])
+
+This function also returns a `Promise`, with `void` as its argument upon completion.
 
 Calls `startFlying()` and moves at a constant speed through 3d space in a straight line to the destination.
 `destination` is a `Vec3`, and often the `x` and `z` coordinates will end with `.5`.

--- a/examples/armor_stand.js
+++ b/examples/armor_stand.js
@@ -16,7 +16,7 @@ const bot = mineflayer.createBot({
   password: process.argv[5]
 })
 
-bot.on('chat', (username, message) => {
+bot.on('chat', async (username, message) => {
   const args = message.split(' ')
   if (args[0] !== 'equip' && args[0] !== 'unequip') return
 
@@ -44,20 +44,18 @@ bot.on('chat', (username, message) => {
       return
     }
 
-    bot.equip(armor, 'hand', () => {
-      bot.activateEntityAt(armorStand, armorStand.position)
-    })
+    await bot.equip(armor, 'hand')
+    bot.activateEntityAt(armorStand, armorStand.position)
   } else if (args[0] === 'unequip') {
-    bot.unequip('hand', () => {
-      if (args[1] === 'helmet') {
-        bot.activateEntityAt(armorStand, armorStand.position.offset(0, 1.8, 0))
-      } else if (args[1] === 'chestplate') {
-        bot.activateEntityAt(armorStand, armorStand.position.offset(0, 1.2, 0))
-      } else if (args[1] === 'leggings') {
-        bot.activateEntityAt(armorStand, armorStand.position.offset(0, 0.75, 0))
-      } else if (args[1] === 'boots') {
-        bot.activateEntityAt(armorStand, armorStand.position.offset(0, 0.1, 0))
-      }
-    })
+    await bot.unequip('hand')
+    if (args[1] === 'helmet') {
+      bot.activateEntityAt(armorStand, armorStand.position.offset(0, 1.8, 0))
+    } else if (args[1] === 'chestplate') {
+      bot.activateEntityAt(armorStand, armorStand.position.offset(0, 1.2, 0))
+    } else if (args[1] === 'leggings') {
+      bot.activateEntityAt(armorStand, armorStand.position.offset(0, 0.75, 0))
+    } else if (args[1] === 'boots') {
+      bot.activateEntityAt(armorStand, armorStand.position.offset(0, 0.1, 0))
+    }
   }
 })

--- a/examples/bee.js
+++ b/examples/bee.js
@@ -15,29 +15,20 @@ const bot = mineflayer.createBot({
 
 // /gamemode creative bee
 
-let i = 0
-function loop (n) {
-  if (i > n) {
-    bot.chat('My flight was amazing !')
-    return
+async function loop (n) {
+  for (let i = 0; i <= n; i++) {
+    const { position } = bot.entity
+    await bot.creative.flyTo(position.offset(Math.sin(i) * 2, 0.5, Math.cos(i) * 2))
   }
-  i += 1
-
-  const { position } = bot.entity
-
-  // Draw a spiral
-  bot.creative.flyTo(position.offset(Math.sin(i) * 2, 0.5, Math.cos(i) * 2), () => {
-    loop(n)
-  })
+  bot.chat('My flight was amazing !')
 }
 
-bot.on('chat', (username, message) => {
+bot.on('chat', async (username, message) => {
   if (username === bot.username) return
   switch (message) {
     case 'loaded':
-      bot.waitForChunksToLoad(() => {
-        bot.chat('Ready!')
-      })
+      await bot.waitForChunksToLoad()
+      bot.chat('Ready!')
       break
     case 'fly':
       bot.creative.startFlying()

--- a/examples/blockfinder.js
+++ b/examples/blockfinder.js
@@ -17,16 +17,15 @@ const bot = mineflayer.createBot({
   password: process.argv[5]
 })
 
-bot.on('chat', (username, message) => {
+bot.on('chat', async (username, message) => {
   if (username === bot.username) return
 
   const mcData = require('minecraft-data')(bot.version)
 
   if (message === 'loaded') {
     console.log(bot.entity.position)
-    bot.waitForChunksToLoad(() => {
-      bot.chat('Ready!')
-    })
+    await bot.waitForChunksToLoad()
+    bot.chat('Ready!')
   }
 
   if (message.startsWith('find')) {

--- a/examples/book.js
+++ b/examples/book.js
@@ -44,15 +44,14 @@ function toss () {
   bot.tossStack(book)
 }
 
-function write () {
+async function write () {
   const [book] = bot.inventory.items().filter(({ name }) => name === 'writable_book')
   if (!book) {
     bot.chat("I don't have a book.")
     return
   }
-  bot.writeBook(book.slot, pages, () => {
-    print()
-  })
+  await bot.writeBook(book.slot, pages)
+  print()
 }
 
 function print () {

--- a/examples/chest.js
+++ b/examples/chest.js
@@ -141,31 +141,29 @@ function watchChest (minecart) {
     bot.removeListener('chat', onChat)
   }
 
-  function withdrawItem (name, amount) {
+  async function withdrawItem (name, amount) {
     const item = itemByName(chest.items(), name)
     if (item) {
-      chest.withdraw(item.type, null, amount, (err) => {
-        if (err) {
-          bot.chat(`unable to withdraw ${amount} ${item.name}`)
-        } else {
-          bot.chat(`withdrew ${amount} ${item.name}`)
-        }
-      })
+      try {
+        await chest.withdraw(item.type, null, amount)
+        bot.chat(`withdrew ${amount} ${item.name}`)
+      } catch (err) {
+        bot.chat(`unable to withdraw ${amount} ${item.name}`)
+      }
     } else {
       bot.chat(`unknown item ${name}`)
     }
   }
 
-  function depositItem (name, amount) {
+  async function depositItem (name, amount) {
     const item = itemByName(bot.inventory.items(), name)
     if (item) {
-      chest.deposit(item.type, null, amount, (err) => {
-        if (err) {
-          bot.chat(`unable to deposit ${amount} ${item.name}`)
-        } else {
-          bot.chat(`deposited ${amount} ${item.name}`)
-        }
-      })
+      try {
+        await chest.deposit(item.type, null, amount)
+        bot.chat(`deposited ${amount} ${item.name}`)
+      } catch (err) {
+        bot.chat(`unable to deposit ${amount} ${item.name}`)
+      }
     } else {
       bot.chat(`unknown item ${name}`)
     }
@@ -308,31 +306,29 @@ function watchDispenser () {
     bot.removeListener('chat', onChat)
   }
 
-  function withdrawItem (name, amount) {
+  async function withdrawItem (name, amount) {
     const item = itemByName(dispenser.items(), name)
     if (item) {
-      dispenser.withdraw(item.type, null, amount, (err) => {
-        if (err) {
-          bot.chat(`unable to withdraw ${amount} ${item.name}`)
-        } else {
-          bot.chat(`withdrew ${amount} ${item.name}`)
-        }
-      })
+      try {
+        await dispenser.withdraw(item.type, null, amount)
+        bot.chat(`withdrew ${amount} ${item.name}`)
+      } catch (err) {
+        bot.chat(`unable to withdraw ${amount} ${item.name}`)
+      }
     } else {
       bot.chat(`unknown item ${name}`)
     }
   }
 
-  function depositItem (name, amount) {
+  async function depositItem (name, amount) {
     const item = itemByName(bot.inventory.items(), name)
     if (item) {
-      dispenser.deposit(item.type, null, amount, (err) => {
-        if (err) {
-          bot.chat(`unable to deposit ${amount} ${item.name}`)
-        } else {
-          bot.chat(`deposited ${amount} ${item.name}`)
-        }
-      })
+      try {
+        await dispenser.deposit(item.type, null, amount)
+        bot.chat(`deposited ${amount} ${item.name}`)
+      } catch (err) {
+        bot.chat(`unable to deposit ${amount} ${item.name}`)
+      }
     } else {
       bot.chat(`unknown item ${name}`)
     }
@@ -393,56 +389,52 @@ function watchEnchantmentTable () {
       table.close()
     }
 
-    function putItem (name) {
+    async function putItem (name) {
       const item = itemByName(table.window.items(), name)
       if (item) {
-        table.putTargetItem(item, (err) => {
-          if (err) {
-            bot.chat(`error putting ${itemToString(item)}`)
-          } else {
-            bot.chat(`I put ${itemToString(item)}`)
-          }
-        })
+        try {
+          await table.putTargetItem(item)
+          bot.chat(`I put ${itemToString(item)}`)
+        } catch (err) {
+          bot.chat(`error putting ${itemToString(item)}`)
+        }
       } else {
         bot.chat(`unknown item ${name}`)
       }
     }
 
-    function addLapis () {
+    async function addLapis () {
       const item = itemByType(table.window.items(), ['dye', 'purple_dye'].filter(name => mcData.itemByName[name] !== undefined)
         .map(name => mcData.itemByName[name].id))
       if (item) {
-        table.putLapis(item, (err) => {
-          if (err) {
-            bot.chat(`error putting ${itemToString(item)}`)
-          } else {
-            bot.chat(`I put ${itemToString(item)}`)
-          }
-        })
+        try {
+          await table.putLapis(item)
+          bot.chat(`I put ${itemToString(item)}`)
+        } catch (err) {
+          bot.chat(`error putting ${itemToString(item)}`)
+        }
       } else {
         bot.chat("I don't have any lapis")
       }
     }
 
-    function enchantItem (choice) {
+    async function enchantItem (choice) {
       choice = parseInt(choice, 10)
-      table.enchant(choice, (err, item) => {
-        if (err) {
-          bot.chat('error enchanting')
-        } else {
-          bot.chat(`enchanted ${itemToString(item)}`)
-        }
-      })
+      try {
+        const item = await table.enchant(choice)
+        bot.chat(`enchanted ${itemToString(item)}`)
+      } catch (err) {
+        bot.chat('error enchanting')
+      }
     }
 
-    function takeEnchantedItem () {
-      table.takeTargetItem((err, item) => {
-        if (err) {
-          bot.chat('error getting item')
-        } else {
-          bot.chat(`got ${itemToString(item)}`)
-        }
-      })
+    async function takeEnchantedItem () {
+      try {
+        const item = await table.takeTargetItem()
+        bot.chat(`got ${itemToString(item)}`)
+      } catch (err) {
+        bot.chat('error getting item')
+      }
     }
   }
 }

--- a/examples/digger.js
+++ b/examples/digger.js
@@ -25,13 +25,12 @@ const bot = mineflayer.createBot({
   password: process.argv[5]
 })
 
-bot.on('chat', (username, message) => {
+bot.on('chat', async (username, message) => {
   if (username === bot.username) return
   switch (message) {
     case 'loaded':
-      bot.waitForChunksToLoad(() => {
-        bot.chat('Ready!')
-      })
+      await bot.waitForChunksToLoad()
+      bot.chat('Ready!')
       break
     case 'list':
       sayItems()

--- a/examples/fisherman.js
+++ b/examples/fisherman.js
@@ -47,24 +47,23 @@ function onCollect (player, entity) {
   }
 }
 
-function startFishing () {
+async function startFishing () {
   bot.chat('Fishing')
-  bot.equip(mcData.itemsByName.fishing_rod.id, 'hand', (err) => {
-    if (err) {
-      return bot.chat(err.message)
-    }
+  try {
+    await bot.equip(mcData.itemsByName.fishing_rod.id, 'hand')
+  } catch (err) {
+    return bot.chat(err.message)
+  }
 
-    nowFishing = true
-    bot.on('playerCollect', onCollect)
+  nowFishing = true
+  bot.on('playerCollect', onCollect)
 
-    bot.fish((err) => {
-      nowFishing = false
-
-      if (err) {
-        bot.chat(err.message)
-      }
-    })
-  })
+  try {
+    await bot.fish()
+  } catch (err) {
+    bot.chat(err.message)
+  }
+  nowFishing = false
 }
 
 function stopFishing () {
@@ -75,18 +74,18 @@ function stopFishing () {
   }
 }
 
-function eat () {
+async function eat () {
   stopFishing()
 
-  bot.equip(mcData.itemsByName.fish.id, 'hand', (err) => {
-    if (err) {
-      return bot.chat(err.message)
-    }
+  try {
+    await bot.equip(mcData.itemsByName.fish.id, 'hand')
+  } catch (err) {
+    return bot.chat(err.message)
+  }
 
-    bot.consume((err) => {
-      if (err) {
-        return bot.chat(err.message)
-      }
-    })
-  })
+  try {
+    await bot.consume()
+  } catch (err) {
+    return bot.chat(err.message)
+  }
 }

--- a/examples/sleeper.js
+++ b/examples/sleeper.js
@@ -39,29 +39,26 @@ bot.on('wake', () => {
   bot.chat('Good morning!')
 })
 
-function goToSleep () {
+async function goToSleep () {
   const bed = bot.findBlock({
     matching: block => bot.isABed(block)
   })
   if (bed) {
-    bot.sleep(bed, (err) => {
-      if (err) {
-        bot.chat(`I can't sleep: ${err.message}`)
-      } else {
-        bot.chat("I'm sleeping")
-      }
-    })
+    try {
+      await bot.sleep(bed)
+      bot.chat("I'm sleeping")
+    } catch (err) {
+      bot.chat(`I can't sleep: ${err.message}`)
+    }
   } else {
     bot.chat('No nearby bed')
   }
 }
 
-function wakeUp () {
-  bot.wake((err) => {
-    if (err) {
-      bot.chat(`I can't wake up: ${err.message}`)
-    } else {
-      bot.chat('I woke up')
-    }
-  })
+async function wakeUp () {
+  try {
+    await bot.wake()
+  } catch (err) {
+    bot.chat(`I can't wake up: ${err.message}`)
+  }
 }

--- a/examples/tab_complete.js
+++ b/examples/tab_complete.js
@@ -20,13 +20,12 @@ bot.on('message', (cm) => {
   }
 })
 
-function complete (str) {
-  bot.tabComplete(str, (err, matches) => {
-    if (err) {
-      return bot.chat(err.message)
-    }
-
+async function complete (str) {
+  try {
+    const matches = await bot.tabComplete(str)
     console.log(str, matches)
     bot.chat(`Matches for "${str}": ${matches.join(', ')}`)
-  })
+  } catch (err) {
+    bot.chat(err.message)
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -663,14 +663,16 @@ export class Dispenser extends (EventEmitter as new () => TypedEmitter<StorageEv
   deposit(
     itemType: number,
     metadata: number | null,
-    count: number | null
-  ): void;
+    count: number | null,
+    cb?: (err?: Error) => void
+  ): Promise<void>;
 
   withdraw(
     itemType: number,
     metadata: number | null,
-    count: number | null
-  ): void;
+    count: number | null,
+    cb?: (err?: Error) => void
+  ): Promise<void>;
 
   count(itemType: number, metadata: number | null): number;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -237,14 +237,14 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   clearControlStates(): void;
 
-  lookAt(point: Vec3, force?: boolean, callback?: () => void): void;
+  lookAt(point: Vec3, force?: boolean, callback?: () => void): Promise<void>;
 
   look(
     yaw: number,
     pitch: number,
     force?: boolean,
     callback?: () => void
-  ): void;
+  ): Promise<void>;
 
   updateSign(block: Block, text: string): void;
 
@@ -252,23 +252,23 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     item: Item,
     destination: EquipmentDestination | null,
     callback?: (error?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   unequip(
     destination: EquipmentDestination | null,
     callback?: () => void
-  ): void;
+  ): Promise<void>;
 
-  tossStack(item: Item, callback?: (error?: Error) => void): void;
+  tossStack(item: Item, callback?: (error?: Error) => void): Promise<void>;
 
   toss(
     itemType: number,
     metadata: number | null,
     count: number | null,
     callback?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
-  dig(block: Block, callback?: (err?: Error) => void): void;
+  dig(block: Block, callback?: (err?: Error) => void): Promise<void>;
 
   stopDigging(): void;
 
@@ -276,15 +276,15 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   placeBlock(referenceBlock: Block, faceVector: Vec3, cb: () => void): Promise<void>;
 
-  activateBlock(block: Block, callback?: (err?: Error) => void): void;
+  activateBlock(block: Block, callback?: (err?: Error) => void): Promise<void>;
 
-  activateEntity(block: Entity, callback?: (err?: Error) => void): void;
+  activateEntity(block: Entity, callback?: (err?: Error) => void): Promise<void>;
 
-  activateEntityAt(block: Entity, position: Vec3, callback?: (err?: Error) => void): void;
+  activateEntityAt(block: Entity, position: Vec3, callback?: (err?: Error) => void): Promise<void>;
 
-  consume(callback: (err?: Error) => void): void;
+  consume(callback: (err?: Error) => void): Promise<void>;
 
-  fish(callback: (err?: Error) => void): void;
+  fish(callback: (err?: Error) => void): Promise<void>;
 
   activateItem(offhand?: boolean): void;
 
@@ -309,13 +309,13 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     count: number | null,
     craftingTable: Block,
     callback?: () => void
-  ): void;
+  ): Promise<void>;
 
   writeBook(
     slot: number,
     pages: Array<string>,
     callback?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   openChest(chest: Block | Entity): Chest;
 
@@ -551,7 +551,7 @@ export interface creativeMethods {
     slot: number,
     item: Item | null,
     callback?: (error?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   flyTo(destination: Vec3, cb?: () => void): Promise<void>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -211,7 +211,7 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     cb: (matches: Array<string>) => void,
     assumeCommand?: boolean,
     sendBlockInSight?: boolean
-  ): void;
+  ): Promise<Array<string>>;
 
   chat(message: string): void;
 
@@ -227,11 +227,11 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   hasPlugin(plugin: Plugin): boolean;
 
-  sleep(bedBlock: Block, cb?: (err?: Error) => void): void;
+  sleep(bedBlock: Block, cb?: (err?: Error) => void): Promise<void>;
 
   isABed(bedBlock: Block): void;
 
-  wake(cb?: (err?: Error) => void): void;
+  wake(cb?: (err?: Error) => void): Promise<void>;
 
   setControlState(control: ControlState, state: boolean): void;
 
@@ -274,7 +274,7 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
 
   digTime(block: Block): number;
 
-  placeBlock(referenceBlock: Block, faceVector: Vec3, cb: () => void): void;
+  placeBlock(referenceBlock: Block, faceVector: Vec3, cb: () => void): Promise<void>;
 
   activateBlock(block: Block, callback?: (err?: Error) => void): void;
 
@@ -344,7 +344,7 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     mouseButton: number,
     mode: number,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   putSelectedItemRange(
     start: number,
@@ -352,13 +352,13 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     window: Window,
     slot: any,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
-  putAway(slot: number, cb?: (err?: Error) => void): void;
+  putAway(slot: number, cb?: (err?: Error) => void): Promise<void>;
 
   closeWindow(window: Window): void;
 
-  transfer(options: TransferOptions, cb?: (err?: Error) => void): void;
+  transfer(options: TransferOptions, cb?: (err?: Error) => void): Promise<void>;
 
   openBlock(block: Block, Class: new () => EventEmitter): void;
 
@@ -368,13 +368,13 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     sourceSlot: number,
     destSlot: number,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   updateHeldItem(): void;
 
   getEquipmentDestSlot(destination: string): number;
 
-  waitForChunksToLoad(cb?: (err?: Error) => void): void;
+  waitForChunksToLoad(cb?: (err?: Error) => void): Promise<void>;
 
   nearestEntity(filter?: (entity: Entity) => boolean): Entity | null;
 }
@@ -553,7 +553,7 @@ export interface creativeMethods {
     callback?: (error?: Error) => void
   ): void;
 
-  flyTo(destination: Vec3, cb?: () => void): void;
+  flyTo(destination: Vec3, cb?: () => void): Promise<void>;
 
   startFlying(): void;
 
@@ -606,14 +606,14 @@ export class Chest extends (EventEmitter as new () => TypedEmitter<StorageEvents
     metadata: number | null,
     count: number | null,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   withdraw(
     itemType: number,
     metadata: number | null,
     count: number | null,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   count(itemType: number, metadata: number | null): number;
 
@@ -628,25 +628,25 @@ export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEven
 
   close(): void;
 
-  takeInput(cb: (err: Error | null, item: Item) => void): void;
+  takeInput(cb: (err: Error | null, item: Item) => void): Promise<Item>;
 
-  takeFuel(cb: (err: Error | null, item: Item) => void): void;
+  takeFuel(cb: (err: Error | null, item: Item) => void): Promise<Item>;
 
-  takeOutput(cb: (err: Error | null, item: Item) => void): void;
+  takeOutput(cb: (err: Error | null, item: Item) => void): Promise<Item>;
 
   putInput(
     itemType: number,
     metadata: number | null,
     count: number,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   putFuel(
     itemType: number,
     metadata: number | null,
     count: number,
     cb?: (err?: Error) => void
-  ): void;
+  ): Promise<void>;
 
   inputItem(): Item;
 
@@ -689,13 +689,13 @@ export class EnchantmentTable extends (EventEmitter as new () => TypedEmitter<Co
   enchant(
     choice: string | number,
     cb?: (err: Error | null, item: Item) => void
-  ): void;
+  ): Promise<Item>;
 
-  takeTargetItem(cb?: (err: Error | null, item: Item) => void): void;
+  takeTargetItem(cb?: (err: Error | null, item: Item) => void): Promise<Item>;
 
-  putTargetItem(item: Item, cb?: (err: Error | null, item: Item) => void): void;
+  putTargetItem(item: Item, cb?: (err: Error | null) => void): Promise<Item>;
 
-  putLapis(item: Item, cb?: (err: Error | null, item: Item) => void): void;
+  putLapis(item: Item, cb?: (err: Error | null) => void): Promise<Item>;
 }
 
 export type Enchantment = {

--- a/index.js
+++ b/index.js
@@ -109,7 +109,6 @@ class Bot extends EventEmitter {
     self._client.on('end', () => {
       self.emit('end')
     })
-    self._internalEvents = new EventEmitter()
     if (!self._client.wait_connect) next()
     else self._client.once('connect_allowed', next)
     function next () {

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ class Bot extends EventEmitter {
   constructor () {
     super()
     this._client = null
+    this._internalEvents = new EventEmitter()
   }
 
   connect (options) {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,6 @@ class Bot extends EventEmitter {
   constructor () {
     super()
     this._client = null
-    this._internalEvents = new EventEmitter()
   }
 
   connect (options) {

--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ class Bot extends EventEmitter {
     self._client.on('end', () => {
       self.emit('end')
     })
+    self._internalEvents = new EventEmitter()
     if (!self._client.wait_connect) next()
     else self._client.once('connect_allowed', next)
     function next () {

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -4,8 +4,11 @@ module.exports = inject
 
 const CARDINAL_DIRECTIONS = ['south', 'west', 'north', 'east']
 
-function noop (err) {
-  if (err) throw err
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }
 
 function inject (bot) {
@@ -69,34 +72,32 @@ function inject (bot) {
     return metadata
   }
 
-  function wake (cb) {
+  async function wake () {
     if (!bot.isSleeping) {
-      cb(new Error('already awake'))
+      throw new Error('already awake')
     } else {
       bot._client.write('entity_action', {
         entityId: bot.entity.id,
         actionId: 2,
         jumpBoost: 0
       })
-      cb()
     }
   }
 
-  function sleep (bedBlock, cb) {
-    cb = cb || noop
+  async function sleep (bedBlock) {
     if (!(bot.time.timeOfDay >= 12541 && bot.time.timeOfDay <= 23458)) {
-      cb(new Error("it's not night"))
+      throw new Error("it's not night")
     } else if (bot.isSleeping) {
-      cb(new Error('already sleeping'))
+      throw new Error('already sleeping')
     } else if (!isABed(bedBlock)) {
-      cb(new Error('wrong block : not a bed block'))
+      throw new Error('wrong block : not a bed block')
     } else {
       const botPos = bot.entity.position.floored()
       const metadata = parseBedMetadata(bedBlock)
       let headPoint = bedBlock.position
 
       if (metadata.occupied) {
-        return cb(new Error('the bed is occupied'))
+        throw new Error('the bed is occupied')
       }
 
       if (!metadata.part) { // Is foot
@@ -112,13 +113,13 @@ function inject (bot) {
             headPoint = bedBlock.position
             bedBlock = lowerBlock
           } else {
-            return cb(new Error("there's only half bed"))
+            throw new Error("there's only half bed")
           }
         }
       }
 
       if (!bot.canDigBlock(bedBlock)) {
-        return cb(new Error('cant click the bed'))
+        throw new Error('cant click the bed')
       }
 
       const clickRange = [2, -3, -3, 2] // [south, west, north, east]
@@ -134,7 +135,7 @@ function inject (bot) {
       const nwClickCorner = headPoint.offset(clickRange[1], -2, clickRange[2]) // North-West lower corner
       const seClickCorner = headPoint.offset(clickRange[3], 2, clickRange[0]) // South-East upper corner
       if (botPos.x > seClickCorner.x || botPos.x < nwClickCorner.x || botPos.y > seClickCorner.y || botPos.y < nwClickCorner.y || botPos.z > seClickCorner.z || botPos.z < nwClickCorner.z) {
-        return cb(new Error('the bed is too far'))
+        throw new Error('the bed is too far')
       }
 
       if (bot.gameMode !== 'creative' || bot.supportFeature('creativeSleepNearMobs')) { // If in creative mode the bot should be able to sleep even if there are monster nearby (starting in 1.13)
@@ -146,13 +147,13 @@ function inject (bot) {
           if (entity.kind === 'Hostile mobs') {
             const entityPos = entity.position.floored()
             if (entityPos.x <= seMonsterCorner.x && entityPos.x >= nwMonsterCorner.x && entityPos.y <= seMonsterCorner.y && entityPos.y >= nwMonsterCorner.y && entityPos.z <= seMonsterCorner.z && entityPos.z >= nwMonsterCorner.z) {
-              return cb(new Error('there are monsters nearby'))
+              throw new Error('there are monsters nearby')
             }
           }
         }
       }
 
-      bot.activateBlock(bedBlock, cb)
+      await bot.activateBlock(bedBlock)
     }
   }
 
@@ -178,7 +179,7 @@ function inject (bot) {
   })
 
   bot.parseBedMetadata = parseBedMetadata
-  bot.wake = wake
-  bot.sleep = sleep
+  bot.wake = callbackify(wake)
+  bot.sleep = callbackify(sleep)
   bot.isABed = isABed
 }

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -6,7 +6,7 @@ const CARDINAL_DIRECTIONS = ['south', 'west', 'north', 'east']
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }
@@ -180,6 +180,6 @@ function inject (bot) {
 
   bot.parseBedMetadata = parseBedMetadata
   bot.wake = callbackify(wake)
-  bot.sleep = callbackify(sleep)
+  bot.sleep = sleep
   bot.isABed = isABed
 }

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -1,15 +1,9 @@
 const Vec3 = require('vec3').Vec3
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
 const CARDINAL_DIRECTIONS = ['south', 'west', 'north', 'east']
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
-}
 
 function inject (bot) {
   bot.isSleeping = false

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -180,6 +180,6 @@ function inject (bot) {
 
   bot.parseBedMetadata = parseBedMetadata
   bot.wake = callbackify(wake)
-  bot.sleep = sleep
+  bot.sleep = callbackify(sleep)
   bot.isABed = isABed
 }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -110,19 +110,21 @@ function inject (bot, { version, storageBuilder }) {
     bot.emit('chunkColumnLoad', columnCorner)
   }
 
-  function waitForChunksToLoad (cb) {
+  async function waitForChunksToLoad () {
     // check 5x5 chunks around us
     for (let x = -2; x <= 2; x++) {
       for (let y = -2; y <= 2; y++) {
         if (bot.world.getColumnAt(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16))) == null) {
           // keep wait
-          return setTimeout(() => {
-            waitForChunksToLoad(cb)
-          }, 100)
+          return new Promise((resolve) =>
+            setTimeout(async () => {
+              await waitForChunksToLoad()
+              resolve()
+            }, 100)
+          )
         }
       }
     }
-    cb()
   }
 
   function getMatchingFunction (matching) {
@@ -495,7 +497,7 @@ function inject (bot, { version, storageBuilder }) {
   bot.blockAt = blockAt
   bot._updateBlockState = updateBlockState
   bot._blockEntities = blockEntities
-  bot.waitForChunksToLoad = waitForChunksToLoad
+  bot.waitForChunksToLoad = callbackify(waitForChunksToLoad)
 }
 
 function onesInShort (n) {
@@ -505,4 +507,11 @@ function onesInShort (n) {
     count = ((1 << i) & n) ? count + 1 : count
   }
   return count
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -511,7 +511,7 @@ function onesInShort (n) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -116,12 +116,8 @@ function inject (bot, { version, storageBuilder }) {
       for (let y = -2; y <= 2; y++) {
         if (bot.world.getColumnAt(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16))) == null) {
           // keep wait
-          return new Promise((resolve) =>
-            setTimeout(async () => {
-              await waitForChunksToLoad()
-              resolve()
-            }, 100)
-          )
+         await new Promise(resolve => setTimeout(resolve, 100))
+         await waitForChunksToLoad()
         }
       }
     }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -2,6 +2,7 @@ const Vec3 = require('vec3').Vec3
 const assert = require('assert')
 const Painting = require('../painting')
 const Location = require('../location')
+const { callbackify, sleep } = require('../promise_utils')
 
 const { OctahedronIterator } = require('../iterators')
 
@@ -116,7 +117,7 @@ function inject (bot, { version, storageBuilder }) {
       for (let y = -2; y <= 2; y++) {
         if (bot.world.getColumnAt(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16))) == null) {
           // keep wait
-          await new Promise(resolve => setTimeout(resolve, 100))
+          await sleep(100)
           await waitForChunksToLoad()
         }
       }
@@ -503,11 +504,4 @@ function onesInShort (n) {
     count = ((1 << i) & n) ? count + 1 : count
   }
   return count
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -116,8 +116,8 @@ function inject (bot, { version, storageBuilder }) {
       for (let y = -2; y <= 2; y++) {
         if (bot.world.getColumnAt(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16))) == null) {
           // keep wait
-         await new Promise(resolve => setTimeout(resolve, 100))
-         await waitForChunksToLoad()
+          await new Promise(resolve => setTimeout(resolve, 100))
+          await waitForChunksToLoad()
         }
       }
     }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -40,12 +40,13 @@ function inject (bot, { version }) {
     bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
 
     const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
-    const response = once(bot, 'setSlot:0')
     editBook(modifiedBook, signing)
-    let [, newItem] = await response
-    while (newItem.slot !== slot) {
+
+    let newItem
+    do {
       [, newItem] = await once(bot, 'setSlot:0')
     }
+    while (newItem.slot !== slot)
 
     bot.setQuickBarSlot(quickBarSlot)
 
@@ -83,13 +84,12 @@ function inject (bot, { version }) {
         value: pages
       }
     }
-    const response = once(bot.inventory, 'windowUpdate')
     bot.inventory.updateSlot(slot, book)
-    let [updatedSlot] = await response
 
-    while (updatedSlot !== slot) {
+    let updatedSlot
+    do {
       [updatedSlot] = await once(bot.inventory, 'windowUpdate')
-    }
+    } while (updatedSlot !== slot)
 
     return book
   }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -45,9 +45,9 @@ function inject (bot, { version }) {
 
     bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
 
-    const book = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
+    const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
     const response = once(bot, 'setSlot:0')
-    editBook(book, signing)
+    editBook(modifiedBook, signing)
     let [oldItem, newItem] = await response
     while (newItem.slot !== slot) {
       [oldItem, newItem] = await once(bot, 'setSlot:0')

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -48,9 +48,9 @@ function inject (bot, { version }) {
     const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
     const response = once(bot, 'setSlot:0')
     editBook(modifiedBook, signing)
-    let [oldItem, newItem] = await response
+    let [, newItem] = await response
     while (newItem.slot !== slot) {
-      [oldItem, newItem] = await once(bot, 'setSlot:0')
+      [, newItem] = await once(bot, 'setSlot:0')
     }
 
     bot.setQuickBarSlot(quickBarSlot)

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -84,12 +84,13 @@ function inject (bot, { version }) {
         value: pages
       }
     }
+    const response = once(bot.inventory, 'windowUpdate')
     bot.inventory.updateSlot(slot, book)
+    let [updatedSlot] = await response
 
-    let updatedSlot
-    do {
+    while (updatedSlot !== slot) {
       [updatedSlot] = await once(bot.inventory, 'windowUpdate')
-    } while (updatedSlot !== slot)
+    }
 
     return book
   }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { once } = require('events')
 
 module.exports = inject
 
@@ -36,35 +37,26 @@ function inject (bot, { version }) {
     const book = bot.inventory.slots[slot]
     assert.ok(book && book.type === mcData.itemsByName.writable_book.id, `no book found in slot ${slot}`)
     const quickBarSlot = bot.quickBarSlot
+    const moveToQuickBar = slot < 36
 
-    if (slot < 36) {
+    if (moveToQuickBar) {
       await bot.moveSlotItem(slot, 36)
-      bot.setQuickBarSlot(0)
-      const book = await modifyBook(36, pages, author, title, signing)
-      return new Promise(resolve => {
-        async function onSetInvSlot (oldItem, newItem) {
-          if (newItem.slot !== slot) return
-          bot.removeListener('setSlot:0', onSetInvSlot)
-          bot.setQuickBarSlot(quickBarSlot)
-          await bot.moveSlotItem(36, slot)
-          resolve()
-        }
-        bot.on('setSlot:0', onSetInvSlot)
-        editBook(book, signing)
-      })
-    } else {
-      bot.setQuickBarSlot(slot - 36)
-      const book = await modifyBook(slot, pages, author, title, signing)
-      return new Promise(resolve => {
-        function onSetInvSlot (oldItem, newItem) {
-          if (newItem.slot !== slot) return
-          bot.removeListener('setSlot:0', onSetInvSlot)
-          bot.setQuickBarSlot(quickBarSlot)
-          resolve()
-        }
-        bot.on('setSlot:0', onSetInvSlot)
-        editBook(book, signing)
-      })
+    }
+
+    bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
+
+    const book = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
+    const response = once(bot, 'setSlot:0')
+    editBook(book, signing)
+    let [oldItem, newItem] = await response
+    while (newItem.slot !== slot) {
+      [oldItem, newItem] = await once(bot, 'setSlot:0')
+    }
+
+    bot.setQuickBarSlot(quickBarSlot)
+
+    if (moveToQuickBar) {
+      await bot.moveSlotItem(36, slot)
     }
   }
 
@@ -97,17 +89,15 @@ function inject (bot, { version }) {
         value: pages
       }
     }
-    return new Promise(resolve => {
-      function onUpdate (updatedSlot) {
-        if (updatedSlot === slot) {
-          bot.inventory.removeListener('windowUpdate', onUpdate)
-          resolve(book)
-        }
-      }
+    const response = once(bot.inventory, 'windowUpdate')
+    bot.inventory.updateSlot(slot, book)
+    let [updatedSlot] = await response
 
-      bot.inventory.on('windowUpdate', onUpdate)
-      bot.inventory.updateSlot(slot, book)
-    })
+    while (updatedSlot !== slot) {
+      [updatedSlot] = await once(bot.inventory, 'windowUpdate')
+    }
+
+    return book
   }
 
   bot.writeBook = callbackify(async (slot, pages) => {

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -1,14 +1,8 @@
 const assert = require('assert')
 const { once } = require('events')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
-}
 
 function inject (bot, { version }) {
   const mcData = require('minecraft-data')(version)

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -40,13 +40,12 @@ function inject (bot, { version }) {
     bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
 
     const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
+    const response = once(bot, 'setSlot:0')
     editBook(modifiedBook, signing)
-
-    let newItem
-    do {
+    let [, newItem] = await response
+    while (newItem.slot !== slot) {
       [, newItem] = await once(bot, 'setSlot:0')
     }
-    while (newItem.slot !== slot)
 
     bot.setQuickBarSlot(quickBarSlot)
 
@@ -84,12 +83,13 @@ function inject (bot, { version }) {
         value: pages
       }
     }
+    const response = once(bot.inventory, 'windowUpdate')
     bot.inventory.updateSlot(slot, book)
+    let [updatedSlot] = await response
 
-    let updatedSlot
-    do {
+    while (updatedSlot !== slot) {
       [updatedSlot] = await once(bot.inventory, 'windowUpdate')
-    } while (updatedSlot !== slot)
+    }
 
     return book
   }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -4,7 +4,7 @@ module.exports = inject
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -84,13 +84,12 @@ function inject (bot, { version }) {
         value: pages
       }
     }
-    const response = once(bot.inventory, 'windowUpdate')
     bot.inventory.updateSlot(slot, book)
-    let [updatedSlot] = await response
 
-    while (updatedSlot !== slot) {
+    let updatedSlot
+    do {
       [updatedSlot] = await once(bot.inventory, 'windowUpdate')
-    }
+    } while (updatedSlot !== slot)
 
     return book
   }

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -40,12 +40,11 @@ function inject (bot, { version }) {
     bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
 
     const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
-    const response = once(bot, 'setSlot:0')
     editBook(modifiedBook, signing)
-    let [, newItem] = await response
-    while (newItem.slot !== slot) {
+    let newItem
+    do {
       [, newItem] = await once(bot, 'setSlot:0')
-    }
+    } while (newItem.slot !== slot)
 
     bot.setQuickBarSlot(quickBarSlot)
 

--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -2,8 +2,11 @@ const assert = require('assert')
 
 module.exports = inject
 
-function noop (err) {
-  if (err) throw err
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }
 
 function inject (bot, { version }) {
@@ -28,36 +31,36 @@ function inject (bot, { version }) {
     }
   }
 
-  function write (slot, pages, author, title, signing, cb = noop) {
+  async function write (slot, pages, author, title, signing) {
     assert.ok(slot >= 0 && slot <= 44, 'slot out of inventory range')
     const book = bot.inventory.slots[slot]
     assert.ok(book && book.type === mcData.itemsByName.writable_book.id, `no book found in slot ${slot}`)
     const quickBarSlot = bot.quickBarSlot
 
     if (slot < 36) {
-      bot.moveSlotItem(slot, 36, (err) => {
-        if (err) return cb(err)
-        bot.setQuickBarSlot(0)
-        modifyBook(36, pages, author, title, signing, (book) => {
-          function onSetInvSlot (oldItem, newItem) {
-            if (newItem.slot !== slot) return
-            bot.removeListener('setSlot:0', onSetInvSlot)
-            bot.setQuickBarSlot(quickBarSlot)
-            bot.moveSlotItem(36, slot, cb)
-            cb()
-          }
-          bot.on('setSlot:0', onSetInvSlot)
-          editBook(book, signing)
-        })
+      await bot.moveSlotItem(slot, 36)
+      bot.setQuickBarSlot(0)
+      const book = await modifyBook(36, pages, author, title, signing)
+      return new Promise(resolve => {
+        async function onSetInvSlot (oldItem, newItem) {
+          if (newItem.slot !== slot) return
+          bot.removeListener('setSlot:0', onSetInvSlot)
+          bot.setQuickBarSlot(quickBarSlot)
+          await bot.moveSlotItem(36, slot)
+          resolve()
+        }
+        bot.on('setSlot:0', onSetInvSlot)
+        editBook(book, signing)
       })
     } else {
       bot.setQuickBarSlot(slot - 36)
-      modifyBook(slot, pages, author, title, signing, (book) => {
+      const book = await modifyBook(slot, pages, author, title, signing)
+      return new Promise(resolve => {
         function onSetInvSlot (oldItem, newItem) {
           if (newItem.slot !== slot) return
           bot.removeListener('setSlot:0', onSetInvSlot)
           bot.setQuickBarSlot(quickBarSlot)
-          cb()
+          resolve()
         }
         bot.on('setSlot:0', onSetInvSlot)
         editBook(book, signing)
@@ -65,7 +68,7 @@ function inject (bot, { version }) {
     }
   }
 
-  function modifyBook (slot, pages, author, title, signing, cb) {
+  async function modifyBook (slot, pages, author, title, signing) {
     const book = Object.assign({}, bot.inventory.slots[slot])
     if (!book.nbt || book.nbt.type !== 'compound') {
       book.nbt = {
@@ -94,22 +97,24 @@ function inject (bot, { version }) {
         value: pages
       }
     }
-    bot.inventory.on('windowUpdate', onUpdate)
-    bot.inventory.updateSlot(slot, book)
-
-    function onUpdate (updatedSlot) {
-      if (updatedSlot === slot) {
-        bot.inventory.removeListener('windowUpdate', onUpdate)
-        cb(book)
+    return new Promise(resolve => {
+      function onUpdate (updatedSlot) {
+        if (updatedSlot === slot) {
+          bot.inventory.removeListener('windowUpdate', onUpdate)
+          resolve(book)
+        }
       }
-    }
+
+      bot.inventory.on('windowUpdate', onUpdate)
+      bot.inventory.updateSlot(slot, book)
+    })
   }
 
-  bot.writeBook = (slot, pages, cb = noop) => {
-    write(slot, pages, null, null, false, cb)
-  }
+  bot.writeBook = callbackify(async (slot, pages) => {
+    await write(slot, pages, null, null, false)
+  })
 
-  bot.signBook = (slot, pages, author, title, cb = noop) => {
-    write(slot, pages, author, title, true, cb)
-  }
+  bot.signBook = callbackify(async (slot, pages, author, title) => {
+    await write(slot, pages, author, title, true)
+  })
 }

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -99,7 +99,7 @@ function inject (bot, options) {
     })
   }
 
-  function tabComplete (text, cb, assumeCommand = false, sendBlockInSight = true) {
+  async function tabComplete (text, assumeCommand = false, sendBlockInSight = true) {
     let position
 
     if (sendBlockInSight) {
@@ -110,14 +110,16 @@ function inject (bot, options) {
       }
     }
 
-    bot._client.once('tab_complete', (packet) => {
-      cb(undefined, packet.matches)
-    })
+    return new Promise(resolve => {
+      bot._client.once('tab_complete', (packet) => {
+        resolve(packet.matches)
+      })
 
-    bot._client.write('tab_complete', {
-      text,
-      assumeCommand,
-      lookedAtBlock: position
+      bot._client.write('tab_complete', {
+        text,
+        assumeCommand,
+        lookedAtBlock: position
+      })
     })
   }
 
@@ -128,5 +130,13 @@ function inject (bot, options) {
     chatWithHeader('', message)
   }
 
-  bot.tabComplete = tabComplete
+  bot.tabComplete = callbackify(tabComplete)
+}
+
+function callbackify (f) { // specifically for this function because cb isn't the last parameter
+  return function (...args) {
+    const cb = args[1] || (() => {})
+    if (cb) args.splice(1, 1)
+    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,4 +1,5 @@
 const PROTO_VER_1_10 = require('minecraft-data')('1.10.2').version.version
+const { once } = require('events')
 
 module.exports = inject
 
@@ -110,17 +111,16 @@ function inject (bot, options) {
       }
     }
 
-    return new Promise(resolve => {
-      bot._client.once('tab_complete', (packet) => {
-        resolve(packet.matches)
-      })
+    const response = once(bot._client, 'tab_complete')
 
-      bot._client.write('tab_complete', {
-        text,
-        assumeCommand,
-        lookedAtBlock: position
-      })
+    bot._client.write('tab_complete', {
+      text,
+      assumeCommand,
+      lookedAtBlock: position
     })
+
+    const [packet] = await response
+    return packet.matches
   }
 
   bot.whisper = (username, message) => {

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -111,13 +111,15 @@ function inject (bot, options) {
       }
     }
 
+    const response = once(bot._client, 'tab_complete')
+
     bot._client.write('tab_complete', {
       text,
       assumeCommand,
       lookedAtBlock: position
     })
 
-    const [packet] = await once(bot._client, 'tab_complete')
+    const [packet] = await response
     return packet.matches
   }
 

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -135,8 +135,8 @@ function inject (bot, options) {
 
 function callbackify (f) { // specifically for this function because cb isn't the last parameter
   return function (...args) {
-    const cb = args[1] || (() => {})
-    if (cb) args.splice(1, 1)
+    const cb = args[1]
+    args.splice(1, 1)
     return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -111,15 +111,13 @@ function inject (bot, options) {
       }
     }
 
-    const response = once(bot._client, 'tab_complete')
-
     bot._client.write('tab_complete', {
       text,
       assumeCommand,
       lookedAtBlock: position
     })
 
-    const [packet] = await response
+    const [packet] = await once(bot._client, 'tab_complete')
     return packet.matches
   }
 

--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -1,5 +1,6 @@
 const Chest = require('../chest')
 const assert = require('assert')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -55,11 +56,4 @@ function inject (bot, { version }) {
   }
 
   bot.openChest = openChest
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -59,7 +59,7 @@ function inject (bot, { version }) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -22,10 +22,10 @@ function inject (bot, { version }) {
     } else {
       assert.ok(false, 'chestToOpen is neither block nor entity')
     }
-    chest.withdraw = withdraw
-    chest.deposit = deposit
+    chest.withdraw = callbackify(withdraw)
+    chest.deposit = callbackify(deposit)
     return chest
-    function deposit (itemType, metadata, count, cb) {
+    async function deposit (itemType, metadata, count) {
       const options = {
         window: chest.window,
         itemType,
@@ -36,10 +36,10 @@ function inject (bot, { version }) {
         destStart: 0,
         destEnd: chest.window.inventoryStart
       }
-      bot.transfer(options, cb)
+      await bot.transfer(options)
     }
 
-    function withdraw (itemType, metadata, count, cb) {
+    async function withdraw (itemType, metadata, count) {
       const options = {
         window: chest.window,
         itemType,
@@ -50,9 +50,16 @@ function inject (bot, { version }) {
         destStart: chest.window.inventoryStart,
         destEnd: chest.window.inventoryEnd
       }
-      bot.transfer(options, cb)
+      await bot.transfer(options)
     }
   }
 
   bot.openChest = openChest
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const { once } = require('events')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -236,11 +237,4 @@ function inject (bot, { version }) {
   bot.craft = callbackify(craft)
   bot.recipesFor = recipesFor
   bot.recipesAll = recipesAll
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -243,7 +243,7 @@ function inject (bot, { version }) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -20,14 +20,12 @@ function inject (bot, { version }) {
   async function craftOnce (recipe, craftingTable) {
     if (craftingTable) {
       bot.activateBlock(craftingTable)
-      return new Promise(resolve => {
-        bot.once('windowOpen', async (window) => {
-          if (!window.type.startsWith('minecraft:crafting')) {
-            throw new Error('crafting: non craftingTable used as craftingTable')
-          }
-          await startClicking(window, 3, 3)
-          resolve()
-        })
+const [window] = await once(bot, 'windowOpen')
+if (!window.type.startsWith('minecraft:crafting')) {
+  throw new Error('crafting: non craftingTable used as craftingTable')
+}
+await startClicking(window, 3, 3)
+
       })
     } else {
       await startClicking(bot.inventory, 2, 2)

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -6,42 +6,34 @@ function inject (bot, { version }) {
   const Item = require('prismarine-item')(version)
   const Recipe = require('prismarine-recipe')(version).Recipe
 
-  function craft (recipe, count, craftingTable, cb) {
+  async function craft (recipe, count, craftingTable) {
     assert.ok(recipe)
-    cb = cb || noop
     count = count == null ? 1 : parseInt(count, 10)
     if (recipe.requiresTable && !craftingTable) {
-      cb(new Error('recipe requires craftingTable'))
-      return
+      throw new Error('recipe requires craftingTable')
     }
-    next()
-    function next (err) {
-      if (err) {
-        cb(err)
-      } else if (count > 0) {
-        count -= 1
-        craftOnce(recipe, craftingTable, next)
-      } else {
-        cb()
-      }
+    for (let i = 0; i < count; i++) {
+      await craftOnce(recipe, craftingTable)
     }
   }
 
-  function craftOnce (recipe, craftingTable, cb) {
+  async function craftOnce (recipe, craftingTable) {
     if (craftingTable) {
       bot.activateBlock(craftingTable)
-      bot.once('windowOpen', (window) => {
-        if (!window.type.startsWith('minecraft:crafting')) {
-          cb(new Error('crafting: non craftingTable used as craftingTable'))
-          return
-        }
-        startClicking(window, 3, 3)
+      return new Promise(resolve => {
+        bot.once('windowOpen', async (window) => {
+          if (!window.type.startsWith('minecraft:crafting')) {
+            throw new Error('crafting: non craftingTable used as craftingTable')
+          }
+          await startClicking(window, 3, 3)
+          resolve()
+        })
       })
     } else {
-      startClicking(bot.inventory, 2, 2)
+      await startClicking(bot.inventory, 2, 2)
     }
 
-    function startClicking (window, w, h) {
+    async function startClicking (window, w, h) {
       const extraSlots = unusedRecipeSlots()
       let ingredientIndex = 0
       let originalSourceSlot = null
@@ -52,9 +44,9 @@ function inject (bot, { version }) {
           y: 0,
           row: recipe.inShape[0]
         }
-        clickShape()
+        await clickShape()
       } else {
-        nextIngredientsClick()
+        await nextIngredientsClick()
       }
 
       function incrementShapeIterator () {
@@ -68,17 +60,17 @@ function inject (bot, { version }) {
         return it
       }
 
-      function nextShapeClick () {
+      async function nextShapeClick () {
         if (incrementShapeIterator()) {
-          clickShape()
+          await clickShape()
         } else if (!recipe.ingredients) {
-          putMaterialsAway()
+          await putMaterialsAway()
         } else {
-          nextIngredientsClick()
+          await nextIngredientsClick()
         }
       }
 
-      function clickShape () {
+      async function clickShape () {
         const destSlot = slot(it.x, it.y)
         const ingredient = it.row[it.x]
         if (ingredient.id === -1) return nextShapeClick()
@@ -87,27 +79,15 @@ function inject (bot, { version }) {
           window.selectedItem.metadata !== ingredient.metadata)) {
           // we are not holding the item we need. click it.
           const sourceItem = window.findInventoryItem(ingredient.id, ingredient.metadata)
-          if (!sourceItem) return cb(new Error('missing ingredient'))
+          if (!sourceItem) throw new Error('missing ingredient')
           if (originalSourceSlot == null) originalSourceSlot = sourceItem.slot
-          bot.clickWindow(sourceItem.slot, 0, 0, (err) => {
-            if (err) return cb(err)
-            clickDest()
-          })
-        } else {
-          clickDest()
+          await bot.clickWindow(sourceItem.slot, 0, 0)
         }
-        function clickDest () {
-          bot.clickWindow(destSlot, 1, 0, (err) => {
-            if (err) {
-              cb(err)
-            } else {
-              nextShapeClick()
-            }
-          })
-        }
+        await bot.clickWindow(destSlot, 1, 0)
+        await nextShapeClick()
       }
 
-      function nextIngredientsClick () {
+      async function nextIngredientsClick () {
         const ingredient = recipe.ingredients[ingredientIndex]
         const destSlot = extraSlots.pop()
         if (!window.selectedItem || window.selectedItem.type !== ingredient.id ||
@@ -115,53 +95,36 @@ function inject (bot, { version }) {
           window.selectedItem.metadata !== ingredient.metadata)) {
           // we are not holding the item we need. click it.
           const sourceItem = window.findInventoryItem(ingredient.id, ingredient.metadata)
-          if (!sourceItem) return cb(new Error('missing ingredient'))
+          if (!sourceItem) throw new Error('missing ingredient')
           if (originalSourceSlot == null) originalSourceSlot = sourceItem.slot
-          bot.clickWindow(sourceItem.slot, 0, 0, clickDest)
-        } else {
-          clickDest()
+          await bot.clickWindow(sourceItem.slot, 0, 0)
         }
-        function clickDest () {
-          bot.clickWindow(destSlot, 1, 0, (err) => {
-            if (err) {
-              cb(err)
-            } else if (++ingredientIndex < recipe.ingredients.length) {
-              nextIngredientsClick()
-            } else {
-              putMaterialsAway()
-            }
-          })
+        await bot.clickWindow(destSlot, 1, 0)
+        if (++ingredientIndex < recipe.ingredients.length) {
+          await nextIngredientsClick()
+        } else {
+          await putMaterialsAway()
         }
       }
 
-      function putMaterialsAway () {
+      async function putMaterialsAway () {
         const start = window.inventoryStart
         const end = window.inventoryEnd
-        bot.putSelectedItemRange(start, end, window, originalSourceSlot, (err) => {
-          if (err) {
-            cb(err)
-          } else {
-            grabResult()
-          }
-        })
+        await bot.putSelectedItemRange(start, end, window, originalSourceSlot)
+        await grabResult()
       }
 
-      function grabResult () {
+      async function grabResult () {
         assert.strictEqual(window.selectedItem, null)
         // put the recipe result in the output
         const item = new Item(recipe.result.id, recipe.result.count, recipe.result.metadata)
         window.updateSlot(0, item)
         // move the result to inventory
-        bot.putAway(0, (err) => {
-          if (err) {
-            cb(err)
-          } else {
-            updateOutShape()
-          }
-        })
+        await bot.putAway(0)
+        await updateOutShape()
       }
 
-      function updateOutShape () {
+      async function updateOutShape () {
         if (!recipe.outShape) {
           for (let i = 1; i <= w * h; i++) {
             window.updateSlot(i, null)
@@ -188,26 +151,16 @@ function inject (bot, { version }) {
             window.updateSlot(theSlot, item)
           }
         }
-        next()
-        function next () {
-          const theSlot = slotsToClick.pop()
-          if (!theSlot) {
-            closeTheWindow()
-            return
-          }
-          bot.putAway(theSlot, (err) => {
-            if (err) {
-              cb(err)
-            } else {
-              next()
-            }
-          })
+        theSlot = slotsToClick.pop()
+        while (theSlot) {
+          await bot.putAway(theSlot)
+          theSlot = slotsToClick.pop()
         }
+        closeTheWindow()
       }
 
       function closeTheWindow () {
         bot.closeWindow(window)
-        cb()
       }
 
       function slot (x, y) {
@@ -283,11 +236,14 @@ function inject (bot, { version }) {
     return true
   }
 
-  bot.craft = craft
+  bot.craft = callbackify(craft)
   bot.recipesFor = recipesFor
   bot.recipesAll = recipesAll
 }
 
-function noop (err) {
-  if (err) throw err
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { once } = require('events')
 
 module.exports = inject
 

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -20,13 +20,11 @@ function inject (bot, { version }) {
   async function craftOnce (recipe, craftingTable) {
     if (craftingTable) {
       bot.activateBlock(craftingTable)
-const [window] = await once(bot, 'windowOpen')
-if (!window.type.startsWith('minecraft:crafting')) {
-  throw new Error('crafting: non craftingTable used as craftingTable')
-}
-await startClicking(window, 3, 3)
-
-      })
+      const [window] = await once(bot, 'windowOpen')
+      if (!window.type.startsWith('minecraft:crafting')) {
+        throw new Error('crafting: non craftingTable used as craftingTable')
+      }
+      await startClicking(window, 3, 3)
     } else {
       await startClicking(bot.inventory, 2, 2)
     }

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { callbackify } = require('../promise_utils')
+const { callbackify, sleep } = require('../promise_utils')
+const { once } = require('events')
 
 module.exports = inject
 
@@ -15,13 +16,10 @@ function inject (bot, { version }) {
     stopFlying
   }
 
-  const creativeSlotsUpdates = new Map()
+  let creativeSlotsUpdates = []
   bot._client.on('set_slot', ({ windowId, slot, item }) => {
-    if (windowId === 0 && creativeSlotsUpdates.has(slot)) {
-      const cb = creativeSlotsUpdates.get(slot)
-      creativeSlotsUpdates.delete(slot)
-
-      setImmediate(cb)
+    if (windowId === 0 && creativeSlotsUpdates[slot]) {
+      bot.emit(`set_creative_slot_${slot}`)
     }
   })
 
@@ -29,18 +27,18 @@ function inject (bot, { version }) {
   async function setInventorySlot (slot, item) {
     assert(slot >= 0 && slot <= 44)
 
-    if (creativeSlotsUpdates.has(slot)) {
+    if (creativeSlotsUpdates.includes(slot)) {
       throw new Error(`Setting slot ${slot} cancelled due to calling bot.creative.setInventorySlot(${slot}, ...) again`)
     }
+    creativeSlotsUpdates[slot] = true
 
-    return new Promise(resolve => {
-      creativeSlotsUpdates.set(slot, resolve)
-
-      bot._client.write('set_creative_slot', {
-        slot,
-        item: Item.toNotch(item)
-      })
+    bot._client.write('set_creative_slot', {
+      slot,
+      item: Item.toNotch(item)
     })
+
+    await once(bot, `set_creative_slot_${slot}`)
+    creativeSlotsUpdates[slot] = false
   }
 
   let normalGravity = null
@@ -51,27 +49,26 @@ function inject (bot, { version }) {
     // TODO: consider sending 0x13
     startFlying()
 
-    return new Promise(resolve => {
-      const intervalHandle = setInterval(flyStep, 50)
+    let vector = destination.minus(bot.entity.position)
+    let magnitude = vecMagnitude(vector)
 
-      function flyStep () {
-        bot.physics.gravity = 0
-        bot.entity.velocity = new Vec3(0, 0, 0)
+    while (magnitude > flyingSpeedPerUpdate) {
+      bot.physics.gravity = 0
+      bot.entity.velocity = new Vec3(0, 0, 0)
 
-        const vector = destination.minus(bot.entity.position)
-        const magnitude = vecMagnitude(vector)
-        if (magnitude <= flyingSpeedPerUpdate) {
-          // last step
-          bot.entity.position = destination
-          bot.once('move', resolve)
-          clearInterval(intervalHandle)
-        } else {
-          // small steps
-          const normalizedVector = vector.scaled(1 / magnitude)
-          bot.entity.position.add(normalizedVector.scaled(flyingSpeedPerUpdate))
-        }
-      }
-    })
+      // small steps
+      const normalizedVector = vector.scaled(1 / magnitude)
+      bot.entity.position.add(normalizedVector.scaled(flyingSpeedPerUpdate))
+
+      await sleep(50)
+
+      vector = destination.minus(bot.entity.position)
+      magnitude = vecMagnitude(vector)
+    }
+
+    // last step
+    bot.entity.position = destination
+    await once(bot, 'move')
   }
 
   function startFlying () {

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -16,7 +16,7 @@ function inject (bot, { version }) {
     stopFlying
   }
 
-  let creativeSlotsUpdates = []
+  const creativeSlotsUpdates = []
   bot._client.on('set_slot', ({ windowId, slot, item }) => {
     if (windowId === 0 && creativeSlotsUpdates[slot]) {
       bot.emit(`set_creative_slot_${slot}`)
@@ -27,7 +27,7 @@ function inject (bot, { version }) {
   async function setInventorySlot (slot, item) {
     assert(slot >= 0 && slot <= 44)
 
-    if (creativeSlotsUpdates.includes(slot)) {
+    if (creativeSlotsUpdates[slot]) {
       throw new Error(`Setting slot ${slot} cancelled due to calling bot.creative.setInventorySlot(${slot}, ...) again`)
     }
     creativeSlotsUpdates[slot] = true

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -9,7 +9,7 @@ function inject (bot, { version }) {
   // these features only work when you are in creative mode.
   bot.creative = {
     setInventorySlot,
-    flyTo,
+    flyTo: callbackify(flyTo),
     startFlying,
     stopFlying
   }
@@ -47,28 +47,31 @@ function inject (bot, { version }) {
   const flyingSpeedPerUpdate = 0.5
 
   // straight line, so make sure there's a clear path.
-  function flyTo (destination, cb) {
+  async function flyTo (destination) {
     // TODO: consider sending 0x13
     startFlying()
-    const intervalHandle = setInterval(flyStep, 50)
 
-    function flyStep () {
-      bot.physics.gravity = 0
-      bot.entity.velocity = new Vec3(0, 0, 0)
+    return new Promise(resolve => {
+      const intervalHandle = setInterval(flyStep, 50)
 
-      const vector = destination.minus(bot.entity.position)
-      const magnitude = vecMagnitude(vector)
-      if (magnitude <= flyingSpeedPerUpdate) {
-        // last step
-        bot.entity.position = destination
-        if (cb != null) bot.once('move', cb)
-        clearInterval(intervalHandle)
-      } else {
-        // small steps
-        const normalizedVector = vector.scaled(1 / magnitude)
-        bot.entity.position.add(normalizedVector.scaled(flyingSpeedPerUpdate))
+      function flyStep () {
+        bot.physics.gravity = 0
+        bot.entity.velocity = new Vec3(0, 0, 0)
+
+        const vector = destination.minus(bot.entity.position)
+        const magnitude = vecMagnitude(vector)
+        if (magnitude <= flyingSpeedPerUpdate) {
+          // last step
+          bot.entity.position = destination
+          bot.once('move', resolve)
+          clearInterval(intervalHandle)
+        } else {
+          // small steps
+          const normalizedVector = vector.scaled(1 / magnitude)
+          bot.entity.position.add(normalizedVector.scaled(flyingSpeedPerUpdate))
+        }
       }
-    }
+    })
   }
 
   function startFlying () {
@@ -84,4 +87,11 @@ function inject (bot, { version }) {
 // this should be in the vector library
 function vecMagnitude (vec) {
   return Math.sqrt(vec.x * vec.x + vec.y * vec.y + vec.z * vec.z)
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -8,7 +8,7 @@ function inject (bot, { version }) {
 
   // these features only work when you are in creative mode.
   bot.creative = {
-    setInventorySlot,
+    setInventorySlot: callbackify(setInventorySlot),
     flyTo: callbackify(flyTo),
     startFlying,
     stopFlying
@@ -25,21 +25,20 @@ function inject (bot, { version }) {
   })
 
   // WARN: This method should not be called twice on the same slot before first callback exceeds
-  function setInventorySlot (slot, item, cb) {
+  async function setInventorySlot (slot, item) {
     assert(slot >= 0 && slot <= 44)
 
-    if (cb != null) {
-      if (creativeSlotsUpdates.has(slot)) {
-        cb(new Error(`Setting slot ${slot} cancelled due to calling bot.creative.setInventorySlot(${slot}, ...) again`))
-        return
-      }
-
-      creativeSlotsUpdates.set(slot, cb)
+    if (creativeSlotsUpdates.has(slot)) {
+      throw new Error(`Setting slot ${slot} cancelled due to calling bot.creative.setInventorySlot(${slot}, ...) again`)
     }
 
-    bot._client.write('set_creative_slot', {
-      slot,
-      item: Item.toNotch(item)
+    return new Promise(resolve => {
+      creativeSlotsUpdates.set(slot, resolve)
+
+      bot._client.write('set_creative_slot', {
+        slot,
+        item: Item.toNotch(item)
+      })
     })
   }
 
@@ -91,7 +90,7 @@ function vecMagnitude (vec) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -86,11 +87,4 @@ function inject (bot, { version }) {
 // this should be in the vector library
 function vecMagnitude (vec) {
   return Math.sqrt(vec.x * vec.x + vec.y * vec.y + vec.z * vec.z)
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -10,28 +10,39 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
-  function dig (block, forceLook, cb) {
+  async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
-    if (typeof forceLook === 'function') {
-      cb = forceLook
-      forceLook = true
-    }
-    cb = cb || noop
-    bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook, () => {
+    await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+    bot._client.write('block_dig', {
+      status: 0, // start digging
+      location: block.position,
+      face: 1 // hard coded to always dig from the top
+    })
+    const waitTime = bot.digTime(block)
+    waitTimeout = setTimeout(finishDigging, waitTime)
+    bot.targetDigBlock = block
+    bot.swingArm()
+
+    swingInterval = setInterval(() => {
+      bot.swingArm()
+    }, 350)
+
+    function finishDigging () {
+      clearInterval(swingInterval)
+      clearTimeout(waitTimeout)
+      swingInterval = null
+      waitTimeout = null
       bot._client.write('block_dig', {
-        status: 0, // start digging
-        location: block.position,
+        status: 2, // finish digging
+        location: bot.targetDigBlock.position,
         face: 1 // hard coded to always dig from the top
       })
-      const waitTime = bot.digTime(block)
-      waitTimeout = setTimeout(finishDigging, waitTime)
-      bot.targetDigBlock = block
-      bot.swingArm()
+      bot.targetDigBlock = null
+      bot.lastDigTime = performance.now()
+      bot._updateBlockState(block.position, 0)
+    }
 
-      swingInterval = setInterval(() => {
-        bot.swingArm()
-      }, 350)
-
+    return new Promise((resolve, reject) => {
       const eventName = `blockUpdate:${block.position}`
       bot.on(eventName, onBlockUpdate)
 
@@ -52,7 +63,7 @@ function inject (bot) {
         bot.lastDigTime = performance.now()
         bot.emit('diggingAborted', block)
         bot.stopDigging = noop
-        cb(new Error('Digging aborted'))
+        reject(new Error('Digging aborted'))
       }
 
       function onBlockUpdate (oldBlock, newBlock) {
@@ -67,22 +78,7 @@ function inject (bot) {
         bot.targetDigBlock = null
         bot.lastDigTime = performance.now()
         bot.emit('diggingCompleted', newBlock)
-        cb()
-      }
-
-      function finishDigging () {
-        clearInterval(swingInterval)
-        clearTimeout(waitTimeout)
-        swingInterval = null
-        waitTimeout = null
-        bot._client.write('block_dig', {
-          status: 2, // finish digging
-          location: bot.targetDigBlock.position,
-          face: 1 // hard coded to always dig from the top
-        })
-        bot.targetDigBlock = null
-        bot.lastDigTime = performance.now()
-        bot._updateBlockState(block.position, 0)
+        resolve()
       }
     })
   }
@@ -104,10 +100,20 @@ function inject (bot) {
     return block.digTime(type, creative, bot.entity.isInWater, !bot.entity.onGround, enchantments, bot.entity.effects)
   }
 
-  bot.dig = dig
+  bot.dig = callbackify(dig)
   bot.stopDigging = noop
   bot.canDigBlock = canDigBlock
   bot.digTime = digTime
+}
+
+function callbackify (f) { // specifically for this function because cb could be the non-last parameter
+  return function (...args) {
+    const cbIndex = typeof args[1] === 'function' ? 1 : 2
+    const cb = args[cbIndex]
+    if (cbIndex === 1) args[1] = true
+    else args[1] = !!args[1] // coerce to boolean
+    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }
 
 function noop (err) {

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,6 +1,6 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
-const { once } = require('events')
+const { EventEmitter, once } = require('events')
 
 module.exports = inject
 
@@ -10,6 +10,8 @@ function inject (bot) {
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
+
+  const diggingEvents = new EventEmitter()
 
   async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
@@ -46,7 +48,7 @@ function inject (bot) {
     const eventName = `blockUpdate:${block.position}`
     bot.on(eventName, onBlockUpdate)
 
-    const [diggingDone] = await once(bot._internalEvents, `diggingDone:${block.position}`)
+    const [diggingDone] = await once(diggingEvents, `diggingDone:${block.position}`)
 
     if (!diggingDone) {
       throw new Error('Digging aborted')
@@ -69,7 +71,7 @@ function inject (bot) {
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
       bot.stopDigging = noop
-      bot._internalEvents.emit(`diggingDone:${block.position}`, false)
+      diggingEvents.emit(`diggingDone:${block.position}`, false)
     }
 
     function onBlockUpdate (oldBlock, newBlock) {
@@ -84,7 +86,7 @@ function inject (bot) {
       bot.targetDigBlock = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingCompleted', newBlock)
-      bot._internalEvents.emit(`diggingDone:${block.position}`, true)
+      diggingEvents.emit(`diggingDone:${block.position}`, true)
     }
   }
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,6 +1,6 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
-const { EventEmitter, once } = require('events')
+const { once } = require('events')
 
 module.exports = inject
 
@@ -10,8 +10,6 @@ function inject (bot) {
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
-
-  const diggingEvents = new EventEmitter()
 
   async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
@@ -48,7 +46,7 @@ function inject (bot) {
     const eventName = `blockUpdate:${block.position}`
     bot.on(eventName, onBlockUpdate)
 
-    const [diggingDone] = await once(diggingEvents, `diggingDone:${block.position}`)
+    const [diggingDone] = await once(bot._internalEvents, `diggingDone:${block.position}`)
 
     if (!diggingDone) {
       throw new Error('Digging aborted')
@@ -71,7 +69,7 @@ function inject (bot) {
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
       bot.stopDigging = noop
-      diggingEvents.emit(`diggingDone:${block.position}`, false)
+      bot._internalEvents.emit(`diggingDone:${block.position}`, false)
     }
 
     function onBlockUpdate (oldBlock, newBlock) {
@@ -86,7 +84,7 @@ function inject (bot) {
       bot.targetDigBlock = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingCompleted', newBlock)
-      diggingEvents.emit(`diggingDone:${block.position}`, true)
+      bot._internalEvents.emit(`diggingDone:${block.position}`, true)
     }
   }
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,12 +1,14 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
-const { once } = require('events')
+const { once, EventEmitter } = require('events')
 
 module.exports = inject
 
 function inject (bot) {
   let swingInterval = null
   let waitTimeout = null
+
+  const diggingEvents = new EventEmitter()
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
@@ -46,7 +48,7 @@ function inject (bot) {
     const eventName = `blockUpdate:${block.position}`
     bot.on(eventName, onBlockUpdate)
 
-    const [diggingDone] = await once(bot._internalEvents, `diggingDone:${block.position}`)
+    const [diggingDone] = await once(diggingEvents, `diggingDone:${block.position}`)
 
     if (!diggingDone) {
       throw new Error('Digging aborted')
@@ -69,7 +71,7 @@ function inject (bot) {
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
       bot.stopDigging = noop
-      bot._internalEvents.emit(`diggingDone:${block.position}`, false)
+      diggingEvents.emit(`diggingDone:${block.position}`, false)
     }
 
     function onBlockUpdate (oldBlock, newBlock) {
@@ -84,7 +86,7 @@ function inject (bot) {
       bot.targetDigBlock = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingCompleted', newBlock)
-      bot._internalEvents.emit(`diggingDone:${block.position}`, true)
+      diggingEvents.emit(`diggingDone:${block.position}`, true)
     }
   }
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,6 +1,8 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
-const { once, EventEmitter } = require('events')
+const { once } = require('events')
+const { callbackify, createDoneTask } = require('../promise_utils')
+
 
 module.exports = inject
 
@@ -8,7 +10,7 @@ function inject (bot) {
   let swingInterval = null
   let waitTimeout = null
 
-  const diggingEvents = new EventEmitter()
+  let diggingTask = createDoneTask()
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
@@ -16,6 +18,7 @@ function inject (bot) {
   async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+    diggingTask = createTask()
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
@@ -48,10 +51,10 @@ function inject (bot) {
     const eventName = `blockUpdate:${block.position}`
     bot.on(eventName, onBlockUpdate)
 
-    const [diggingDone] = await once(diggingEvents, `diggingDone:${block.position}`)
-
-    if (!diggingDone) {
-      throw new Error('Digging aborted')
+    try {
+      await diggingTask.promise
+    } catch (err) {
+      throw err
     }
 
     bot.stopDigging = () => {
@@ -71,7 +74,7 @@ function inject (bot) {
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
       bot.stopDigging = noop
-      diggingEvents.emit(`diggingDone:${block.position}`, false)
+      diggingTask.cancel(new Error('Digging aborted'))
     }
 
     function onBlockUpdate (oldBlock, newBlock) {
@@ -86,7 +89,7 @@ function inject (bot) {
       bot.targetDigBlock = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingCompleted', newBlock)
-      diggingEvents.emit(`diggingDone:${block.position}`, true)
+      diggingTask.finish()
     }
   }
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,8 +1,6 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
-const { once } = require('events')
-const { callbackify, createDoneTask } = require('../promise_utils')
-
+const { createDoneTask, createTask } = require('../promise_utils')
 
 module.exports = inject
 
@@ -51,11 +49,7 @@ function inject (bot) {
     const eventName = `blockUpdate:${block.position}`
     bot.on(eventName, onBlockUpdate)
 
-    try {
-      await diggingTask.promise
-    } catch (err) {
-      throw err
-    }
+    await diggingTask.promise
 
     bot.stopDigging = () => {
       if (bot.targetDigBlock === null) return

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,5 +1,6 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
+const { EventEmitter, once } = require('events')
 
 module.exports = inject
 
@@ -9,6 +10,8 @@ function inject (bot) {
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
+
+  const diggingEvents = new EventEmitter()
 
   async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
@@ -42,45 +45,49 @@ function inject (bot) {
       bot._updateBlockState(block.position, 0)
     }
 
-    return new Promise((resolve, reject) => {
-      const eventName = `blockUpdate:${block.position}`
-      bot.on(eventName, onBlockUpdate)
+    const eventName = `blockUpdate:${block.position}`
+    bot.on(eventName, onBlockUpdate)
 
-      bot.stopDigging = () => {
-        if (bot.targetDigBlock === null) return
-        bot.removeListener(eventName, onBlockUpdate)
-        clearInterval(swingInterval)
-        clearTimeout(waitTimeout)
-        swingInterval = null
-        waitTimeout = null
-        bot._client.write('block_dig', {
-          status: 1, // cancel digging
-          location: bot.targetDigBlock.position,
-          face: 1 // hard coded to always dig from the top
-        })
-        const block = bot.targetDigBlock
-        bot.targetDigBlock = null
-        bot.lastDigTime = performance.now()
-        bot.emit('diggingAborted', block)
-        bot.stopDigging = noop
-        reject(new Error('Digging aborted'))
-      }
+    const [diggingDone] = await once(diggingEvents, `diggingDone:${block.position}`)
 
-      function onBlockUpdate (oldBlock, newBlock) {
-        // vanilla server never actually interrupt digging, but some server send block update when you start digging
-        // so ignore block update if not air
-        if (newBlock.type !== 0) return
-        bot.removeListener(eventName, onBlockUpdate)
-        clearInterval(swingInterval)
-        clearTimeout(waitTimeout)
-        swingInterval = null
-        waitTimeout = null
-        bot.targetDigBlock = null
-        bot.lastDigTime = performance.now()
-        bot.emit('diggingCompleted', newBlock)
-        resolve()
-      }
-    })
+    if (!diggingDone) {
+      throw new Error('Digging aborted')
+    }
+
+    bot.stopDigging = () => {
+      if (bot.targetDigBlock === null) return
+      bot.removeListener(eventName, onBlockUpdate)
+      clearInterval(swingInterval)
+      clearTimeout(waitTimeout)
+      swingInterval = null
+      waitTimeout = null
+      bot._client.write('block_dig', {
+        status: 1, // cancel digging
+        location: bot.targetDigBlock.position,
+        face: 1 // hard coded to always dig from the top
+      })
+      const block = bot.targetDigBlock
+      bot.targetDigBlock = null
+      bot.lastDigTime = performance.now()
+      bot.emit('diggingAborted', block)
+      bot.stopDigging = noop
+      diggingEvents.emit(`diggingDone:${block.position}`, false)
+    }
+
+    function onBlockUpdate (oldBlock, newBlock) {
+      // vanilla server never actually interrupt digging, but some server send block update when you start digging
+      // so ignore block update if not air
+      if (newBlock.type !== 0) return
+      bot.removeListener(eventName, onBlockUpdate)
+      clearInterval(swingInterval)
+      clearTimeout(waitTimeout)
+      swingInterval = null
+      waitTimeout = null
+      bot.targetDigBlock = null
+      bot.lastDigTime = performance.now()
+      bot.emit('diggingCompleted', newBlock)
+      diggingEvents.emit(`diggingDone:${block.position}`, true)
+    }
   }
 
   function canDigBlock (block) {

--- a/lib/plugins/dispenser.js
+++ b/lib/plugins/dispenser.js
@@ -44,7 +44,7 @@ function inject (bot) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/dispenser.js
+++ b/lib/plugins/dispenser.js
@@ -7,10 +7,10 @@ function inject (bot) {
   function openDispenser (dispenserBlock) {
     assert.strictEqual(dispenserBlock.name, 'dispenser')
     const dispenser = bot.openBlock(dispenserBlock, Dispenser)
-    dispenser.deposit = deposit
-    dispenser.withdraw = withdraw
+    dispenser.deposit = callbackify(deposit)
+    dispenser.withdraw = callbackify(withdraw)
     return dispenser
-    function deposit (itemType, metadata, count, cb) {
+    async function deposit (itemType, metadata, count) {
       const options = {
         window: dispenser.window,
         itemType,
@@ -21,10 +21,10 @@ function inject (bot) {
         destStart: 0,
         destEnd: dispenser.window.inventoryStart
       }
-      bot.transfer(options, cb)
+      await bot.transfer(options)
     }
 
-    function withdraw (itemType, metadata, count, cb) {
+    async function withdraw (itemType, metadata, count) {
       const options = {
         window: dispenser.window,
         itemType,
@@ -35,9 +35,16 @@ function inject (bot) {
         destStart: dispenser.window.inventoryStart,
         destEnd: dispenser.window.inventoryEnd
       }
-      bot.transfer(options, cb)
+      await bot.transfer(options)
     }
   }
 
   bot.openDispenser = openDispenser
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/dispenser.js
+++ b/lib/plugins/dispenser.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const Dispenser = require('../dispenser')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -40,11 +41,4 @@ function inject (bot) {
   }
 
   bot.openDispenser = openDispenser
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/enchantment_table.js
+++ b/lib/plugins/enchantment_table.js
@@ -1,6 +1,7 @@
 const EnchantmentTable = require('../enchantment_table')
 const assert = require('assert')
 const { once } = require('events')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -76,11 +77,4 @@ function inject (bot, { version }) {
   }
 
   bot.openEnchantmentTable = openEnchantmentTable
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/enchantment_table.js
+++ b/lib/plugins/enchantment_table.js
@@ -82,7 +82,7 @@ function inject (bot, { version }) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/enchantment_table.js
+++ b/lib/plugins/enchantment_table.js
@@ -3,10 +3,6 @@ const assert = require('assert')
 
 module.exports = inject
 
-function noop (err) {
-  if (err) throw err
-}
-
 function inject (bot, { version }) {
   function openEnchantmentTable (enchantmentTableBlock) {
     assert.strictEqual(enchantmentTableBlock.name, 'enchanting_table')
@@ -16,10 +12,10 @@ function inject (bot, { version }) {
     bot._client.on('craft_progress_bar', onUpdateWindowProperty)
     enchantmentTable.on('updateSlot', onUpdateSlot)
     enchantmentTable.once('close', onClose)
-    enchantmentTable.enchant = enchant
-    enchantmentTable.takeTargetItem = takeTargetItem
-    enchantmentTable.putTargetItem = putTargetItem
-    enchantmentTable.putLapis = putLapis
+    enchantmentTable.enchant = callbackify(enchant)
+    enchantmentTable.takeTargetItem = callbackify(takeTargetItem)
+    enchantmentTable.putTargetItem = callbackify(putTargetItem)
+    enchantmentTable.putLapis = callbackify(putLapis)
     return enchantmentTable
     function onClose () {
       bot._client.removeListener('craft_progress_bar', onUpdateWindowProperty)
@@ -51,35 +47,42 @@ function inject (bot, { version }) {
       ready = false
     }
 
-    function enchant (choice, cb) {
+    async function enchant (choice) {
       choice = parseInt(choice, 10) // allow string argument
-      cb = cb || noop
       assert.notStrictEqual(enchantmentTable.enchantments[choice].level, null)
       bot._client.write('enchant_item', {
         windowId: enchantmentTable.window.id,
         enchantment: choice
       })
-      enchantmentTable.once('updateSlot', (oldItem, newItem) => {
-        cb(null, newItem)
+      return new Promise(resolve => {
+        enchantmentTable.once('updateSlot', (oldItem, newItem) => {
+          resolve(newItem)
+        })
       })
     }
 
-    function takeTargetItem (cb = noop) {
+    async function takeTargetItem () {
       const item = enchantmentTable.targetItem()
       assert.ok(item)
-      bot.putAway(item.slot, (err) => {
-        cb(err, item)
-      })
+      await bot.putAway(item.slot)
+      return item
     }
 
-    function putTargetItem (item, cb = noop) {
-      bot.moveSlotItem(item.slot, 0, cb)
+    async function putTargetItem (item) {
+      await bot.moveSlotItem(item.slot, 0)
     }
 
-    function putLapis (item, cb = noop) {
-      bot.moveSlotItem(item.slot, 1, cb)
+    async function putLapis (item) {
+      await bot.moveSlotItem(item.slot, 1)
     }
   }
 
   bot.openEnchantmentTable = openEnchantmentTable
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/enchantment_table.js
+++ b/lib/plugins/enchantment_table.js
@@ -1,5 +1,6 @@
 const EnchantmentTable = require('../enchantment_table')
 const assert = require('assert')
+const { once } = require('events')
 
 module.exports = inject
 
@@ -54,11 +55,8 @@ function inject (bot, { version }) {
         windowId: enchantmentTable.window.id,
         enchantment: choice
       })
-      return new Promise(resolve => {
-        enchantmentTable.once('updateSlot', (oldItem, newItem) => {
-          resolve(newItem)
-        })
-      })
+      const [, newItem] = await once(enchantmentTable, 'updateSlot')
+      return newItem
     }
 
     async function takeTargetItem () {

--- a/lib/plugins/furnace.js
+++ b/lib/plugins/furnace.js
@@ -102,7 +102,7 @@ function inject (bot, { version }) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/furnace.js
+++ b/lib/plugins/furnace.js
@@ -7,11 +7,11 @@ function inject (bot, { version }) {
   function openFurnace (furnaceBlock) {
     assert.ok(furnaceBlock.name === 'furnace' || furnaceBlock.name === 'lit_furnace')
     const furnace = bot.openBlock(furnaceBlock, Furnace)
-    furnace.takeInput = takeInput
-    furnace.takeFuel = takeFuel
-    furnace.takeOutput = takeOutput
-    furnace.putInput = putInput
-    furnace.putFuel = putFuel
+    furnace.takeInput = callbackify(takeInput)
+    furnace.takeFuel = callbackify(takeFuel)
+    furnace.takeOutput = callbackify(takeOutput)
+    furnace.putInput = callbackify(putInput)
+    furnace.putFuel = callbackify(putFuel)
     bot._client.on('craft_progress_bar', onUpdateWindowProperty)
     furnace.once('close', onClose)
     return furnace
@@ -52,30 +52,25 @@ function inject (bot, { version }) {
       furnace.emit('update')
     }
 
-    function takeSomething (item, cb) {
+    async function takeSomething (item) {
       assert.ok(item)
-      bot.putAway(item.slot, (err) => {
-        if (err) {
-          cb(err)
-        } else {
-          cb(null, item)
-        }
-      })
+      await bot.putAway(item.slot)
+      return item
     }
 
-    function takeInput (cb) {
-      takeSomething(furnace.inputItem(), cb)
+    async function takeInput () {
+      return takeSomething(furnace.inputItem())
     }
 
-    function takeFuel (cb) {
-      takeSomething(furnace.fuelItem(), cb)
+    async function takeFuel () {
+      return takeSomething(furnace.fuelItem())
     }
 
-    function takeOutput (cb) {
-      takeSomething(furnace.outputItem(), cb)
+    async function takeOutput () {
+      return takeSomething(furnace.outputItem())
     }
 
-    function putSomething (destSlot, itemType, metadata, count, cb) {
+    async function putSomething (destSlot, itemType, metadata, count) {
       const options = {
         window: furnace.window,
         itemType,
@@ -86,15 +81,15 @@ function inject (bot, { version }) {
         destStart: destSlot,
         destEnd: destSlot + 1
       }
-      bot.transfer(options, cb)
+      await bot.transfer(options)
     }
 
-    function putInput (itemType, metadata, count, cb) {
-      putSomething(0, itemType, metadata, count, cb)
+    async function putInput (itemType, metadata, count) {
+      await putSomething(0, itemType, metadata, count)
     }
 
-    function putFuel (itemType, metadata, count, cb) {
-      putSomething(1, itemType, metadata, count, cb)
+    async function putFuel (itemType, metadata, count) {
+      await putSomething(1, itemType, metadata, count)
     }
   }
 
@@ -103,4 +98,11 @@ function inject (bot, { version }) {
   }
 
   bot.openFurnace = openFurnace
+}
+
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }

--- a/lib/plugins/furnace.js
+++ b/lib/plugins/furnace.js
@@ -1,5 +1,6 @@
 const Furnace = require('../furnace')
 const assert = require('assert')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -98,11 +99,4 @@ function inject (bot, { version }) {
   }
 
   bot.openFurnace = openFurnace
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once } = require('events')
+const { once, EventEmitter } = require('events')
 const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
@@ -22,10 +22,12 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
+  const inventoryEvents = new EventEmitter()
+  inventoryEvents.eating = false
+  inventoryEvents.fishing = false
+
   let nextActionNumber = 0
   const windowClickQueue = []
-  let lastEating
-  let lastFishing
   let lastFloat
   let windowItems
 
@@ -37,27 +39,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && lastEating) {
-      lastEating()
-      lastEating = undefined
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone', true)
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && lastFishing && !lastFloat) {
+    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !lastFishing) return
+    if (!lastFloat || !inventoryEvents.fishing) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      setImmediate(lastFishing)
-      lastFishing = undefined
+      inventoryEvents.emit('fishingDone', true)
     }
   })
 
@@ -65,44 +65,51 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      setImmediate(lastFishing, new Error('Fishing cancelled'))
-      lastFishing = undefined
+      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (lastEating) {
-      lastEating(new Error('Consuming cancelled due to calling bot.consume() again'))
+    if (inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
+      inventoryEvents.eating = false
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
+    inventoryEvents.eating = true
+
     activateItem()
 
-    return new Promise((resolve, reject) => {
-      lastEating = (err) => {
-        if (err) reject(err)
-        else resolve()
-      }
-    })
+    const [eatingDone, err] = await once(inventoryEvents, 'eatingDone')
+
+    if (!eatingDone) {
+      throw err
+    }
+
+    inventoryEvents.eating = false
   }
 
   async function fish () {
-    if (lastFishing) {
-      lastFishing(new Error('Fishing cancelled due to calling bot.fish() again'))
-      lastFishing = undefined
+    if (inventoryEvents.fishing) {
+      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
+      inventoryEvents.fishing = false
       return
     }
 
+    inventoryEvents.fishing = true
+
     activateItem()
-    return new Promise((resolve, reject) => {
-      lastFishing = (err) => {
-        if (err) reject(err)
-        else resolve()
-      }
-    })
+
+    const [fishingDone, err] = await once(inventoryEvents, 'fishingDone')
+
+    if (!fishingDone) {
+      throw err
+    }
+
+    inventoryEvents.fishing = false
   }
 
   function activateItem (offHand = false) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once } = require('events')
+const { once, EventEmitter } = require('events')
 const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
@@ -22,8 +22,9 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
-  bot._internalEvents.eating = false
-  bot._internalEvents.fishing = false
+  const inventoryEvents = new EventEmitter()
+  inventoryEvents.eating = false
+  inventoryEvents.fishing = false
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -38,25 +39,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone')
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone', true)
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && bot._internalEvents.fishing && !lastFloat) {
+    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !bot._internalEvents.fishing) return
+    if (!lastFloat || !inventoryEvents.fishing) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone', true)
+      inventoryEvents.emit('fishingDone', true)
     }
   })
 
@@ -64,51 +65,51 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled'))
+      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
-      bot._internalEvents.eating = false
+    if (inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
+      inventoryEvents.eating = false
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
-    bot._internalEvents.eating = true
+    inventoryEvents.eating = true
 
     activateItem()
 
-    const [err] = await once(bot._internalEvents, 'eatingDone')
+    const [eatingDone, err] = await once(inventoryEvents, 'eatingDone')
 
-    if (err) {
+    if (!eatingDone) {
       throw err
     }
 
-    bot._internalEvents.eating = false
+    inventoryEvents.eating = false
   }
 
   async function fish () {
-    if (bot._internalEvents.fishing) {
-      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
-      bot._internalEvents.fishing = false
+    if (inventoryEvents.fishing) {
+      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
+      inventoryEvents.fishing = false
       return
     }
 
-    bot._internalEvents.fishing = true
+    inventoryEvents.fishing = true
 
     activateItem()
 
-    const [err] = await once(bot._internalEvents, 'fishingDone')
+    const [fishingDone, err] = await once(inventoryEvents, 'fishingDone')
 
-    if (err) {
+    if (!fishingDone) {
       throw err
     }
 
-    bot._internalEvents.fishing = false
+    inventoryEvents.fishing = false
   }
 
   function activateItem (offHand = false) {
@@ -540,14 +541,15 @@ function inject (bot, { version, hideErrors }) {
       item: Item.toNotch(click.item)
     })
 
+    const response = once(bot, `confirmTransaction${actionId}`)
+
     // notchian servers are assholes and only confirm certain transactions.
     if (!window.transactionRequiresConfirmation(click)) {
       // jump the gun and accept the click
       confirmTransaction(window.id, actionId, true)
-      return
     }
 
-    const [success] = await once(bot, `confirmTransaction${actionId}`)
+    const [success] = await response
     if (!success) {
       throw new Error('Server rejected transaction.')
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once, EventEmitter } = require('events')
+const { once } = require('events')
 const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
@@ -22,9 +22,8 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
-  const inventoryEvents = new EventEmitter()
-  inventoryEvents.eating = false
-  inventoryEvents.fishing = false
+  bot._internalEvents.eating = false
+  bot._internalEvents.fishing = false
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -39,25 +38,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone', true)
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && bot._internalEvents.eating) {
+      bot._internalEvents.emit('eatingDone', true)
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
+    if (packet.type === bobberId && bot._internalEvents.fishing && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !inventoryEvents.fishing) return
+    if (!lastFloat || !bot._internalEvents.fishing) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone', true)
+      bot._internalEvents.emit('fishingDone', true)
     }
   })
 
@@ -65,51 +64,51 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
+      bot._internalEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
-      inventoryEvents.eating = false
+    if (bot._internalEvents.eating) {
+      bot._internalEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
+      bot._internalEvents.eating = false
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
-    inventoryEvents.eating = true
+    bot._internalEvents.eating = true
 
     activateItem()
 
-    const [eatingDone, err] = await once(inventoryEvents, 'eatingDone')
+    const [eatingDone, err] = await once(bot._internalEvents, 'eatingDone')
 
     if (!eatingDone) {
       throw err
     }
 
-    inventoryEvents.eating = false
+    bot._internalEvents.eating = false
   }
 
   async function fish () {
-    if (inventoryEvents.fishing) {
-      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
-      inventoryEvents.fishing = false
+    if (bot._internalEvents.fishing) {
+      bot._internalEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
+      bot._internalEvents.fishing = false
       return
     }
 
-    inventoryEvents.fishing = true
+    bot._internalEvents.fishing = true
 
     activateItem()
 
-    const [fishingDone, err] = await once(inventoryEvents, 'fishingDone')
+    const [fishingDone, err] = await once(bot._internalEvents, 'fishingDone')
 
     if (!fishingDone) {
       throw err
     }
 
-    inventoryEvents.fishing = false
+    bot._internalEvents.fishing = false
   }
 
   function activateItem (offHand = false) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once, EventEmitter } = require('events')
-const { callbackify, sleep } = require('../promise_utils')
+const { once } = require('events')
+const { callbackify, sleep, createDoneTask } = require('../promise_utils')
 
 module.exports = inject
 
@@ -22,9 +22,8 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
-  const inventoryEvents = new EventEmitter()
-  inventoryEvents.eating = false
-  inventoryEvents.fishing = false
+  let eatingTask = createDoneTask()
+  let fishingTask = createDoneTask()
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -39,25 +38,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone')
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && !eatingTask.done) {
+      eatingTask.finish()
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
+    if (packet.type === bobberId && !fishingTask.done && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !inventoryEvents.fishing) return
+    if (!lastFloat || fishingTask.done) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone')
+      fishingTask.finish()
     }
   })
 
@@ -65,51 +64,45 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone', new Error('Fishing cancelled'))
+      fishingTask.cancel(new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
-      inventoryEvents.eating = false
+    if (!eatingTask.done) {
+      eatingTask.cancel(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
-    inventoryEvents.eating = true
+    eatingTask = createTask()
 
     activateItem()
 
-    const [err] = await once(inventoryEvents, 'eatingDone')
-
-    if (err) {
+    try {
+      await eatingTask.promise
+    } catch (err) {
       throw err
     }
-
-    inventoryEvents.eating = false
   }
 
   async function fish () {
-    if (inventoryEvents.fishing) {
-      inventoryEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
-      inventoryEvents.fishing = false
-      return
+    if (!fishingTask.done) {
+      fishingTask.cancel(new Error('Fishing cancelled due to calling bot.fish() again'))
     }
 
-    inventoryEvents.fishing = true
+    fishingTask = createTask()
 
     activateItem()
 
-    const [err] = await once(inventoryEvents, 'fishingDone')
-
-    if (err) {
+    try {
+      await fishingTask.promise
+    }
+    catch (err) {
       throw err
     }
-
-    inventoryEvents.fishing = false
   }
 
   function activateItem (offHand = false) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -39,7 +39,7 @@ function inject (bot, { version, hideErrors }) {
 
   bot._client.on('entity_status', (packet) => {
     if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone', true)
+      bot._internalEvents.emit('eatingDone')
     }
   })
 
@@ -56,7 +56,7 @@ function inject (bot, { version, hideErrors }) {
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone', true)
+      bot._internalEvents.emit('fishingDone')
     }
   })
 
@@ -64,13 +64,13 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
+      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
     if (bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
+      bot._internalEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
       bot._internalEvents.eating = false
     }
 
@@ -82,9 +82,9 @@ function inject (bot, { version, hideErrors }) {
 
     activateItem()
 
-    const [eatingDone, err] = await once(bot._internalEvents, 'eatingDone')
+    const [err] = await once(bot._internalEvents, 'eatingDone')
 
-    if (!eatingDone) {
+    if (err) {
       throw err
     }
 
@@ -93,7 +93,7 @@ function inject (bot, { version, hideErrors }) {
 
   async function fish () {
     if (bot._internalEvents.fishing) {
-      bot._internalEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
+      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
       bot._internalEvents.fishing = false
       return
     }
@@ -102,9 +102,9 @@ function inject (bot, { version, hideErrors }) {
 
     activateItem()
 
-    const [fishingDone, err] = await once(bot._internalEvents, 'fishingDone')
+    const [err] = await once(bot._internalEvents, 'fishingDone')
 
-    if (!fishingDone) {
+    if (err) {
       throw err
     }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -683,7 +683,7 @@ function inject (bot, { version, hideErrors }) {
 function callbackify (f) {
   return function (...args) {
     const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
+const { once } = require('events')
 
 module.exports = inject
 
@@ -432,15 +433,12 @@ function inject (bot, { version, hideErrors }) {
 
     const dest = pos.plus(faceVector)
     const eventName = `blockUpdate:${dest}`
-    return new Promise((resolve, reject) => {
-      bot.once(eventName, (oldBlock, newBlock) => {
-        if (oldBlock.type === newBlock.type) {
-          reject(new Error(`No block has been placed : the block is still ${oldBlock.name}`))
-        } else {
-          resolve()
-        }
-      })
-    })
+
+    const [oldBlock, newBlock] = await once(bot, eventName)
+
+    if (oldBlock.type === newBlock.type) {
+      throw new Error(`No block has been placed : the block is still ${oldBlock.name}`)
+    }
   }
 
   function createActionNumber () {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -531,11 +531,6 @@ function inject (bot, { version, hideErrors }) {
       mode,
       item: Item.toNotch(click.item)
     })
-    // notchian servers are assholes and only confirm certain transactions.
-    if (!window.transactionRequiresConfirmation(click)) {
-      // jump the gun and accept the click
-      confirmTransaction(window.id, actionId, true)
-    }
 
     return new Promise((resolve, reject) => {
       bot.once(`confirmTransaction${actionId}`, (success) => {
@@ -545,6 +540,12 @@ function inject (bot, { version, hideErrors }) {
           reject(new Error('Server rejected transaction.'))
         }
       })
+
+      // notchian servers are assholes and only confirm certain transactions.
+      if (!window.transactionRequiresConfirmation(click)) {
+        // jump the gun and accept the click
+        confirmTransaction(window.id, actionId, true)
+      }
     })
   }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
 const { once } = require('events')
-const { callbackify, sleep, createDoneTask } = require('../promise_utils')
+const { callbackify, sleep, createDoneTask, createTask } = require('../promise_utils')
 
 module.exports = inject
 
@@ -81,11 +81,7 @@ function inject (bot, { version, hideErrors }) {
 
     activateItem()
 
-    try {
-      await eatingTask.promise
-    } catch (err) {
-      throw err
-    }
+    await eatingTask.promise
   }
 
   async function fish () {
@@ -97,12 +93,7 @@ function inject (bot, { version, hideErrors }) {
 
     activateItem()
 
-    try {
-      await fishingTask.promise
-    }
-    catch (err) {
-      throw err
-    }
+    await fishingTask.promise
   }
 
   function activateItem (offHand = false) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,7 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
 const { once } = require('events')
+const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
 
@@ -504,14 +505,9 @@ function inject (bot, { version, hideErrors }) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
     if (slot >= bot.QUICK_BAR_START && bot.lastDigTime != null) {
-      const timeSinceLastDig = new Date() - bot.lastDigTime
-      if (timeSinceLastDig < DIG_CLICK_TIMEOUT) {
-        return new Promise(resolve => {
-          setTimeout(async () => {
-            await clickWindow(slot, mouseButton, mode)
-            resolve()
-          }, DIG_CLICK_TIMEOUT - timeSinceLastDig)
-        })
+      let timeSinceLastDig
+      while ((timeSinceLastDig = new Date() - bot.lastDigTime) < DIG_CLICK_TIMEOUT) {
+        await sleep(DIG_CLICK_TIMEOUT - timeSinceLastDig)
       }
     }
     const window = bot.currentWindow || bot.inventory
@@ -538,21 +534,18 @@ function inject (bot, { version, hideErrors }) {
       item: Item.toNotch(click.item)
     })
 
-    return new Promise((resolve, reject) => {
-      bot.once(`confirmTransaction${actionId}`, (success) => {
-        if (success) {
-          resolve()
-        } else {
-          reject(new Error('Server rejected transaction.'))
-        }
-      })
+    const response = once(bot, `confirmTransaction${actionId}`)
 
-      // notchian servers are assholes and only confirm certain transactions.
-      if (!window.transactionRequiresConfirmation(click)) {
-        // jump the gun and accept the click
-        confirmTransaction(window.id, actionId, true)
-      }
-    })
+    // notchian servers are assholes and only confirm certain transactions.
+    if (!window.transactionRequiresConfirmation(click)) {
+      // jump the gun and accept the click
+      confirmTransaction(window.id, actionId, true)
+    }
+
+    const [success] = await response
+    if (!success) {
+      throw new Error('Server rejected transaction.')
+    }
   }
 
   async function putAway (slot) {
@@ -676,13 +669,6 @@ function inject (bot, { version, hideErrors }) {
   bot.openEntity = openEntity
   bot.moveSlotItem = callbackify(moveSlotItem)
   bot.updateHeldItem = updateHeldItem
-}
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
 }
 
 function vectorToDirection (v) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -68,29 +68,39 @@ function inject (bot, { version, hideErrors }) {
     }
   })
 
-  function consume (cb) {
+  async function consume () {
     if (lastEating) {
       lastEating(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
 
     if (bot.food === 20) {
-      return cb(new Error('Food is full'))
+      throw new Error('Food is full')
     }
 
     activateItem()
 
-    lastEating = (err) => setImmediate(cb, err)
+    return new Promise((resolve, reject) => {
+      lastEating = (err) => {
+        if (err) reject(err)
+        else resolve()
+      }
+    })
   }
 
-  function fish (cb) {
+  async function fish () {
     if (lastFishing) {
-      setImmediate(lastFishing, new Error('Fishing cancelled due to calling bot.fish() again'))
+      lastFishing(new Error('Fishing cancelled due to calling bot.fish() again'))
       lastFishing = undefined
       return
     }
 
     activateItem()
-    lastFishing = cb
+    return new Promise((resolve, reject) => {
+      lastFishing = (err) => {
+        if (err) reject(err)
+        else resolve()
+      }
+    })
   }
 
   function activateItem (offHand = false) {
@@ -135,7 +145,7 @@ function inject (bot, { version, hideErrors }) {
         await clickWindow(item.slot, 0, 0)
         await tryToJoin()
       } else {
-        tryToFindEmpty()
+        await tryToFindEmpty()
       }
     }
 
@@ -261,10 +271,8 @@ function inject (bot, { version, hideErrors }) {
         if (firstSourceSlot === null) firstSourceSlot = sourceItem.slot
         // number of item that can be moved from that slot
         await clickWindow(sourceItem.slot, 0, 0)
-        clickDest()
-      } else {
-        clickDest()
       }
+      await clickDest()
 
       async function clickDest () {
         assert.notStrictEqual(window.selectedItem.type, null)
@@ -296,12 +304,12 @@ function inject (bot, { version, hideErrors }) {
           await clickWindow(destSlot, 0, 0)
           // update the number of item we want to move (count)
           count -= movedItems
-          transferOne()
+          await transferOne()
         } else {
           // one by one (right click)
           await clickWindow(destSlot, 1, 0)
           count -= 1
-          transferOne()
+          await transferOne()
         }
       }
     }
@@ -655,8 +663,8 @@ function inject (bot, { version, hideErrors }) {
   bot.activateEntity = callbackify(activateEntity)
   bot.activateEntityAt = callbackify(activateEntityAt)
   bot.placeBlock = callbackify(placeBlock)
-  bot.consume = consume
-  bot.fish = fish
+  bot.consume = callbackify(consume)
+  bot.fish = callbackify(fish)
   bot.activateItem = activateItem
   bot.deactivateItem = deactivateItem
 
@@ -674,7 +682,7 @@ function inject (bot, { version, hideErrors }) {
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -357,7 +357,7 @@ function inject (bot, { version, hideErrors }) {
 
   function openEntity (entity, Class) {
     const session = new Class()
-    session.close = close
+    session.close = callbackify(close)
     bot.once('windowOpen', onWindowOpen)
     bot.activateEntity(entity)
     return session
@@ -370,9 +370,10 @@ function inject (bot, { version, hideErrors }) {
       session.emit('open')
     }
 
-    function close (cb) {
-      if (cb) bot.once('windowClose', cb)
+    async function close () {
+      const closeEvent = once(bot, 'windowClose')
       closeWindow(session.window)
+      await closeEvent
     }
 
     function onClose () {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -118,141 +118,124 @@ function inject (bot, { version, hideErrors }) {
     })
   }
 
-  function putSelectedItemRange (start, end, window, slot, cb) {
+  async function putSelectedItemRange (start, end, window, slot) {
     // put the selected item back indow the slot range in window
 
     // try to put it in an item that already exists and just increase
     // the count.
-    tryToJoin()
+    await tryToJoin()
 
-    function tryToJoin () {
+    async function tryToJoin () {
       if (!window.selectedItem) {
-        cb()
         return
       }
       const item = window.findItemRange(start, end, window.selectedItem.type,
         window.selectedItem.metadata, true)
       if (item) {
-        clickWindow(item.slot, 0, 0, onClick)
+        await clickWindow(item.slot, 0, 0)
+        await tryToJoin()
       } else {
         tryToFindEmpty()
       }
-
-      function onClick (err) {
-        if (err) {
-          cb(err)
-        } else {
-          tryToJoin()
-        }
-      }
     }
 
-    function tryToFindEmpty () {
+    async function tryToFindEmpty () {
       const emptySlot = window.firstEmptySlotRange(start, end)
       if (emptySlot === null) {
         // if there is still some leftover and slot is not null, click slot
         if (slot === null) {
-          tossLeftover()
+          await tossLeftover()
         } else {
-          clickWindow(slot, 0, 0, tossLeftover)
+          await clickWindow(slot, 0, 0)
+          await tossLeftover()
         }
       } else {
-        clickWindow(emptySlot, 0, 0, cb)
+        await clickWindow(emptySlot, 0, 0)
       }
     }
 
-    function tossLeftover () {
+    async function tossLeftover () {
       if (window.selectedItem) {
-        clickWindow(-999, 0, 0, cb)
-      } else {
-        cb()
+        await clickWindow(-999, 0, 0)
       }
     }
   }
 
-  function activateBlock (block, cb) {
+  async function activateBlock (block) {
     // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false, () => {
-      // place block message
-      if (bot.supportFeature('blockPlaceHasHeldItem')) {
-        bot._client.write('block_place', {
-          location: block.position,
-          direction: 1,
-          heldItem: Item.toNotch(bot.heldItem),
-          cursorX: 8,
-          cursorY: 8,
-          cursorZ: 8
-        })
-      } else if (bot.supportFeature('blockPlaceHasHandAndIntCursor')) {
-        bot._client.write('block_place', {
-          location: block.position,
-          direction: 1,
-          hand: 0,
-          cursorX: 8,
-          cursorY: 8,
-          cursorZ: 8
-        })
-      } else if (bot.supportFeature('blockPlaceHasHandAndFloatCursor')) {
-        bot._client.write('block_place', {
-          location: block.position,
-          direction: 1,
-          hand: 0,
-          cursorX: 0.5,
-          cursorY: 0.5,
-          cursorZ: 0.5
-        })
-      } else if (bot.supportFeature('blockPlaceHasInsideBlock')) {
-        bot._client.write('block_place', {
-          location: block.position,
-          direction: 1,
-          hand: 0,
-          cursorX: 0.5,
-          cursorY: 0.5,
-          cursorZ: 0.5,
-          insideBlock: false
-        })
-      }
-
-      // swing arm animation
-      bot.swingArm()
-
-      if (cb) cb()
-    })
-  }
-
-  function activateEntity (entity, cb) {
-    // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(entity.position.offset(0, 1, 0), false, () => {
-      bot._client.write('use_entity', {
-        target: entity.id,
-        mouse: 0,
-        sneaking: false
+    await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
+    // place block message
+    if (bot.supportFeature('blockPlaceHasHeldItem')) {
+      bot._client.write('block_place', {
+        location: block.position,
+        direction: 1,
+        heldItem: Item.toNotch(bot.heldItem),
+        cursorX: 8,
+        cursorY: 8,
+        cursorZ: 8
       })
-      if (cb) cb()
-    })
-  }
-
-  function activateEntityAt (entity, position, cb) {
-    // TODO: tell the server that we are not sneaking while doing this
-    bot.lookAt(position, false, () => {
-      bot._client.write('use_entity', {
-        target: entity.id,
-        mouse: 2,
-        sneaking: false,
-        x: position.x - entity.position.x,
-        y: position.y - entity.position.y,
-        z: position.z - entity.position.z
+    } else if (bot.supportFeature('blockPlaceHasHandAndIntCursor')) {
+      bot._client.write('block_place', {
+        location: block.position,
+        direction: 1,
+        hand: 0,
+        cursorX: 8,
+        cursorY: 8,
+        cursorZ: 8
       })
-      if (cb) cb()
+    } else if (bot.supportFeature('blockPlaceHasHandAndFloatCursor')) {
+      bot._client.write('block_place', {
+        location: block.position,
+        direction: 1,
+        hand: 0,
+        cursorX: 0.5,
+        cursorY: 0.5,
+        cursorZ: 0.5
+      })
+    } else if (bot.supportFeature('blockPlaceHasInsideBlock')) {
+      bot._client.write('block_place', {
+        location: block.position,
+        direction: 1,
+        hand: 0,
+        cursorX: 0.5,
+        cursorY: 0.5,
+        cursorZ: 0.5,
+        insideBlock: false
+      })
+    }
+
+    // swing arm animation
+    bot.swingArm()
+  }
+
+  async function activateEntity (entity) {
+    // TODO: tell the server that we are not sneaking while doing this
+    await bot.lookAt(entity.position.offset(0, 1, 0), false)
+    bot._client.write('use_entity', {
+      target: entity.id,
+      mouse: 0,
+      sneaking: false
     })
   }
 
-  function transfer (options, cb) {
+  async function activateEntityAt (entity, position) {
+    // TODO: tell the server that we are not sneaking while doing this
+    await bot.lookAt(position, false)
+    bot._client.write('use_entity', {
+      target: entity.id,
+      mouse: 2,
+      sneaking: false,
+      x: position.x - entity.position.x,
+      y: position.y - entity.position.y,
+      z: position.z - entity.position.z
+    })
+  }
+
+  async function transfer (options) {
     const window = options.window || bot.currentWindow || bot.inventory
     const itemType = options.itemType
     const metadata = options.metadata
     let count = options.count === null ? 1 : options.count
-    cb = cb || noop
     let firstSourceSlot = null
 
     // ranges
@@ -263,32 +246,27 @@ function inject (bot, { version, hideErrors }) {
     const sourceEnd = options.sourceEnd === null ? sourceStart + 1 : options.sourceEnd
     const destEnd = options.destEnd === null ? destStart + 1 : options.destEnd
 
-    transferOne()
+    await transferOne()
 
-    function transferOne () {
+    async function transferOne () {
       if (count === 0) {
-        putSelectedItemRange(sourceStart, sourceEnd, window, firstSourceSlot, cb)
+        await putSelectedItemRange(sourceStart, sourceEnd, window, firstSourceSlot)
         return
       }
       if (!window.selectedItem || window.selectedItem.type !== itemType ||
         (metadata != null && window.selectedItem.metadata !== metadata)) {
         // we are not holding the item we need. click it.
         const sourceItem = window.findItemRange(sourceStart, sourceEnd, itemType, metadata)
-        if (!sourceItem) return cb(new Error(`missing source item ${itemType}:${metadata} in (${sourceStart},${sourceEnd})`))
+        if (!sourceItem) throw new Error(`missing source item ${itemType}:${metadata} in (${sourceStart},${sourceEnd})`)
         if (firstSourceSlot === null) firstSourceSlot = sourceItem.slot
         // number of item that can be moved from that slot
-        clickWindow(sourceItem.slot, 0, 0, (err) => {
-          if (err) {
-            cb(err)
-          } else {
-            clickDest()
-          }
-        })
+        await clickWindow(sourceItem.slot, 0, 0)
+        clickDest()
       } else {
         clickDest()
       }
 
-      function clickDest () {
+      async function clickDest () {
         assert.notStrictEqual(window.selectedItem.type, null)
         assert.notStrictEqual(window.selectedItem.metadata, null)
         let destItem
@@ -306,8 +284,7 @@ function inject (bot, { version, hideErrors }) {
             : window.firstEmptySlotRange(destStart, destEnd)
           // if that didn't work, give up
           if (destSlot === null) {
-            cb(new Error('destination full'))
-            return
+            throw new Error('destination full')
           }
         }
         // move the maximum number of item that can be moved
@@ -316,25 +293,15 @@ function inject (bot, { version, hideErrors }) {
         // if the number of item the left click moves is less than the number of item we want to move
         // several at the same time (left click)
         if (movedItems <= count) {
-          clickWindow(destSlot, 0, 0, (err) => {
-            if (err) {
-              cb(err)
-            } else {
-              // update the number of item we want to move (count)
-              count -= movedItems
-              transferOne()
-            }
-          })
+          await clickWindow(destSlot, 0, 0)
+          // update the number of item we want to move (count)
+          count -= movedItems
+          transferOne()
         } else {
           // one by one (right click)
-          clickWindow(destSlot, 1, 0, (err) => {
-            if (err) {
-              cb(err)
-            } else {
-              count -= 1
-              transferOne()
-            }
-          })
+          await clickWindow(destSlot, 1, 0)
+          count -= 1
+          transferOne()
         }
       }
     }
@@ -405,66 +372,66 @@ function inject (bot, { version, hideErrors }) {
     }
   }
 
-  function placeBlock (referenceBlock, faceVector, cb = noop) {
-    if (!bot.heldItem) return cb(new Error('must be holding an item to place a block'))
+  async function placeBlock (referenceBlock, faceVector) {
+    if (!bot.heldItem) throw new Error('must be holding an item to place a block')
     // Look at the center of the face
     const dx = 0.5 + faceVector.x * 0.5
     const dy = 0.5 + faceVector.y * 0.5
     const dz = 0.5 + faceVector.z * 0.5
-    bot.lookAt(referenceBlock.position.offset(dx, dy, dz), false, () => {
-      // TODO: tell the server that we are sneaking while doing this
-      bot.swingArm()
-      const pos = referenceBlock.position
+    await bot.lookAt(referenceBlock.position.offset(dx, dy, dz), false)
+    // TODO: tell the server that we are sneaking while doing this
+    bot.swingArm()
+    const pos = referenceBlock.position
 
-      if (bot.supportFeature('blockPlaceHasHeldItem')) {
-        bot._client.write('block_place', {
-          location: pos,
-          direction: vectorToDirection(faceVector),
-          heldItem: Item.toNotch(bot.heldItem),
-          cursorX: 8,
-          cursorY: 8,
-          cursorZ: 8
-        })
-      } else if (bot.supportFeature('blockPlaceHasHandAndIntCursor')) {
-        bot._client.write('block_place', {
-          location: pos,
-          direction: vectorToDirection(faceVector),
-          hand: 0,
-          cursorX: 8,
-          cursorY: 8,
-          cursorZ: 8
-        })
-      } else if (bot.supportFeature('blockPlaceHasHandAndFloatCursor')) {
-        bot._client.write('block_place', {
-          location: pos,
-          direction: vectorToDirection(faceVector),
-          hand: 0,
-          cursorX: 0.5,
-          cursorY: 0.5,
-          cursorZ: 0.5
-        })
-      } else if (bot.supportFeature('blockPlaceHasInsideBlock')) {
-        bot._client.write('block_place', {
-          location: pos,
-          direction: vectorToDirection(faceVector),
-          hand: 0,
-          cursorX: 0.5,
-          cursorY: 0.5,
-          cursorZ: 0.5,
-          insideBlock: false
-        })
-      }
+    if (bot.supportFeature('blockPlaceHasHeldItem')) {
+      bot._client.write('block_place', {
+        location: pos,
+        direction: vectorToDirection(faceVector),
+        heldItem: Item.toNotch(bot.heldItem),
+        cursorX: 8,
+        cursorY: 8,
+        cursorZ: 8
+      })
+    } else if (bot.supportFeature('blockPlaceHasHandAndIntCursor')) {
+      bot._client.write('block_place', {
+        location: pos,
+        direction: vectorToDirection(faceVector),
+        hand: 0,
+        cursorX: 8,
+        cursorY: 8,
+        cursorZ: 8
+      })
+    } else if (bot.supportFeature('blockPlaceHasHandAndFloatCursor')) {
+      bot._client.write('block_place', {
+        location: pos,
+        direction: vectorToDirection(faceVector),
+        hand: 0,
+        cursorX: 0.5,
+        cursorY: 0.5,
+        cursorZ: 0.5
+      })
+    } else if (bot.supportFeature('blockPlaceHasInsideBlock')) {
+      bot._client.write('block_place', {
+        location: pos,
+        direction: vectorToDirection(faceVector),
+        hand: 0,
+        cursorX: 0.5,
+        cursorY: 0.5,
+        cursorZ: 0.5,
+        insideBlock: false
+      })
+    }
 
-      const dest = pos.plus(faceVector)
-      const eventName = `blockUpdate:${dest}`
-      bot.once(eventName, onBlockUpdate)
-      function onBlockUpdate (oldBlock, newBlock) {
+    const dest = pos.plus(faceVector)
+    const eventName = `blockUpdate:${dest}`
+    return new Promise((resolve, reject) => {
+      bot.once(eventName, (oldBlock, newBlock) => {
         if (oldBlock.type === newBlock.type) {
-          cb(new Error(`No block has been placed : the block is still ${oldBlock.name}`))
+          reject(new Error(`No block has been placed : the block is still ${oldBlock.name}`))
         } else {
-          cb()
+          resolve()
         }
-      }
+      })
     })
   }
 
@@ -527,19 +494,20 @@ function inject (bot, { version, hideErrors }) {
     }
   }
 
-  function clickWindow (slot, mouseButton, mode, cb) {
+  async function clickWindow (slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
     if (slot >= bot.QUICK_BAR_START && bot.lastDigTime != null) {
       const timeSinceLastDig = new Date() - bot.lastDigTime
       if (timeSinceLastDig < DIG_CLICK_TIMEOUT) {
-        setTimeout(() => {
-          clickWindow(slot, mouseButton, mode, cb)
-        }, DIG_CLICK_TIMEOUT - timeSinceLastDig)
-        return
+        return new Promise(resolve => {
+          setTimeout(async () => {
+            await clickWindow(slot, mouseButton, mode)
+            resolve()
+          }, DIG_CLICK_TIMEOUT - timeSinceLastDig)
+        })
       }
     }
-    cb = cb || noop
     const window = bot.currentWindow || bot.inventory
 
     assert.ok(mouseButton === 0 || mouseButton === 1)
@@ -563,46 +531,40 @@ function inject (bot, { version, hideErrors }) {
       mode,
       item: Item.toNotch(click.item)
     })
-    bot.once(`confirmTransaction${actionId}`, (success) => {
-      if (success) {
-        cb()
-      } else {
-        cb(new Error('Server rejected transaction.'))
-      }
-    })
     // notchian servers are assholes and only confirm certain transactions.
     if (!window.transactionRequiresConfirmation(click)) {
       // jump the gun and accept the click
       confirmTransaction(window.id, actionId, true)
     }
-  }
 
-  function putAway (slot, cb) {
-    clickWindow(slot, 0, 0, (err) => {
-      if (err) return cb(err)
-      const window = bot.currentWindow || bot.inventory
-      const start = window.inventoryStart
-      const end = window.inventoryEnd
-      putSelectedItemRange(start, end, window, null, cb)
-    })
-  }
-
-  function moveSlotItem (sourceSlot, destSlot, cb) {
-    clickWindow(sourceSlot, 0, 0, (err) => {
-      if (err) return cb(err)
-      clickWindow(destSlot, 0, 0, (err) => {
-        // if we're holding an item, put it back where the source item was.
-        // otherwise we're done.
-        updateHeldItem()
-        if (err) {
-          cb(err)
-        } else if (bot.inventory.selectedItem) {
-          clickWindow(sourceSlot, 0, 0, cb)
+    return new Promise((resolve, reject) => {
+      bot.once(`confirmTransaction${actionId}`, (success) => {
+        if (success) {
+          resolve()
         } else {
-          cb()
+          reject(new Error('Server rejected transaction.'))
         }
       })
     })
+  }
+
+  async function putAway (slot) {
+    await clickWindow(slot, 0, 0)
+    const window = bot.currentWindow || bot.inventory
+    const start = window.inventoryStart
+    const end = window.inventoryEnd
+    await putSelectedItemRange(start, end, window, null)
+  }
+
+  async function moveSlotItem (sourceSlot, destSlot) {
+    await clickWindow(sourceSlot, 0, 0)
+    await clickWindow(destSlot, 0, 0)
+    // if we're holding an item, put it back where the source item was.
+    // otherwise we're done.
+    updateHeldItem()
+    if (bot.inventory.selectedItem) {
+      await clickWindow(sourceSlot, 0, 0)
+    }
   }
 
   bot._client.on('transaction', (packet) => {
@@ -688,29 +650,32 @@ function inject (bot, { version, hideErrors }) {
     bot.emit(`setWindowItems:${window.id}`)
   })
 
-  bot.activateBlock = activateBlock
-  bot.activateEntity = activateEntity
-  bot.activateEntityAt = activateEntityAt
-  bot.placeBlock = placeBlock
+  bot.activateBlock = callbackify(activateBlock)
+  bot.activateEntity = callbackify(activateEntity)
+  bot.activateEntityAt = callbackify(activateEntityAt)
+  bot.placeBlock = callbackify(placeBlock)
   bot.consume = consume
   bot.fish = fish
   bot.activateItem = activateItem
   bot.deactivateItem = deactivateItem
 
   // not really in the public API
-  bot.clickWindow = clickWindow
-  bot.putSelectedItemRange = putSelectedItemRange
-  bot.putAway = putAway
+  bot.clickWindow = callbackify(clickWindow)
+  bot.putSelectedItemRange = callbackify(putSelectedItemRange)
+  bot.putAway = callbackify(putAway)
   bot.closeWindow = closeWindow
-  bot.transfer = transfer
+  bot.transfer = callbackify(transfer)
   bot.openBlock = openBlock
   bot.openEntity = openEntity
-  bot.moveSlotItem = moveSlotItem
+  bot.moveSlotItem = callbackify(moveSlotItem)
   bot.updateHeldItem = updateHeldItem
 }
 
-function noop (err) {
-  if (err) throw err
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }
 
 function vectorToDirection (v) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once } = require('events')
+const { once, EventEmitter } = require('events')
 const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
@@ -22,8 +22,9 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
-  bot._internalEvents.eating = false
-  bot._internalEvents.fishing = false
+  const inventoryEvents = new EventEmitter()
+  inventoryEvents.eating = false
+  inventoryEvents.fishing = false
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -38,25 +39,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone')
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone')
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && bot._internalEvents.fishing && !lastFloat) {
+    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !bot._internalEvents.fishing) return
+    if (!lastFloat || !inventoryEvents.fishing) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone')
+      inventoryEvents.emit('fishingDone')
     }
   })
 
@@ -64,51 +65,51 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled'))
+      inventoryEvents.emit('fishingDone', new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (bot._internalEvents.eating) {
-      bot._internalEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
-      bot._internalEvents.eating = false
+    if (inventoryEvents.eating) {
+      inventoryEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
+      inventoryEvents.eating = false
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
-    bot._internalEvents.eating = true
+    inventoryEvents.eating = true
 
     activateItem()
 
-    const [err] = await once(bot._internalEvents, 'eatingDone')
+    const [err] = await once(inventoryEvents, 'eatingDone')
 
     if (err) {
       throw err
     }
 
-    bot._internalEvents.eating = false
+    inventoryEvents.eating = false
   }
 
   async function fish () {
-    if (bot._internalEvents.fishing) {
-      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
-      bot._internalEvents.fishing = false
+    if (inventoryEvents.fishing) {
+      inventoryEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
+      inventoryEvents.fishing = false
       return
     }
 
-    bot._internalEvents.fishing = true
+    inventoryEvents.fishing = true
 
     activateItem()
 
-    const [err] = await once(bot._internalEvents, 'fishingDone')
+    const [err] = await once(inventoryEvents, 'fishingDone')
 
     if (err) {
       throw err
     }
 
-    bot._internalEvents.fishing = false
+    inventoryEvents.fishing = false
   }
 
   function activateItem (offHand = false) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
-const { once, EventEmitter } = require('events')
+const { once } = require('events')
 const { callbackify, sleep } = require('../promise_utils')
 
 module.exports = inject
@@ -22,9 +22,8 @@ function inject (bot, { version, hideErrors }) {
     bobberId = mcData.entitiesByName.fishing_bobber.id
   }
 
-  const inventoryEvents = new EventEmitter()
-  inventoryEvents.eating = false
-  inventoryEvents.fishing = false
+  bot._internalEvents.eating = false
+  bot._internalEvents.fishing = false
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -39,25 +38,25 @@ function inject (bot, { version, hideErrors }) {
   bot.heldItem = null
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone', true)
+    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && bot._internalEvents.eating) {
+      bot._internalEvents.emit('eatingDone')
     }
   })
 
   bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && inventoryEvents.fishing && !lastFloat) {
+    if (packet.type === bobberId && bot._internalEvents.fishing && !lastFloat) {
       lastFloat = bot.entities[packet.entityId]
     }
   })
 
   bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || !inventoryEvents.fishing) return
+    if (!lastFloat || !bot._internalEvents.fishing) return
 
     const pos = lastFloat.position
     if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
       activateItem()
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone', true)
+      bot._internalEvents.emit('fishingDone', true)
     }
   })
 
@@ -65,51 +64,51 @@ function inject (bot, { version, hideErrors }) {
     if (!lastFloat) return
     if (packet.entityIds.some(id => id === lastFloat.id)) {
       lastFloat = undefined
-      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled'))
+      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled'))
     }
   })
 
   async function consume () {
-    if (inventoryEvents.eating) {
-      inventoryEvents.emit('eatingDone', false, new Error('Consuming cancelled due to calling bot.consume() again'))
-      inventoryEvents.eating = false
+    if (bot._internalEvents.eating) {
+      bot._internalEvents.emit('eatingDone', new Error('Consuming cancelled due to calling bot.consume() again'))
+      bot._internalEvents.eating = false
     }
 
     if (bot.food === 20) {
       throw new Error('Food is full')
     }
 
-    inventoryEvents.eating = true
+    bot._internalEvents.eating = true
 
     activateItem()
 
-    const [eatingDone, err] = await once(inventoryEvents, 'eatingDone')
+    const [err] = await once(bot._internalEvents, 'eatingDone')
 
-    if (!eatingDone) {
+    if (err) {
       throw err
     }
 
-    inventoryEvents.eating = false
+    bot._internalEvents.eating = false
   }
 
   async function fish () {
-    if (inventoryEvents.fishing) {
-      inventoryEvents.emit('fishingDone', false, new Error('Fishing cancelled due to calling bot.fish() again'))
-      inventoryEvents.fishing = false
+    if (bot._internalEvents.fishing) {
+      bot._internalEvents.emit('fishingDone', new Error('Fishing cancelled due to calling bot.fish() again'))
+      bot._internalEvents.fishing = false
       return
     }
 
-    inventoryEvents.fishing = true
+    bot._internalEvents.fishing = true
 
     activateItem()
 
-    const [fishingDone, err] = await once(inventoryEvents, 'fishingDone')
+    const [err] = await once(bot._internalEvents, 'fishingDone')
 
-    if (!fishingDone) {
+    if (err) {
       throw err
     }
 
-    inventoryEvents.fishing = false
+    bot._internalEvents.fishing = false
   }
 
   function activateItem (offHand = false) {
@@ -541,15 +540,14 @@ function inject (bot, { version, hideErrors }) {
       item: Item.toNotch(click.item)
     })
 
-    const response = once(bot, `confirmTransaction${actionId}`)
-
     // notchian servers are assholes and only confirm certain transactions.
     if (!window.transactionRequiresConfirmation(click)) {
       // jump the gun and accept the click
       confirmTransaction(window.id, actionId, true)
+      return
     }
 
-    const [success] = await response
+    const [success] = await once(bot, `confirmTransaction${actionId}`)
     if (!success) {
       throw new Error('Server rejected transaction.')
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const math = require('../math')
 const conv = require('../conversions')
 const { performance } = require('perf_hooks')
+const { callbackify } = require('../promise_utils')
 
 const { Physics, PlayerState } = require('prismarine-physics')
 
@@ -196,13 +197,6 @@ function inject (bot) {
 
   function noop (err) {
     if (err) throw err
-  }
-
-  function callbackify (f) {
-    return function (...args) {
-      const cb = args[f.length]
-      return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-    }
   }
 
   let lookAtCb = noop

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -198,6 +198,13 @@ function inject (bot) {
     if (err) throw err
   }
 
+  function callbackify (f) {
+    return function (...args) {
+      const cb = args[f.length] || (() => {})
+      return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+    }
+  }
+
   let lookAtCb = noop
   function checkYaw () {
     if (Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001) {
@@ -207,25 +214,24 @@ function inject (bot) {
   }
   bot.on('move', checkYaw)
 
-  bot.look = (yaw, pitch, force, cb) => {
+  bot.look = callbackify((yaw, pitch, force) => {
     bot.entity.yaw = yaw
     bot.entity.pitch = pitch
     if (force) {
       lastSentYaw = yaw
-      lookAtCb = noop
-      cb()
+      return Promise.resolve()
     } else {
-      lookAtCb = cb || noop
+      return new Promise(resolve => { lookAtCb = resolve })
     }
-  }
+  })
 
-  bot.lookAt = (point, force, cb) => {
+  bot.lookAt = callbackify(async (point, force) => {
     const delta = point.minus(bot.entity.position.offset(0, bot.entity.height, 0))
     const yaw = Math.atan2(-delta.x, -delta.z)
     const groundDistance = Math.sqrt(delta.x * delta.x + delta.z * delta.z)
     const pitch = Math.atan2(delta.y, groundDistance)
-    bot.look(yaw, pitch, force, cb)
-  }
+    await bot.look(yaw, pitch, force)
+  })
 
   // player position and look (clientbound)
   bot._client.on('position', (packet) => {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -200,7 +200,7 @@ function inject (bot) {
 
   function callbackify (f) {
     return function (...args) {
-      const cb = args[f.length] || (() => {})
+      const cb = args[f.length]
       return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
     }
   }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -4,6 +4,7 @@ const math = require('../math')
 const conv = require('../conversions')
 const { performance } = require('perf_hooks')
 const { callbackify } = require('../promise_utils')
+const { once } = require('events')
 
 const { Physics, PlayerState } = require('prismarine-physics')
 
@@ -195,28 +196,17 @@ function inject (bot) {
     })
   }
 
-  function noop (err) {
-    if (err) throw err
-  }
-
-  let lookAtCb = noop
-  function checkYaw () {
-    if (Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001) {
-      lookAtCb()
-      lookAtCb = noop
-    }
-  }
-  bot.on('move', checkYaw)
-
-  bot.look = callbackify((yaw, pitch, force) => {
+  bot.look = callbackify(async (yaw, pitch, force) => {
     bot.entity.yaw = yaw
     bot.entity.pitch = pitch
     if (force) {
       lastSentYaw = yaw
-      return Promise.resolve()
-    } else {
-      return new Promise(resolve => { lookAtCb = resolve })
+      return
     }
+
+    do {
+      await once(bot, 'move')
+    } while (Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) >= 0.001)
   })
 
   bot.lookAt = callbackify(async (point, force) => {

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -7,7 +7,7 @@ const QUICK_BAR_START = 36
 
 function callbackify (f) {
   return function (...args) {
-    const cb = args[f.length] || (() => {})
+    const cb = args[f.length]
     return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -5,8 +5,11 @@ module.exports = inject
 const QUICK_BAR_COUNT = 9
 const QUICK_BAR_START = 36
 
-function noop (err) {
-  if (err) throw err
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length] || (() => {})
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
 }
 
 function inject (bot) {
@@ -23,16 +26,14 @@ function inject (bot) {
     armorSlots['off-hand'] = 45
   }
 
-  function tossStack (item, cb = noop) {
+  async function tossStack (item) {
     assert.ok(item)
-    bot.clickWindow(item.slot, 0, 0, (err) => {
-      if (err) return cb(err)
-      bot.clickWindow(-999, 0, 0, cb)
-      bot.closeWindow(bot.currentWindow || bot.inventory)
-    })
+    await bot.clickWindow(item.slot, 0, 0)
+    await bot.clickWindow(-999, 0, 0)
+    bot.closeWindow(bot.currentWindow || bot.inventory)
   }
 
-  function toss (itemType, metadata, count, cb) {
+  async function toss (itemType, metadata, count) {
     const window = bot.currentWindow || bot.inventory
     const options = {
       window,
@@ -43,14 +44,14 @@ function inject (bot) {
       sourceEnd: window.inventoryEnd,
       destStart: -999
     }
-    bot.transfer(options, cb)
+    await bot.transfer(options)
   }
 
-  function unequip (destination, cb = noop) {
+  async function unequip (destination) {
     if (destination === 'hand') {
-      equipEmpty(cb)
+      await equipEmpty()
     } else {
-      disrobe(destination, cb)
+      await disrobe(destination)
     }
   }
 
@@ -65,64 +66,55 @@ function inject (bot) {
     bot.updateHeldItem()
   }
 
-  function equipEmpty (cb) {
+  async function equipEmpty () {
     for (let i = 0; i < 9; ++i) {
       if (!bot.inventory.slots[QUICK_BAR_START + i]) {
         setQuickBarSlot(i)
-        process.nextTick(cb)
         return
       }
     }
     const slot = bot.inventory.firstEmptyInventorySlot()
     if (!slot) {
-      bot.tossStack(bot.heldItem, cb)
+      await bot.tossStack(bot.heldItem)
       return
     }
     const equipSlot = QUICK_BAR_START + bot.quickBarSlot
-    bot.clickWindow(equipSlot, 0, 0, (err) => {
-      if (err) return cb(err)
-      bot.clickWindow(slot, 0, 0, (err) => {
-        if (err) return cb(err)
-        if (bot.inventory.selectedItem) {
-          bot.clickWindow(-999, 0, 0, cb)
-        } else {
-          cb()
-        }
-      })
-    })
+    await bot.clickWindow(equipSlot, 0, 0)
+    await bot.clickWindow(slot, 0, 0)
+    if (bot.inventory.selectedItem) {
+      await bot.clickWindow(-999, 0, 0)
+    }
   }
 
-  function disrobe (destination, cb) {
+  async function disrobe (destination) {
     assert.strictEqual(bot.currentWindow, null)
     const destSlot = getDestSlot(destination)
-    bot.putAway(destSlot, cb)
+    await bot.putAway(destSlot)
   }
 
-  function equip (item, destination, cb = noop) {
+  async function equip (item, destination) {
     if (typeof item === 'number') {
       item = bot.inventory.findInventoryItem(item)
     }
     if (item == null || typeof item !== 'object') {
-      return cb(new Error('Invalid item object in equip'))
+      throw new Error('Invalid item object in equip')
     }
     const sourceSlot = item.slot
     let destSlot = getDestSlot(destination)
 
     if (sourceSlot === destSlot) {
       // don't need to do anything
-      process.nextTick(cb)
       return
     }
 
     if (destination !== 'hand') {
-      bot.moveSlotItem(sourceSlot, destSlot, cb)
+      await bot.moveSlotItem(sourceSlot, destSlot)
       return
     }
 
     if (destSlot >= QUICK_BAR_START && sourceSlot >= QUICK_BAR_START) {
       // all we have to do is change the quick bar selection
       bot.setQuickBarSlot(sourceSlot - QUICK_BAR_START)
-      process.nextTick(cb)
       return
     }
 
@@ -134,7 +126,7 @@ function inject (bot) {
       nextQuickBarSlot = (nextQuickBarSlot + 1) % QUICK_BAR_COUNT
     }
     setQuickBarSlot(destSlot - QUICK_BAR_START)
-    bot.moveSlotItem(sourceSlot, destSlot, cb)
+    await bot.moveSlotItem(sourceSlot, destSlot)
   }
 
   function getDestSlot (destination) {
@@ -147,10 +139,10 @@ function inject (bot) {
     }
   }
 
-  bot.equip = equip
-  bot.unequip = unequip
-  bot.toss = toss
-  bot.tossStack = tossStack
+  bot.equip = callbackify(equip)
+  bot.unequip = callbackify(unequip)
+  bot.toss = callbackify(toss)
+  bot.tossStack = callbackify(tossStack)
   bot.setQuickBarSlot = setQuickBarSlot
   bot.getEquipmentDestSlot = getDestSlot
 

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -1,16 +1,10 @@
 const assert = require('assert')
+const { callbackify } = require('../promise_utils')
 
 module.exports = inject
 
 const QUICK_BAR_COUNT = 9
 const QUICK_BAR_START = 36
-
-function callbackify (f) {
-  return function (...args) {
-    const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
-  }
-}
 
 function inject (bot) {
   let nextQuickBarSlot = 0

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -1,0 +1,15 @@
+function callbackify (f) {
+  return function (...args) {
+    const cb = args[f.length]
+    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+  }
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+module.exports = {
+  callbackify,
+  sleep
+}

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -26,8 +26,8 @@ function createTask () {
   return task
 }
 
-function createDoneTask() {
-  const task = { 
+function createDoneTask () {
+  const task = {
     done: true,
     promise: Promise.resolve(),
     cancel: () => {},

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -1,7 +1,7 @@
 function callbackify (f) {
   return function (...args) {
     const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(null, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }
 

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -9,7 +9,36 @@ function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+function createTask () {
+  const task = {
+    done: false
+  }
+  task.promise = new Promise((resolve, reject) => {
+    task.cancel = (err) => {
+      reject(err)
+      task.done = true
+    }
+    task.finish = () => {
+      resolve()
+      task.done = true
+    }
+  })
+  return task
+}
+
+function createDoneTask() {
+  const task = { 
+    done: true,
+    promise: Promise.resolve(),
+    cancel: () => {},
+    finish: () => {}
+  }
+  return task
+}
+
 module.exports = {
   callbackify,
-  sleep
+  sleep,
+  createTask,
+  createDoneTask
 }

--- a/test/externalTests/commandBlock.js
+++ b/test/externalTests/commandBlock.js
@@ -1,10 +1,5 @@
 const vec3 = require('vec3')
-
-function sleep (ms) {
-  return new Promise((resolve, reject) => {
-    setTimeout(resolve, ms)
-  })
-}
+const { sleep } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot, done) => {
   const command = `/say ${Math.floor(Math.random() * 1000)}`

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -481,12 +481,12 @@ mineflayer.testedVersions.forEach((supportedVersion, i) => {
           assert.strictEqual(bedBockMetadata.part, false, 'The part property seems to be wrong') // Is the foot
 
           if (beds[bed].throws) {
-            assert.throws(() => {
-              bot.sleep(bedBock)
-            }, beds[bed].error)
+            bot.sleep(bedBock, (err) => {
+              assert.strictEqual(err, beds[bed].error)
+            })
           } else {
-            assert.doesNotThrow(() => {
-              bot.sleep(bedBock)
+            bot.sleep(bedBock, (err) => {
+              assert.ifError(err)
             })
           }
         }


### PR DESCRIPTION
Fixes #725. All callback functions have been promisifed. All tests are passing. The only functions not promisified are the following in villager.js:

```
villager#openVillager
villager#trade
(villager#putRequirements)
(villager#deposit)
```

I would like people to think with me on what is the best way to promisify these. The reason they aren't done now is because openVillager has a callback and _also_ synchronously returns a value. This is not something supported by promises normally.

There are also a few remarks to this PR.
- While going through the code, I was wondering if [the enchant function](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/enchantment_table.js#L54) was actually in the right order? Shouldn't the listener be registered before the 'enchant_item' call so as to not create a race condition?
- In [simple_inventory#tossStack](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/simple_inventory.js#L26), I have slightly changed the order of operations. This can be seen [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/simple_inventory.js#L29). It seemed to make the most sense to me to close the window only after clicking outside the inventory, not introducing a race condition.
- In [creative#setInventorySlot](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/creative.js#L28) it doesn't check if cb is null anymore, as can be seen [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/creative.js#L28). Calling the function on the same slot again will now _always_ fail if called before the previous callback has succeeded, even if there is no callback passed through the "callbackified" function. This is because internally the resolve function is always present, and null checks cannot be done on it. This seemed fine to me, since it would be weird behavior anyway to call this function without a callback.
- [Inventory#consume](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/inventory.js#L71) used to _return_ an error **synchronously**. It now throws this instead, as can be seen [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/inventory.js#L71), so it will be passed asynchronously to the callback function as an err object, or to the promise's reject function of course.
- The same as above goes for [bed#sleep](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/bed.js#L85). The changed version is [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/bed.js#L87). An important distinction is that a test had to be changed for this. [Where it asserted .throws() before,](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/test/internalTest.js#L483), it now asserts equality with the err object instead, as can be seen [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/test/internalTest.js#L483)
- Lastly, [inventory#consume](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/inventory.js#L71) and [inventory#fish](https://github.com/PrismarineJS/mineflayer/blob/124e8508f44ee1e18cd2ac13c59d50a30b733d7e/lib/plugins/inventory.js#L85) have their _setImmediate_ calls removed. The new functions are respectively [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/inventory.js#L71) and [here](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/inventory.js#L90). I'm _pretty_ sure the semantics are correct, but I'd like someone to verify if possible.

All in all, the promisification allows for much cleaner code both internally and externally. I've done some slight cleaning up in the [craft](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/craft.js#L9) function that is now flattened with a for loop instead of a recursive function, as well as lots of places with chained callbacks, but more can be done. [Inventory#transfer](https://github.com/ph0t0shop/mineflayer/blob/26c55e54f8c38a066cd60843106dc0c0e5e28974/lib/plugins/inventory.js#L244) for example can be greatly improved. Functionally though, I think everything works fine, and the outside API is backwards compatible with the callback versions.