### PR TITLE
Fix wait for ticks && Expose bot.physicEnabled

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -716,6 +716,10 @@ The item in the bot's hand, represented as a [prismarine-item](https://github.co
 
 #### bot.game.serverBrand
 
+### bot.physicEnabled
+
+Enable physics, default true.
+
 ### bot.player
 
 Bot's player object

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -35,6 +35,8 @@ function inject (bot, { version }) {
     if (bot.supportFeature('doesntHaveChestType')) {
       const facing = parseChestMetadata(chestBlock).facing
 
+      if (!facing) return 'single'
+
       // We have to check if the adjacent blocks in the perpendicular cardinals are the same type
       const perpendicularCardinals = Object.keys(FACING_MAP[facing])
       for (const cardinal of perpendicularCardinals) {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -35,7 +35,7 @@ function inject (bot) {
   let lastSentYaw = null
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
-  let physicEnabled = false
+  bot.physicEnabled = false
 
   const lastSent = {
     x: 0,
@@ -58,7 +58,7 @@ function inject (bot) {
     timeAccumulator += deltaSeconds
 
     while (timeAccumulator >= PHYSICS_TIMESTEP) {
-      if (physicEnabled) {
+      if (bot.physicEnabled) {
         physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
         bot.emit('physicTick')
       }
@@ -253,7 +253,7 @@ function inject (bot) {
     }
     sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
 
-    physicEnabled = true
+    bot.physicEnabled = true
     bot.entity.timeSinceOnGround = 0
     lastSentYaw = bot.entity.yaw
 
@@ -279,7 +279,7 @@ function inject (bot) {
     })
   }
 
-  bot.on('mount', () => { physicEnabled = false })
-  bot.on('respawn', () => { physicEnabled = false })
+  bot.on('mount', () => { bot.physicEnabled = false })
+  bot.on('respawn', () => { bot.physicEnabled = false })
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -275,7 +275,7 @@ function inject (bot) {
         }
       }
 
-      this.bot.on('physicTick', tickListener)
+      bot.on('physicTick', tickListener)
     })
   }
 


### PR DESCRIPTION
* `this.` cannot be used in the promise scope @TheDudeFromCI 
* exposed physicEnabled so that users don't have to disable the physic plugin if they want to switch off physic
* implemented https://github.com/PrismarineJS/mineflayer/pull/1633 changes with linter fix