### PR TITLE
Removed "this" from waitForTicks

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -270,7 +270,7 @@ function inject (bot) {
       const tickListener = () => {
         ticks--
         if (ticks === 0) {
-          this.bot.removeListener('physicTick', tickListener)
+          bot.removeListener('physicTick', tickListener)
           resolve()
         }
       }


### PR DESCRIPTION
Fixed this scope issue which caused bot to always be null at the end of the event.