### PR TITLE
added null or undefined check

### DIFF
--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -93,6 +93,9 @@ function inject (bot) {
     if (item == null || typeof item !== 'object') {
       throw new Error('Invalid item object in equip')
     }
+    if (!destination || destination === null) {
+      destination = 'hand'
+    }
     const sourceSlot = item.slot
     let destSlot = getDestSlot(destination)
 


### PR DESCRIPTION
in the api doc here: https://github.com/PrismarineJS/mineflayer/blob/master/docs/api.md#botequipitem-destination-callback it says that equipitem should default to hand, but now, it doesn't, so this check would add that