### PR TITLE
Emit death once

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -20,8 +20,10 @@ function inject (bot) {
     bot.foodSaturation = packet.foodSaturation
     bot.emit('health')
     if (bot.health <= 0) {
-      bot.isAlive = false
-      bot.emit('death')
+      if (bot.isAlive) {
+        bot.isAlive = false
+        bot.emit('death')
+      }
       bot._client.write('client_command', { payload: 0 })
     } else if (bot.health > 0 && !bot.isAlive) {
       bot.isAlive = true


### PR DESCRIPTION
Fixes an issue where death is emitted after bot is already dead (untested in-game, so someone should check to verify)