### PR TITLE
Fixed message types.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,19 +48,20 @@ interface BotEvents {
     username: string,
     message: string,
     translate: string | null,
-    jsonMsg: string,
+    jsonMsg: ChatMessage,
     matches: Array<string> | null
   ) => void;
   whisper: (
     username: string,
     message: string,
     translate: string | null,
-    jsonMsg: string,
+    jsonMsg: ChatMessage,
     matches: Array<string> | null
   ) => void;
-  actionBar: (jsonMsg: string) => void;
+  actionBar: (jsonMsg: ChatMessage) => void;
   error: (err: Error) => void;
-  message: (jsonMsg: string, position: string) => void;
+  message: (jsonMsg: ChatMessage, position: string) => void;
+  unmatchedMessage: (stringMsg: string, jsonMsg: ChatMessage) => void;
   login: () => void;
   spawn: () => void;
   respawn: () => void;


### PR DESCRIPTION
The object types for all message events are ChatMessages, but in the d.ts file, they are listed as strings. Fixed.

Also, I noticed that the `unmatchedMessage` event was missing, so I added that.