### PR TITLE
Fix typo in event name

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -57,7 +57,7 @@ function inject (bot, options) {
       }
 
       if (matchAny === false) {
-        bot.emit('unmachedMessage', stringMsg, msg)
+        bot.emit('unmatchedMessage', stringMsg, msg)
       }
     }
 


### PR DESCRIPTION
Renames event 'unmachedMessage' to 'unmatchedMessage' in lib/plugins/chat.js