### PR TITLE
Fishing refactor

### DIFF
--- a/examples/fisherman.js
+++ b/examples/fisherman.js
@@ -55,11 +55,10 @@ async function startFishing () {
     return bot.chat(err.message)
   }
 
-  nowFishing = true
   bot.on('playerCollect', onCollect)
 
   try {
-    await bot.fish()
+    nowFishing = await bot.fish()
   } catch (err) {
     bot.chat(err.message)
   }
@@ -70,7 +69,7 @@ function stopFishing () {
   bot.removeListener('playerCollect', onCollect)
 
   if (nowFishing) {
-    bot.activateItem()
+    nowFishing.cancel()
   }
 }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const Vec3 = require('vec3').Vec3
 const { once } = require('events')
-const { callbackify, sleep, createDoneTask, createTask } = require('../promise_utils')
+const { callbackify, sleep, newTask, createDoneTask, createTask } = require('../promise_utils')
 
 module.exports = inject
 
@@ -23,7 +23,6 @@ function inject (bot, { version, hideErrors }) {
   }
 
   let eatingTask = createDoneTask()
-  let fishingTask = createDoneTask()
 
   let nextActionNumber = 0
   const windowClickQueue = []
@@ -43,30 +42,60 @@ function inject (bot, { version, hideErrors }) {
     }
   })
 
-  bot._client.on('spawn_entity', (packet) => {
-    if (packet.type === bobberId && !fishingTask.done && !lastFloat) {
-      lastFloat = bot.entities[packet.entityId]
+  // Fishing
+  async function fish () {
+    if (bot._fishing) {
+      bot._fishing.cancel(Error('fish called again'))
     }
-  })
+    let onParticles, onRemoveEntity
+    bot._fishing = newTask(async (res, rej) => {
+      await activateItem() // throw bobber
+      console.log('FISH fish 1')
+      while (!bot._fishingBobber) {
+        const [packet] = await once(bot._client, 'spawn_entity')
+        console.log('FISH spawned', packet)
+        if (packet.type === bobberId) {
+          bot._fishingBobber = bot.entities[packet.entityId]
+        }
+      }
+      console.log('FISH fish 2')
 
-  bot._client.on('world_particles', (packet) => {
-    if (!lastFloat || fishingTask.done) return
+      onParticles = (packet) => {
+        console.log('FISH part ', packet)
+        const pos = bot._fishingBobber.position
+        if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
+          activateItem()
+          res()
+        }
+      }
 
-    const pos = lastFloat.position
-    if (packet.particleId === 4 && packet.particles === 6 && pos.distanceTo(new Vec3(packet.x, pos.y, packet.z)) <= 1.23) {
-      activateItem()
-      lastFloat = undefined
-      fishingTask.finish()
-    }
-  })
+      onRemoveEntity = (packet) => {
+        console.log('FISH remove entity', packet)
+        if (packet.entityIds.some(id => id === lastFloat.id)) {
+          rej(new Error('Fishing cancelled'))
+        }
+      }
 
-  bot._client.on('entity_destroy', (packet) => {
-    if (!lastFloat) return
-    if (packet.entityIds.some(id => id === lastFloat.id)) {
-      lastFloat = undefined
-      fishingTask.cancel(new Error('Fishing cancelled'))
-    }
-  })
+      bot._client.on('world_particles', onParticles)
+      bot._client.on('entity_destroy', onRemoveEntity)
+      console.log('FISH registered')
+    }, { timeout: 60 * 1000 }, async (err) => {
+      if (bot._fishingBobber) {
+        console.log('FISH pulling back rod', bot._fishingBobber)
+        await activateItem() // pull back bobber
+      }
+      bot._client.removeListener('world_particles', onParticles)
+      bot._client.removeListener('entity_destroy', onRemoveEntity)
+      console.log('FISH resolved')
+      delete bot._fishingBobber
+      delete bot._fishing
+      if (err) {
+        console.log('FISH error', err)
+        throw err // did not get a fish
+      }
+    })
+    return bot._fishing
+  }
 
   async function consume () {
     if (!eatingTask.done) {
@@ -82,18 +111,6 @@ function inject (bot, { version, hideErrors }) {
     activateItem()
 
     await eatingTask.promise
-  }
-
-  async function fish () {
-    if (!fishingTask.done) {
-      fishingTask.cancel(new Error('Fishing cancelled due to calling bot.fish() again'))
-    }
-
-    fishingTask = createTask()
-
-    activateItem()
-
-    await fishingTask.promise
   }
 
   function activateItem (offHand = false) {

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -9,6 +9,31 @@ function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+class Task extends Promise {
+  constructor (handler) {
+    let cancel
+    super((res, rej) => {
+      handler(res, rej)
+      cancel = (...args) => rej(...args)
+    })
+    this.cancel = cancel
+    // know if promise has been resolved:
+    for (const k of ['then', 'catch', 'finally']) {
+      this[k] = (...args) => {
+        this.done = true
+        return super[k](...args)
+      }
+    }
+  }
+}
+
+function newTask (handler, options, complete) {
+  return new Task((res, rej) => {
+    if (options?.timeout) setTimeout(() => rej(Error('timeout')), options?.timeout)
+    handler(res, rej)
+  }).then(complete, complete)
+}
+
 function createTask () {
   const task = {
     done: false
@@ -39,6 +64,7 @@ function createDoneTask () {
 module.exports = {
   callbackify,
   sleep,
+  newTask,
   createTask,
   createDoneTask
 }


### PR DESCRIPTION
Fishing now returns a promise that can be canceled. Also adds a timeout of 60 seconds to fish() to cancel if no fishes were found based on the timeout on the wiki. It throws on a timeout and entity despawn now, so these can be handled by the user now (for example moving away somewhere else to find fish). 