### PR TITLE
Fixed small bug with dig(block, 'ignore')

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -124,8 +124,11 @@ function callbackify (f) { // specifically for this function because cb could be
   return function (...args) {
     const cbIndex = typeof args[1] === 'function' ? 1 : 2
     const cb = args[cbIndex]
+
     if (cbIndex === 1) args[1] = true
+    else if (typeof args[1] === 'string') args[1] = args[1] === 'ignore' ? args[1] : false
     else args[1] = !!args[1] // coerce to boolean
+
     return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
   }
 }


### PR DESCRIPTION
Apparently, my PR in https://github.com/PrismarineJS/mineflayer/pull/1507 was broke due to the implementation of `callbackify().` So I had to make a quick tweak to fix it.