### PR TITLE
Fix typings of findBlock and findBlocks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1239,7 +1239,7 @@ Returns an array (possibly empty) with the found block coordinates (not the bloc
 
 #### bot.findBlock(options)
 
-Alias for `bot.findBlocks(options)[0]`. Return a single block or `null`.
+Alias for `bot.blockAt(bot.findBlocks(options)[0])`. Return a single block or `null`.
 
 #### bot.canDigBlock(block)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -184,9 +184,9 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   canSeeBlock(block: Block): boolean;
 
-  findBlock(options: FindBlockOptions): Block;
+  findBlock(options: FindBlockOptions): Block | null;
 
-  findBlocks(options: FindBlockOptions): Block[];
+  findBlocks(options: FindBlockOptions): Vec3[];
 
   canDigBlock(block: Block): boolean;
 


### PR DESCRIPTION
As described in #1663, the typings for findBlock and findBlocks were incorrect. This PR fixes them, as well as updates the docs for findBlock so that it better reflects what's actually happening.