### PR TITLE
Better calculation of digging range.

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -98,7 +98,7 @@ function inject (bot) {
   }
 
   function canDigBlock (block) {
-    return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 2, 0)) <= 5.2
+    return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 1.65, 0)) <= 5.1
   }
 
   function digTime (block) {

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -98,7 +98,7 @@ function inject (bot) {
   }
 
   function canDigBlock (block) {
-    return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position) < 6
+    return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 2, 0)) <= 5.2
   }
 
   function digTime (block) {


### PR DESCRIPTION
Before the change, the bot that used `bot.canDigBlock()` only dig 4 blocks up, but the player digs 5 up. I tested the function in different directions and achieved a perfect calculation.