### PR TITLE
Promisify testCommon  

### DIFF
--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -58,7 +58,7 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
   const task = createTask()
 
   const onEvent = (...data) => {
-    if (checkCondition && !checkCondition(...data)) {
+    if (typeof checkCondition === 'function' && !checkCondition(...data)) {
       return
     }
 
@@ -67,9 +67,9 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
 
   emitter.addListener(event, onEvent)
 
-  if (timeout > 0) {
+  if (typeof timeout === 'number' && timeout > 0) {
     // For some reason, the call stack gets lost if we don't create the error outside of the .then call
-    const timeoutError = new Error(`Event ${event} did not fire within timeout of ${timeout}ms ${checkCondition && checkCondition.name}`)
+    const timeoutError = new Error(`Event ${event} did not fire within timeout of ${timeout}ms`)
     sleep(timeout).then(() => {
       if (!task.done) {
         task.cancel(timeoutError)
@@ -83,21 +83,12 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
 }
 
 function withTimeout (promise, timeout) {
-  return new Promise((resolve, reject) => {
-    const timeoutHandle = setTimeout(() => reject(new Error('Promise timed out.')), timeout)
-    promise
-      .finally(() => {
-        clearTimeout(timeoutHandle)
-      })
-      .then((result) => {
-        resolve(result)
-        return result
-      })
-      .catch((err) => {
-        reject(err)
-        return err
-      })
-  })
+  return Promise.race([
+    promise,
+    sleep(timeout).then(() => {
+      throw new Error('Promise timed out.')
+    })
+  ])
 }
 
 module.exports = {

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -1,7 +1,10 @@
 function callbackify (f) {
   return function (...args) {
     const cb = args[f.length]
-    return f(...args).then(r => { if (cb) { cb(undefined, r) } return r }, err => { if (cb) { cb(err) } else throw err })
+    return f(...args).then(r => {
+      if (cb) { cb(undefined, r) }
+      return r
+    }, err => { if (cb) { cb(err) } else throw err })
   }
 }
 
@@ -15,12 +18,16 @@ function createTask () {
   }
   task.promise = new Promise((resolve, reject) => {
     task.cancel = (err) => {
-      reject(err)
-      task.done = true
+      if (!task.done) {
+        task.done = true
+        reject(err)
+      }
     }
-    task.finish = () => {
-      resolve()
-      task.done = true
+    task.finish = (result) => {
+      if (!task.done) {
+        task.done = true
+        resolve(result)
+      }
     }
   })
   return task
@@ -36,9 +43,66 @@ function createDoneTask () {
   return task
 }
 
+/**
+ * Similar to the 'once' function from the 'events' module, but allows you to add a condition for when you want to
+ * actually handle the event, as well as a timeout. The listener is additionally removed if a timeout occurs, instead
+ * of with 'once' where a listener might stay forever if it never triggers.
+ * Note that timeout and checkCondition, both optional, are in the third parameter as an object.
+ * @param emitter - The event emitter to listen to
+ * @param event - The name of the event you want to listen for
+ * @param [timeout=0] - An amount, in milliseconds, for which to wait before considering the promise failed. <0 = none.
+ * @param [checkCondition] - A function which matches the same signature of an event emitter handler, and should return something truthy if you want the event to be handled. If this is not provided, all events are handled.
+ * @returns {Promise} A promise which will either resolve to an *array* of values in the handled event, or will reject on timeout if applicable. This may never resolve if no timeout is set and the event does not fire.
+ */
+function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefined } = {}) {
+  const task = createTask()
+
+  const onEvent = (...data) => {
+    if (checkCondition && !checkCondition(...data)) {
+      return
+    }
+
+    task.finish(data)
+  }
+
+  emitter.addListener(event, onEvent)
+
+  if (timeout > 0) {
+    sleep(timeout).then(() => {
+      if (!task.done) {
+        task.cancel(new Error(`Event ${event} did not fire within timeout of ${timeout}ms`))
+      }
+    })
+  }
+
+  task.promise.finally(() => emitter.removeListener(event, onEvent))
+
+  return task.promise
+}
+
+function withTimeout (promise, timeout) {
+  return new Promise((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => reject(new Error('Promise timed out.')), timeout)
+    promise
+      .finally(() => {
+        clearTimeout(timeoutHandle)
+      })
+      .then((result) => {
+        resolve(result)
+        return result
+      })
+      .catch((err) => {
+        reject(err)
+        return err
+      })
+  })
+}
+
 module.exports = {
   callbackify,
   sleep,
   createTask,
-  createDoneTask
+  createDoneTask,
+  onceWithCleanup,
+  withTimeout
 }

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -68,9 +68,11 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
   emitter.addListener(event, onEvent)
 
   if (timeout > 0) {
+    // For some reason, the call stack gets lost if we don't create the error outside of the .then call
+    const timeoutError = new Error(`Event ${event} did not fire within timeout of ${timeout}ms ${checkCondition && checkCondition.name}`)
     sleep(timeout).then(() => {
       if (!task.done) {
-        task.cancel(new Error(`Event ${event} did not fire within timeout of ${timeout}ms`))
+        task.cancel(timeoutError)
       }
     })
   }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -11,7 +11,7 @@ const path = require('path')
 const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
 const WAIT_TIME_BEFORE_STARTING = 5000
-const TEST_TIMEOUT_MS = 30000
+const TEST_TIMEOUT_MS = 60000
 
 const excludedTests = ['digEverything']
 

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -11,6 +11,7 @@ const path = require('path')
 const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
 const WAIT_TIME_BEFORE_STARTING = 5000
+const TEST_TIMEOUT_MS = 30000
 
 const excludedTests = ['digEverything']
 
@@ -118,27 +119,28 @@ mineflayer.testedVersions.forEach((supportedVersion, i) => {
       })
     })
 
-    fs.readdirSync('./test/externalTests')
-      .filter(file => fs.statSync(`./test/externalTests/${file}`).isFile())
+    const externalTestsFolder = path.resolve(__dirname, './externalTests')
+    fs.readdirSync(externalTestsFolder)
+      .filter(file => fs.statSync(path.join(externalTestsFolder, file)).isFile())
       .forEach((test) => {
         test = path.basename(test, '.js')
         const testFunctions = require(`./externalTests/${test}`)(supportedVersion)
+        const runTest = (testName, testFunction) => {
+          return function (done) {
+            this.timeout(TEST_TIMEOUT_MS)
+            bot.test.sayEverywhere(`starting ${testName}`)
+            testFunction(bot, done)
+          }
+        }
         if (excludedTests.indexOf(test) === -1) {
           if (typeof testFunctions === 'object') {
             for (const testFunctionName in testFunctions) {
               if (testFunctions[testFunctionName] !== undefined) {
-                it(`${test} ${testFunctionName}`, (testFunctionName => function (done) {
-                  this.timeout(30000)
-                  bot.test.sayEverywhere(`starting ${test} ${testFunctionName}`)
-                  testFunctions[testFunctionName](bot, done)
-                })(testFunctionName))
+                it(`${test} ${testFunctionName}`, (testFunctionName => runTest(`${test} ${testFunctionName}`, testFunctions[testFunctionName]))(testFunctionName))
               }
             }
           } else {
-            it(test, (done) => {
-              bot.test.sayEverywhere(`starting ${test}`)
-              testFunctions(bot, done)
-            })
+            it(test, runTest(test, testFunctions))
           }
         }
       })

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -3,6 +3,7 @@ const Vec3 = require('vec3').Vec3
 const { spawn } = require('child_process')
 const process = require('process')
 const assert = require('assert')
+const { callbackify, sleep } = require('../../../lib/promise_utils')
 
 module.exports = inject
 
@@ -15,19 +16,20 @@ function inject (bot) {
   bot.test = {}
   bot.test.callbackChain = callbackChain
   bot.test.sayEverywhere = sayEverywhere
-  bot.test.clearInventory = clearInventory
-  bot.test.becomeSurvival = becomeSurvival
-  bot.test.fly = fly
-  bot.test.resetState = resetState
-  bot.test.setInventorySlot = setInventorySlot
-  bot.test.placeBlock = placeBlock
-  bot.test.runExample = runExample
-  bot.test.tellAndListen = tellAndListen
+  bot.test.clearInventory = callbackify(clearInventory)
+  bot.test.becomeSurvival = callbackify(becomeSurvival)
+  bot.test.fly = callbackify(fly)
+  bot.test.resetState = callbackify(resetState)
+  bot.test.setInventorySlot = callbackify(setInventorySlot)
+  bot.test.placeBlock = callbackify(placeBlock)
+  bot.test.runExample = callbackify(runExample)
+  bot.test.tellAndListen = callbackify(tellAndListen)
 
   function callbackChain (functions, cb) {
     assert(cb, new Error('You must provide a callback to bot.test.callbackChain'))
     let i = 0
     callNext()
+
     function callNext () {
       if (i < functions.length) {
         functions[i++](callNext)
@@ -64,8 +66,7 @@ function inject (bot) {
     }
   }
 
-  // eslint-disable-next-line no-unused-vars
-  function resetBlocksToSuperflat (cb) {
+  async function resetBlocksToSuperflat () {
     // console.log('reset blocks to superflat')
     const groundY = 4
     for (let y = groundY + 4; y >= groundY - 1; y--) {
@@ -77,136 +78,124 @@ function inject (bot) {
         if (expectedBlock === null) {
           if (block.name === 'air') continue
           // dig it
-          return digAndResume(position)
+          await dig(position)
         } else {
           if (expectedBlock.type === block.type) continue
           // fix it
           if (block.type !== 0) {
             // dig it
-            return digAndResume(position)
+            await dig(position)
           }
           console.log('going to place layer ', y, 'with item ', superflatLayers[y].item.type, position)
           // place it
-          return placeAndResume(position, superflatLayers[y].item)
+          await place(position, superflatLayers[y].item)
         }
       }
     }
-    // all good
-    cb()
 
-    function digAndResume (position) {
-      bot.dig(bot.blockAt(position), resume)
+    function dig (position) {
+      return bot.dig(bot.blockAt(position))
     }
 
-    function placeAndResume (position, item) {
+    async function place (position, item) {
       // console.log('place and resume with', item)
-      setInventorySlot(36, new Item(item.type, 1, 0), () => {
-        placeBlock(36, position, resume)
-      })
-    }
-
-    function resume () {
-      resetBlocksToSuperflat(cb)
+      await setInventorySlot(36, new Item(item.type, 1, 0))
+      await placeBlock(36, position)
     }
   }
 
-  function placeBlock (slot, position, cb) {
+  async function placeBlock (slot, position) {
     bot.setQuickBarSlot(slot - 36)
     // always place the block on the top of the block below it, i guess.
     const referenceBlock = bot.blockAt(position.plus(new Vec3(0, -1, 0)))
-    bot.placeBlock(referenceBlock, new Vec3(0, 1, 0), cb)
+    return bot.placeBlock(referenceBlock, new Vec3(0, 1, 0))
   }
 
   // always leaves you in creative mode
-  function resetState (cb) {
-    callbackChain([
-      becomeCreative,
-      clearInventory,
-      (cb) => {
-        // console.log('start flying')
-        bot.creative.startFlying()
-        teleport(new Vec3(0, 4, 0), cb)
-      },
-      cb => bot.waitForChunksToLoad(cb),
-      resetBlocksToSuperflat,
-      (cb) => { setTimeout(cb, 1000) },
-      clearInventory
-    ], cb)
+  async function resetState () {
+    await becomeCreative()
+    await clearInventory()
+    bot.creative.startFlying()
+    await teleport(new Vec3(0, 4, 0))
+    await bot.waitForChunksToLoad()
+    await resetBlocksToSuperflat()
+    await sleep(1000)
+    await clearInventory()
   }
 
-  function becomeCreative (cb) {
+  async function becomeCreative () {
     // console.log('become creative')
-    setCreativeMode(true, cb)
+    return setCreativeMode(true)
   }
 
-  function becomeSurvival (cb) {
-    setCreativeMode(false, cb)
+  async function becomeSurvival () {
+    return setCreativeMode(false)
   }
 
-  function setCreativeMode (value, cb) {
-    // this function behaves the same whether we start in creative mode or not.
-    // also, creative mode is always allowed for ops, even if server.properties says force-gamemode=true in survival mode.
+  async function setCreativeMode (value) {
+    return new Promise((resolve) => {
+      // this function behaves the same whether we start in creative mode or not.
+      // also, creative mode is always allowed for ops, even if server.properties says force-gamemode=true in survival mode.
 
-    function onMessage (jsonMsg) {
-      // console.log(jsonMsg)
-      switch (jsonMsg.translate) {
-        case 'commands.gamemode.success.self':
-        case 'gameMode.changed':
-          // good.
-          bot.removeListener('message', onMessage)
-          clearTimeout(timeOut)
-          return cb()
-        case 'commands.generic.permission':
-          sayEverywhere('ERROR: I need to be an op (allow cheats).')
-          bot.removeListener('message', onMessage)
-        // at this point we just wait forever.
-        // the intention is that someone ops us while we're sitting here, then you kill and restart the test.
+      function onMessage (jsonMsg) {
+        // console.log(jsonMsg)
+        switch (jsonMsg.translate) {
+          case 'commands.gamemode.success.self':
+          case 'gameMode.changed':
+            // good.
+            bot.removeListener('message', onMessage)
+            clearTimeout(timeOut)
+            return resolve()
+          case 'commands.generic.permission':
+            sayEverywhere('ERROR: I need to be an op (allow cheats).')
+            bot.removeListener('message', onMessage)
+          // at this point we just wait forever.
+          // the intention is that someone ops us while we're sitting here, then you kill and restart the test.
+        }
+        // console.log("I didn't expect this message:", jsonMsg);
       }
-      // console.log("I didn't expect this message:", jsonMsg);
-    }
-    bot.on('message', onMessage)
-    bot.chat(`/gamemode ${value ? 'creative' : 'survival'}`)
-    const timeOut = setTimeout(() => {
-      bot.removeListener('message', onMessage)
-      cb()
-    }, 10000)
+
+      bot.on('message', onMessage)
+      bot.chat(`/gamemode ${value ? 'creative' : 'survival'}`)
+      const timeOut = setTimeout(() => {
+        bot.removeListener('message', onMessage)
+        resolve()
+      }, 10000)
+    })
   }
 
-  function clearInventory (cb) {
+  async function clearInventory () {
     for (let i = 0; i < bot.inventory.slots.length; i++) {
       if (bot.inventory.slots[i] == null) continue
-      setInventorySlot(i, null, () => {
-        // start over until we have nothing to do
-        clearInventory(cb)
-      })
-      return
+      await setInventorySlot(i, null)
     }
-    // done
-    cb()
   }
 
   // you need to be in creative mode for this to work
-  function setInventorySlot (targetSlot, item, cb) {
+  async function setInventorySlot (targetSlot, item) {
     assert(item === null || item.name !== 'unknown', `item should not be unknown ${JSON.stringify(item)}`)
     // TODO FIX
     if (Item.equal(bot.inventory.slots[targetSlot], item)) {
       // console.log('placing')
       // console.log(bot.inventory.slots[targetSlot])
       // already good to go
-      return setImmediate(cb)
+      return
     }
 
-    bot.creative.setInventorySlot(targetSlot, item, cb)
+    return bot.creative.setInventorySlot(targetSlot, item)
   }
 
-  function teleport (position, cb) {
+  async function teleport (position) {
     bot.chat(`/tp ${bot.username} ${position.x} ${position.y} ${position.z}`)
-    bot.on('move', function onMove () {
-      if (bot.entity.position.distanceTo(position) < 0.9) {
-        // close enough
-        bot.removeListener('move', onMove)
-        cb()
-      }
+
+    return new Promise(resolve => {
+      bot.on('move', function onMove () {
+        // the bot is close enough to the desired position
+        if (bot.entity.position.distanceTo(position) < 0.9) {
+          bot.removeListener('move', onMove)
+          resolve()
+        }
+      })
     })
   }
 
@@ -215,60 +204,73 @@ function inject (bot) {
     console.log(message)
   }
 
-  function fly (delta, cb) {
-    bot.creative.flyTo(bot.entity.position.plus(delta), cb)
+  async function fly (delta) {
+    return bot.creative.flyTo(bot.entity.position.plus(delta))
   }
 
-  function tellAndListen (to, what, listen, done) {
-    function chatHandler (username, message) {
-      if (username === to && listen(message)) {
-        bot.removeListener('chat', chatHandler)
-        done()
+  async function tellAndListen (to, what, listen) {
+    return new Promise(resolve => {
+      const onChatMessage = (username, message) => {
+        if (username === to && listen(message)) {
+          bot.removeListener('chat', onChatMessage)
+          resolve()
+        }
       }
-    }
-    bot.on('chat', chatHandler)
-    bot.chat(what)
+      bot.on('chat', onChatMessage)
+      bot.chat(what)
+    })
   }
 
-  function runExample (file, run, cb) {
-    let childBotName
-    function joinHandler (message) {
-      if (message.json.translate === 'multiplayer.player.joined') {
-        bot.removeListener('message', joinHandler)
-        childBotName = message.json.with[0].insertion
-        bot.chat(`/tp ${childBotName} 50 4 0`)
-        setTimeout(() => {
-          bot.chat('loaded')
-        }, 5000)
+  async function runExample (file, run) {
+    return new Promise((resolve, reject) => {
+      let childBotName
+
+      function joinHandler (message) {
+        if (message.json.translate === 'multiplayer.player.joined') {
+          bot.removeListener('message', joinHandler)
+          childBotName = message.json.with[0].insertion
+          bot.chat(`/tp ${childBotName} 50 4 0`)
+          setTimeout(() => {
+            bot.chat('loaded')
+          }, 5000)
+        }
       }
-    }
-    bot.on('chat', (username, message) => {
-      if (message === 'Ready!') {
-        run(childBotName, closeExample)
+
+      const onChatMessage = (username, message) => {
+        if (message === 'Ready!') {
+          run(childBotName, closeExample)
+        }
+      }
+      bot.on('chat', onChatMessage)
+      bot.on('message', joinHandler)
+
+      const child = spawn('node', [file, 'localhost', `${bot.test.port}`])
+
+      // Useful to debug child processes:
+      child.stdout.on('data', (data) => { console.log(`${data}`) })
+      child.stderr.on('data', (data) => { console.error(`${data}`) })
+
+      const timeout = setTimeout(() => {
+        console.log('Timeout, test took too long')
+        closeExample(new Error('Timeout, test took too long'))
+      }, 20000)
+
+      function closeExample (err) {
+        if (timeout) clearTimeout(timeout)
+        console.log('kill process ' + child.pid)
+
+        bot.removeListener('chat', onChatMessage)
+
+        child.once('close', (code) => {
+          console.log('close requested ' + code)
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+        process.kill(child.pid, 'SIGTERM')
       }
     })
-    bot.on('message', joinHandler)
-
-    const child = spawn('node', [file, 'localhost', `${bot.test.port}`])
-
-    // Useful to debug child processes:
-    child.stdout.on('data', (data) => { console.log(`${data}`) })
-    child.stderr.on('data', (data) => { console.error(`${data}`) })
-
-    const timeout = setTimeout(() => {
-      console.log('Timeout, test took too long')
-      closeExample(new Error('Timeout, test took too long'))
-    }, 20000)
-
-    function closeExample (err) {
-      if (timeout) clearTimeout(timeout)
-      console.log('kill process ' + child.pid)
-
-      child.once('close', (code) => {
-        console.log('close requested ' + code)
-        cb(err)
-      })
-      process.kill(child.pid, 'SIGTERM')
-    }
   }
 }

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -153,15 +153,23 @@ function inject (bot) {
       return false
     }
 
-    // For whatever reason, timeout = success, and there is no other failure condition in this promise
-    const listenerPromise = new Promise((resolve) => onceWithCleanup(bot, 'message', {
-      checkCondition: onMessage,
-      timeout: 10000
-    }).then(resolve, resolve))
+    const waitForMessage = async () => {
+      try {
+        await onceWithCleanup(bot, 'message', {
+          checkCondition: onMessage,
+          timeout: 10000
+        })
+      } catch (_) {
+        // For whatever reason, timeout = success, and there is no other failure condition in this promise,
+        // so we can safely eat this exception.
+      }
+    }
+
+    const messagePromise = waitForMessage()
 
     bot.chat(`/gamemode ${value ? 'creative' : 'survival'}`)
 
-    return listenerPromise
+    return messagePromise
   }
 
   async function clearInventory () {


### PR DESCRIPTION
This PR replaces all `bot.test.*` methods which took callbacks with methods that now return promises instead. Support for callbacks is still retained however, using `callbackify`. Because of this, I have chosen not to promisify all the tests themselves for now. `bot.test.callbackChain` is unmodified as well, so all existing tests still work. 

The main benefit of this is to allow us to convert each test individually if desired (as they're modified in the future), rather than needing to sit down for hours on end to tediously convert each test from callbacks to promises.