### PR TITLE
Bot is not Skipping the end credits in 1.12

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -20,7 +20,7 @@ function inject (bot) {
 
   bot._client.on('game_state_change', (packet) => {
     if (packet?.reason === 4 && packet?.gameMode === 1) {
-      bot._client.write('client_command', {action: 0})
+      bot._client.write('client_command', { action: 0 })
     }
   })
 

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -18,6 +18,12 @@ function inject (bot) {
     }
   })
 
+  bot._client.on('game_state_change', (packet) => {
+    if (packet?.reason === 4 && packet?.gameMode === 1) {
+      bot._client.write('client_command', {action: 0})
+    }
+  })
+
   bot._client.on('login', (packet) => {
     bot.game.levelType = (packet.levelType ? packet.levelType : (packet.isFlat ? 'flat' : 'default'))
     bot.game.gameMode = parseGameMode(packet.gameMode)


### PR DESCRIPTION
If the bot does not send a client_command packet when it enters the endportal in the end for the first time it gets stuck in the end credits. 