### PR TITLE
add a 'messagestr' event

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -17,6 +17,44 @@ Spigot servers, in particular some plugins, use custom chat formats, you need to
 Read and adapt [chatAddPattern.js](https://github.com/PrismarineJS/mineflayer/blob/master/examples/chatAddPattern.js) to make it work for your particular
 chat plugin. Also read http://mineflayer.prismarine.js.org/#/tutorial?id=custom-chat
 
+### How can I collect info from an custom plugin in chat ?
+
+Most custom minecraft servers have plugin support, and a lot of these plugins say something in chat when something happens. If it is just one message, it's best to use the solution discussed in the solution above, but when these messages are split into many small messages, another option is using the `"messagestr"` event as it allows for easily parsing multi-line messages.
+
+**Example:**
+
+chat message in chat looks like:
+```
+(!) U9G has won the /jackpot and received
+$26,418,402,450! They purchased 2,350,000 (76.32%) ticket(s) out of the
+3,079,185 ticket(s) sold!
+```
+```js
+const regex = {
+  first: /\(!\) (.+) has won the \/jackpot and received +/,
+  second: /\$(.+)! They purchased (.+) \((.+)%\) ticket\(s\) out of the /,
+  third: /(.+) ticket\(s\) sold!/
+}
+
+let jackpot = {}
+bot.on('messagestr', msg => {
+  if (regex.first.test(text)) {
+    const username = text.match(regex.first)[1]
+    jackpot.username = username
+  } else if (regex.second.test(text)) {
+    const [, moneyWon, boughtTickets, winPercent] = text.match(regex.second)
+    jackpot.moneyWon = parseInt(moneyWon.replace(/,/g, ''))
+    jackpot.boughtTickets = parseInt(boughtTickets.replace(/,/g, ''))
+    jackpot.winPercent = parseFloat(winPercent)
+  } else if (regex.third.test(text)) {
+    const totalTickets = text.match(regex.third)[1]
+    jackpot.totalTickets = parseInt(totalTickets.replace(/,/g, ''))
+    onDone(jackpot)
+    jackpot = {}
+  }
+})
+
+```
 ### How can I send a command ?
 
 By using `bot.chat()`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -951,6 +951,10 @@ Emitted for every server message, including chats.
    * system
    * game_info
 
+#### "messagestr" (message, messagePosition)
+
+alias for the "message" event but it calls .toString() on the message object to get a string for the message before emitting.
+
 #### "login"
 
 Fires after you successfully login to the server.

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -77,6 +77,7 @@ function inject (bot, options) {
     const chatPosition = ChatPositions[packet.position]
 
     bot.emit('message', msg, chatPosition)
+    bot.emit('messagestr', msg.toString(), chatPosition)
     checkForChatPatterns(msg)
 
     // Position 2 is the action bar


### PR DESCRIPTION
I think a lot of people use the message event, but don't care about the color or any other information from the message, and just instantly make it into a string using `msg.toString()` then use the input, this adds a native way to just use the stringified version of message instantly, without the boilerplate. An example of when a chataddpattern wouldn't be better is when I have to parse messages that happen in series, in this case its just cleaner to have it all in one switch, or an if else ladder. I'd argue that this isn't any more extra then emitting a different event for an actionbar message, because that too is emitted by a separate event to make it easier.