### PR TITLE
Added a option to dig that changes the face to bot uses to mine a block

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1572,7 +1572,7 @@ This function also returns a `Promise`, with `void` as its argument upon complet
  * `count` - how many you want to toss. `null` is an alias for `1`.
  * `callback(err)` - (optional) called once tossing is complete
 
-#### bot.dig(block, [forceLook = true], [callback])
+#### bot.dig(block, [forceLook = true], [digFace], [callback])
 
 This function also returns a `Promise`, with `void` as its argument upon completion.
 
@@ -1585,6 +1585,8 @@ dig any other blocks until the block has been broken, or you call
 
  * `block` - the block to start digging into
  * `forceLook` - (optional) if true, look at the block and start mining instantly. If false, the bot will slowly turn to the block to mine. Additionally, this can be assigned to 'ignore' to prevent the bot from moving it's head at all.
+ * `digFace` - (optional) Default is 'auto' looks at the center of the block and mines the top face. Can also be a vec3 vector 
+ of the face the bot should be looking at when digging the block. For example: ```vec3(0, 1, 0)``` when mining the top. Can also be 'raycast' raycast checks if there is a face visible by the bot and mines that face. Useful for servers with anti cheat.
  * `callback(err)` - (optional) called when the block is broken or you
    are interrupted.
 

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,7 +1,7 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
 const { createDoneTask, createTask } = require('../promise_utils')
-const { RaycastIterator, BlockFace } = require('prismarine-world').iterators
+const BlockFaces = require('prismarine-world').iterators.BlockFace
 const { Vec3 } = require('vec3')
 
 module.exports = inject
@@ -31,18 +31,20 @@ function inject (bot) {
       if (digFace?.x || digFace?.y || digFace?.z) {
         // Determine the block face the bot should mine
         if (digFace.x) {
-          diggingFace = digFace.x > 0 ? BlockFace.EAST : BlockFace.WEST
+          diggingFace = digFace.x > 0 ? BlockFaces.EAST : BlockFaces.WEST
         } else if (digFace.y) {
-          diggingFace = digFace.y > 0 ? BlockFace.TOP : BlockFace.BOTTOM
+          diggingFace = digFace.y > 0 ? BlockFaces.TOP : BlockFaces.BOTTOM
         } else if (digFace.z) {
-          diggingFace = digFace.z > 0 ? BlockFace.SOUTH : BlockFace.NORTH
+          diggingFace = digFace.z > 0 ? BlockFaces.SOUTH : BlockFaces.NORTH
         }
         await bot.lookAt(block.position.offset(0.5, 0.5, 0.5).offset(digFace.x * 0.5, digFace.y * 0.5, digFace.z * 0.5), forceLook)
       } else if (digFace === 'raycast') {
-        // Check faces that could be seen from the current position. If the delta is smaller then 0.5 that means the bot cam most likely not see the face as the block is 1 block thick
+        // Check faces that could be seen from the current position. If the delta is smaller then 0.5 that means the
+        // bot cam most likely not see the face as the block is 1 block thick
         // this could be false for blocks that have a smaller bounding box then 1x1x1
         const dx = bot.entity.position.x - block.position.x + 0.5
-        const dy = bot.entity.position.y - block.position.y - 0.5 + bot.entity.height // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
+        const dy = bot.entity.position.y - block.position.y - 0.5 + bot.entity.height // -0.5 because the bot position
+        // is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
         const dz = bot.entity.position.z - block.position.z + 0.5
         // Check y first then x and z
         const visibleFaces = {
@@ -52,35 +54,20 @@ function inject (bot) {
         }
         const validFaces = []
         for (const i in visibleFaces) {
-          if (!visibleFaces[i]) {
-            // skip as this face is not visible
-            continue
-          }
+          if (!visibleFaces[i]) continue // skip as this face is not visible
+          // target position on the target block face. -> 0.5 + (current face) * 0.5
           const targetPos = block.position.offset(0.5 + (i === 'x' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'y' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'z' ? visibleFaces[i] * 0.5 : 0))
           const startPos = bot.entity.position.offset(0, bot.entity.height, 0)
-          const rayIterator = new RaycastIterator(startPos, targetPos.clone().subtract(startPos).normalize(), 5) // overshoot a bit for more reliable raycasting
-          let rayBlock = rayIterator.next()
-          let last = rayBlock
-          while (rayBlock) {
-            if (rayBlock.x === block.position.x && rayBlock.y === block.position.y && rayBlock.z === block.position.z) {
-              if (last) {
-                console.info('Valid face', targetPos, last.face)
-                // is the face value switched for rayIterator.next() ? Should be the face it entered not exited ?
-                validFaces.push({
-                  face: last.face,
-                  targetPos
-                })
-              }
-              break
+          const rayBlock = bot.world.raycast(startPos, targetPos.clone().subtract(startPos).normalize(), 5)
+          if (rayBlock) {
+            const rayPos = rayBlock.position
+            if (rayPos.x === block.position.x && rayPos.y === block.position.y && rayPos.z === block.position.z) {
+              // console.info(rayBlock)
+              validFaces.push({
+                face: rayBlock.face,
+                targetPos: rayBlock.intersect
+              })
             }
-            const tmp = bot.blockAt(new Vec3(rayBlock.x, rayBlock.y, rayBlock.z))
-            // Should there be other bounding boxes included?
-            if (tmp?.boundingBox !== 'empty') {
-              // Hit a none empty block
-              break
-            }
-            last = rayBlock
-            rayBlock = rayIterator.next()
           }
         }
         if (validFaces.length > 0) {
@@ -99,8 +86,7 @@ function inject (bot) {
           diggingFace = closest.face
         } else {
           // Block is obstructed return error?
-          // Try to mine the block anyway
-          await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+          throw new Error('Block not in view')
         }
       } else {
         await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -1,6 +1,8 @@
 const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
 const { createDoneTask, createTask } = require('../promise_utils')
+const { RaycastIterator, BlockFace } = require('prismarine-world').iterators
+const Vec3 = require('vec3')
 
 module.exports = inject
 
@@ -13,22 +15,104 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
-  async function dig (block, forceLook) {
+  async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
       throw new Error('dig was called with an undefined or null block')
+    }
+    if (!digFace || typeof digFace === 'function') {
+      digFace = 'auto'
     }
 
     if (bot.targetDigBlock) bot.stopDigging()
 
+    let diggingFace = 1 // Default (top)
+
     if (forceLook !== 'ignore') {
-      await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+      if (digFace?.x || digFace?.y || digFace?.z) {
+        // Determine the block face the bot should mine
+        if (digFace.x) {
+          diggingFace = digFace.x > 0 ? BlockFace.EAST : BlockFace.WEST
+        } else if (digFace.y) {
+          diggingFace = digFace.y > 0 ? BlockFace.TOP : BlockFace.BOTTOM
+        } else if (digFace.z) {
+          diggingFace = digFace.z > 0 ? BlockFace.SOUTH : BlockFace.NORTH
+        }
+        await bot.lookAt(block.position.offset(0.5, 0.5, 0.5).offset(digFace.x * 0.5, digFace.y * 0.5, digFace.z * 0.5), forceLook)
+      } else if (digFace === 'raycast') {
+        // Check faces that could be seen from the current position. If the delta is smaller then 0.5 that means the bot cam most likely not see the face as the block is 1 block thick
+        // this could be false for blocks that have a smaller bounding box then 1x1x1
+        const dx = bot.entity.position.x - block.position.x + 0.5
+        const dy = bot.entity.position.y - block.position.y - 0.5 + bot.entity.height // -0.5 because the bot position is calculated from the block position that is inside its feet so 0.5 - 1 = -0.5
+        const dz = bot.entity.position.z - block.position.z + 0.5
+        // Check y first then x and z
+        const visibleFaces = {
+          y: Math.sign(Math.abs(dy) > 0.5 ? dy : 0),
+          x: Math.sign(Math.abs(dx) > 0.5 ? dx : 0),
+          z: Math.sign(Math.abs(dz) > 0.5 ? dz : 0)
+        }
+        const validFaces = []
+        outerLoop:
+        for (const i in visibleFaces) {
+          if (!visibleFaces[i]) {
+            // skip as this face is not visible
+            continue
+          }
+          const targetPos = block.position.offset(0.5 + (i === 'x' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'y' ? visibleFaces[i] * 0.5 : 0), 0.5 + (i === 'z' ? visibleFaces[i] * 0.5 : 0))
+          const startPos = bot.entity.position.offset(0, bot.entity.height, 0)
+          const rayIterator = new RaycastIterator(startPos, targetPos.clone().subtract(startPos).normalize(), 5) // overshoot a bit for more reliable raycasting
+          let rayBlock = rayIterator.next()
+          let last = rayBlock
+          while (rayBlock) {
+            if (rayBlock.x === block.position.x && rayBlock.y === block.position.y && rayBlock.z === block.position.z) {
+              if (last) {
+                console.info('Valid face', targetPos, last.face)
+                // is the face value switched for rayIterator.next() ? Should be the face it entered not exited ?
+                validFaces.push({
+                  face: last.face,
+                  targetPos
+                })
+              }
+              break
+            }
+            const tmp = bot.blockAt(new Vec3(rayBlock.x, rayBlock.y, rayBlock.z))
+            // Should there be other bounding boxes included?
+            if (tmp?.boundingBox !== 'empty') {
+              // Hit a none empty block
+              continue outerLoop
+            }
+            last = rayBlock
+            rayBlock = rayIterator.next()
+          }
+        }
+        if (validFaces.length > 0) {
+          // Chose closest valid face
+          let closest
+          let distSqrt = 999
+          for (const i in validFaces) {
+            const tPos = validFaces[i].targetPos
+            const cDist = new Vec3(tPos.x, tPos.y, tPos.z).distanceSquared(bot.entity.position.offset(0, bot.entity.height, 0))
+            if (distSqrt > cDist) {
+              closest = validFaces[i]
+              distSqrt = cDist
+            }
+          }
+          await bot.lookAt(closest.targetPos, forceLook)
+          diggingFace = closest.face
+        } else {
+          // Block is obstructed return error?
+          // Try to mine the block anyway
+          await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+        }
+      } else {
+        await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
+      }
     }
 
     diggingTask = createTask()
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: 1 // hard coded to always dig from the top
+      face: diggingFace // default face is 1 (top)
     })
     const waitTime = bot.digTime(block)
     waitTimeout = setTimeout(finishDigging, waitTime)
@@ -48,7 +132,7 @@ function inject (bot) {
         bot._client.write('block_dig', {
           status: 2, // finish digging
           location: bot.targetDigBlock.position,
-          face: 1 // hard coded to always dig from the top
+          face: diggingFace // hard coded to always dig from the top
         })
       }
       bot.targetDigBlock = null
@@ -122,7 +206,7 @@ function inject (bot) {
 
 function callbackify (f) { // specifically for this function because cb could be the non-last parameter
   return function (...args) {
-    const cbIndex = typeof args[1] === 'function' ? 1 : 2
+    const cbIndex = typeof args[1] === 'function' ? 1 : (typeof args[2] === 'function' ? 2 : 3)
     const cb = args[cbIndex]
 
     if (cbIndex === 1) args[1] = true

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -2,7 +2,7 @@ const nbt = require('prismarine-nbt')
 const { performance } = require('perf_hooks')
 const { createDoneTask, createTask } = require('../promise_utils')
 const { RaycastIterator, BlockFace } = require('prismarine-world').iterators
-const Vec3 = require('vec3')
+const { Vec3 } = require('vec3')
 
 module.exports = inject
 
@@ -51,7 +51,6 @@ function inject (bot) {
           z: Math.sign(Math.abs(dz) > 0.5 ? dz : 0)
         }
         const validFaces = []
-        outerLoop:
         for (const i in visibleFaces) {
           if (!visibleFaces[i]) {
             // skip as this face is not visible
@@ -78,7 +77,7 @@ function inject (bot) {
             // Should there be other bounding boxes included?
             if (tmp?.boundingBox !== 'empty') {
               // Hit a none empty block
-              continue outerLoop
+              break
             }
             last = rayBlock
             rayBlock = rayIterator.next()


### PR DESCRIPTION
Most servers with anti cheat, don't allow you to mine blocks if you dont have direct line of sight to the block you want to mine. The bot mines blocks using the top face of the block by default while looking at the center of the block. 
With this change to bot can mine blocks using different faces and also change its view to be in line of sight with the block face it wants to mine. 
The raycast option tries to look for faces that are visible to the bot and chooses a valid face automatically. 