### PR TITLE
setQuickBarSlot Small fix

### DIFF
--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -50,12 +50,12 @@ function inject (bot) {
   }
 
   function setQuickBarSlot (slot) {
-    assert.ok(slot >= 0)
-    assert.ok(slot < 9)
-    if (bot.quickBarSlot === slot) return
-    bot.quickBarSlot = slot
+    assert.ok(+slot >= 0)
+    assert.ok(+slot < 9)
+    if (bot.quickBarSlot === +slot) return
+    bot.quickBarSlot = +slot
     bot._client.write('held_item_slot', {
-      slotId: slot
+      slotId: +slot
     })
     bot.updateHeldItem()
   }


### PR DESCRIPTION
If slot value will be an not empty string, it will not throw an error.