### PR TITLE
avoid typescript compile errors in strict mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -172,8 +172,6 @@ export interface Bot extends TypedEmitter<BotEvents> {
   _client: Client;
   heldItem: Item | null;
 
-  constructor(): Bot;
-
   connect(options: BotOptions): void;
 
   supportFeature(feature: string): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   _client: Client;
   heldItem: Item | null;
 
-  constructor();
+  constructor(): Bot;
 
   connect(options: BotOptions): void;
 


### PR DESCRIPTION
the constructor of the "interface" Bot had no implicit return type, but should have been Bot