### PR TITLE
set extraInfos to false in blockIsNotEmpty

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -228,7 +228,7 @@ function inject (bot, { version, storageBuilder }) {
   }
 
   function blockIsNotEmpty (pos) {
-    const block = bot.blockAt(pos)
+    const block = bot.blockAt(pos, false)
     return block !== null && block.boundingBox !== 'empty'
   }
 


### PR DESCRIPTION
We don't need extraInfos to be true in blockIsNotEmpty since it's just checking the bounding box, and according to the docs it makes it slower too.