### PR TITLE
Use Nullish Coalescing Operator for Default Values

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function createBot (options = {}) {
   options.plugins = options.plugins ?? {}
   options.hideErrors = options.hideErrors ?? true
   options.logErrors = options.logErrors ?? true
-  options.loadInternalPlugins = options.loadInternalPlugins ?? false
+  options.loadInternalPlugins = options.loadInternalPlugins ?? true
   const bot = new EventEmitter()
   bot._client = null
   bot.end = () => bot._client.end()

--- a/index.js
+++ b/index.js
@@ -59,12 +59,12 @@ module.exports = {
 }
 
 function createBot (options = {}) {
-  options.username = options.username || 'Player'
-  options.version = options.version || false
-  options.plugins = options.plugins || {}
-  options.hideErrors = options.hideErrors || true
-  options.logErrors = options.logErrors === undefined ? true : options.logErrors
-  options.loadInternalPlugins = options.loadInternalPlugins !== false
+  options.username = options.username ?? 'Player'
+  options.version = options.version ?? false
+  options.plugins = options.plugins ?? {}
+  options.hideErrors = options.hideErrors ?? true
+  options.logErrors = options.logErrors ?? true
+  options.loadInternalPlugins = options.loadInternalPlugins ?? false
   const bot = new EventEmitter()
   bot._client = null
   bot.end = () => bot._client.end()

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -11,10 +11,10 @@ function inject (bot) {
     assert.strictEqual(bot.blockAt(pos).name, 'command_block', new Error("The block isn't a command block"))
 
     // Default values when a command block is placed in vanilla minecraft
-    options.trackOutput = options.trackOutput || false
-    options.conditional = options.conditional || false
-    options.alwaysActive = options.alwaysActive || false
-    options.mode = options.mode || 2 // Possible values: 0: SEQUENCE, 1: AUTO and 2: REDSTONE
+    options.trackOutput = options.trackOutput ?? false
+    options.conditional = options.conditional ?? false
+    options.alwaysActive = options.alwaysActive ?? false
+    options.mode = options.mode ?? 2 // Possible values: 0: SEQUENCE, 1: AUTO and 2: REDSTONE
 
     let flags = 0
     flags |= +options.trackOutput << 0 // 0x01

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -10,7 +10,7 @@ function inject (bot, { version }) {
 
   async function craft (recipe, count, craftingTable) {
     assert.ok(recipe)
-    count = count == null ? 1 : parseInt(count, 10)
+    count = parseInt(count ?? 1, 10)
     if (recipe.requiresTable && !craftingTable) {
       throw new Error('recipe requires craftingTable')
     }
@@ -198,7 +198,7 @@ function inject (bot, { version }) {
   }
 
   function recipesFor (itemType, metadata, minResultCount, craftingTable) {
-    minResultCount = minResultCount == null ? 1 : minResultCount
+    minResultCount = minResultCount ?? 1
     const results = []
     Recipe.find(itemType, metadata).forEach((recipe) => {
       if (requirementsMetForRecipe(recipe, minResultCount, craftingTable)) {

--- a/lib/plugins/kick.js
+++ b/lib/plugins/kick.js
@@ -8,7 +8,7 @@ function inject (bot) {
     bot.emit('kicked', packet.reason, false)
   })
   bot.quit = (reason) => {
-    reason = reason || 'disconnect.quitting'
+    reason = reason ?? 'disconnect.quitting'
     bot._client.end(reason)
   }
 }


### PR DESCRIPTION
The Nullish Coalescing Operator (??) was introduced in Node 14 which is currently already the minimum Version that Mineflayer can be used with.
The Nullish Coalescing Operator is used like this:
`value = value ?? default`
And behaves like this:
`value = (value === undefined || value === null ? default : value)`
This is a better alternative to the OR || Operator, because using the OR operator can create bugs where a falsly value may be allowed. For example: index.js: Line 65
`options.hideErrors = options.hideErrors || true`
I do not know how noone ever noticed this, but this code can never assign false to options.hideErrors:
When omitting the option, undefined || true will result in true, as is intended
However when setting the option to false, false || true will also result in true, which makes it impossible to assign false to that value - it will always be true