### PR TITLE
Make the ChatMessage.toAnsi:lang argument optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -437,7 +437,7 @@ export class ChatMessage {
 
   toMotd(lang?: { [key: string]: string }): string;
 
-  toAnsi(lang: { [key: string]: string }): string;
+  toAnsi(lang?: { [key: string]: string }): string;
 }
 
 export interface ChatPattern {


### PR DESCRIPTION
According to the example ansi.js on line 21 (https://github.com/PrismarineJS/mineflayer/blob/4afb69d83fc58008c4d96bcde78fbca4954dcc8e/examples/ansi.js#L21), the `lang` argument should be optional, similar to `toMotd`.
If I'm incorrect, feel free to correct me.