### PR TITLE
Added option to allow the bot to keep it's head in place when mining.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1555,7 +1555,7 @@ dig any other blocks until the block has been broken, or you call
 `bot.stopDigging()`.
 
  * `block` - the block to start digging into
- * `forceLook` - (optional) if true, look at the block and start mining instantly
+ * `forceLook` - (optional) if true, look at the block and start mining instantly. If false, the bot will slowly turn to the block to mine. Additionally, this can be assigned to 'ignore' to prevent the bot from moving it's head at all.
  * `callback(err)` - (optional) called when the block is broken or you
    are interrupted.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -268,7 +268,7 @@ export class Bot extends (EventEmitter as new () => TypedEmitter<BotEvents>) {
     callback?: (err?: Error) => void
   ): Promise<void>;
 
-  dig(block: Block, callback?: (err?: Error) => void): Promise<void>;
+  dig(block: Block, forceLook?: boolean | 'ignore', callback?: (err?: Error) => void): Promise<void>;
 
   stopDigging(): void;
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -15,7 +15,11 @@ function inject (bot) {
 
   async function dig (block, forceLook) {
     if (bot.targetDigBlock) bot.stopDigging()
-    await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+
+    if (forceLook !== 'ignore') {
+        await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+    }
+
     diggingTask = createTask()
     bot._client.write('block_dig', {
       status: 0, // start digging

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -17,7 +17,7 @@ function inject (bot) {
     if (bot.targetDigBlock) bot.stopDigging()
 
     if (forceLook !== 'ignore') {
-        await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+      await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
     }
 
     diggingTask = createTask()


### PR DESCRIPTION
This has been a feature that's been requested several times over the last few weeks, so I figured I might as well add it.

Basically, if you write `bot.dig(block, 'ignore')` the bot will not move it's head when digging. Useful for edge-case AFK farms that require specific viewing angle to work. (I.e. mining the corner of the block instead of the center.)