### PR TITLE
Added mcData reference QOL

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -103,6 +103,7 @@
       - [bot.game.gameMode](#botgamegamemode)
       - [bot.game.hardcore](#botgamehardcore)
       - [bot.game.maxPlayers](#botgamemaxplayers)
+      - [bot.mcData](#botmcdata)
     - [bot.player](#botplayer)
       - [bot.players](#botplayers)
       - [bot.isRaining](#botisraining)
@@ -789,6 +790,10 @@ Coordinates to the main spawn point, where all compasses point to.
 #### bot.game.hardcore
 
 #### bot.game.maxPlayers
+
+#### bot.mcData
+
+A reference to the Minecraft-Data object for the Minecraft version that is currently being used by this bot.
 
 ### bot.player
 

--- a/index.js
+++ b/index.js
@@ -112,7 +112,8 @@ class Bot extends EventEmitter {
     if (!self._client.wait_connect) next()
     else self._client.once('connect_allowed', next)
     function next () {
-      const version = require('minecraft-data')(self._client.version).version
+      const mcData = require('minecraft-data')(self._client.version)
+      const version = mcData.version
       if (supportedVersions.indexOf(version.majorVersion) === -1) {
         throw new Error(`Version ${version.minecraftVersion} is not supported.`)
       }
@@ -128,6 +129,8 @@ class Bot extends EventEmitter {
       self.version = version.minecraftVersion
       options.version = version.minecraftVersion
       self.supportFeature = feature => supportFeature(feature, version.minecraftVersion)
+      self.mcData = mcData
+
       self.emit('inject_allowed')
     }
   }


### PR DESCRIPTION
I thought that it would be useful to initalize a mcData instance alongwith the bot on startup. Since Minecraft-Data is loaded by the bot on startup anyway, why not attach it as a property for quality of life. This way you don't have to redefine mcData whenever you want to use it. (Which is quite often.)

