### PR TITLE
fix incorrect handling of username definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,10 +96,6 @@ class Bot extends EventEmitter {
   connect (options) {
     const self = this
     self._client = mc.createClient(options)
-    self.username = self._client.username
-    self._client.on('session', () => {
-      self.username = self._client.username
-    })
     self._client.on('connect', () => {
       self.emit('connect')
     })

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -88,7 +88,8 @@ function inject (bot, { version }) {
   bot._client.once('login', (packet) => {
     // login
     bot.entity = fetchEntity(packet.entityId)
-    bot.entity.username = bot.username
+    bot.username = bot._client.username
+    bot.entity.username = bot._client.username
     bot.entity.type = 'player'
   })
 


### PR DESCRIPTION
The right place to set the username mineflayer side is the login packet.
At this point both in offline and online mode, all information about the username is known.

The previous behavior relied on an incorrect assumption that the username definition was always available in the same event loop iteration than createClient call.