### PR TITLE
trading: fix timeout handling and make hasItem2 consistent

### DIFF
--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -100,18 +100,19 @@ function inject (bot, { version }) {
       if (packet.windowId !== villager.id) return
       assert.ok(packet.trades)
       villager.trades = packet.trades.map(trade => {
-        const ret = Object.assign(trade, {
+        Object.assign(trade, {
           inputItem1: Item.fromNotch(trade.inputItem1 || { blockId: -1 }),
           inputItem2: Item.fromNotch(trade.inputItem2 || { blockId: -1 }),
           outputItem: Item.fromNotch(trade.outputItem || { blockId: -1 })
         })
         if (trade.demand !== undefined && trade.specialPrice !== undefined) { // the price is affected by demand and reputation
           const demandDiff = Math.max(0, Math.floor(trade.inputItem1.count * trade.demand * trade.priceMultiplier))
-          ret.realPrice = Math.min(Math.max((trade.inputItem1.count + trade.specialPrice + demandDiff), 1), trade.inputItem1.stackSize)
+          trade.realPrice = Math.min(Math.max((trade.inputItem1.count + trade.specialPrice + demandDiff), 1), trade.inputItem1.stackSize)
         } else {
-          ret.realPrice = trade.inputItem1.count
+          trade.realPrice = trade.inputItem1.count
         }
-        return ret
+        trade.hasItem2 = !!(trade.inputItem2 && trade.inputItem2.type && trade.inputItem2.count)
+        return trade
       })
       if (!ready) {
         ready = true
@@ -133,7 +134,7 @@ function inject (bot, { version }) {
     const itemCount1 = villager.count(Trade.inputItem1.type, Trade.inputItem1.metadata)
     const hasEnoughItem1 = itemCount1 >= Trade.realPrice * count
     let hasEnoughItem2 = true
-    if (Trade.inputItem2 && Trade.inputItem2.type && Trade.inputItem2.count) {
+    if (Trade.hasItem2) {
       const itemCount2 = villager.count(Trade.inputItem2.type, Trade.inputItem2.metadata)
       hasEnoughItem2 = itemCount2 >= Trade.inputItem2.count * count
     }
@@ -146,18 +147,20 @@ function inject (bot, { version }) {
     if (bot.supportFeature('selectingTradeMovesItems')) { // 1.14+ the server moves items around by itself after selecting a trade
       await new Promise((resolve, reject) => {
         const updatedSlots = {}
-        const timeout = setTimeout(() => {
-          clearTimeout(timeout)
-          reject(new Error('Timed out waiting for window updates'))
-        }, 30000)
-        villager.on('updateSlot', function cb (slot) {
+        function cb (slot) {
           updatedSlots[slot] = true
           if (updatedSlots[0] && updatedSlots[2] && (!Trade.hasItem2 || updatedSlots[1])) {
             clearTimeout(timeout)
             villager.removeListener('updateSlot', cb)
             resolve()
           }
-        })
+        }
+        villager.on('updateSlot', cb)
+        const timeout = setTimeout(() => {
+          clearTimeout(timeout)
+          villager.removeListener('updateSlot', cb)
+          reject(new Error('Timed out waiting for window updates'))
+        }, 30000)
       })
     }
     for (let i = 0; i < count; i++) {


### PR DESCRIPTION
1. fixing my previous PR which will leave the updateSlot event handler listening in case of timeout
2. in newer versions trade.hasItem2 doesn't make it into the decoded packet object as a separate value , so I just added a consistent client-side assignment to it.