### PR TITLE
Removing unnecessary package sending.

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -140,10 +140,6 @@ function inject (bot) {
       sendPacketPosition(position, onGround)
     } else if (lookUpdated && bot.isAlive) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (performance.now() - lastSent.time >= 1000) {
-      // Send a position packet every second, even if no update was made
-      sendPacketPosition(position, onGround)
-      lastSent.time = performance.now()
     } else if (bot.supportFeature('positionUpdateSentEveryTick') && bot.isAlive) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly


### PR DESCRIPTION
Removing unnecessary package sending. This is not vanilla, the bot does not pass many checks because of this part of code. After deleting it, the bot passes all checks.