### PR TITLE
Change transaction apology packet to match vanilla client

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -359,9 +359,9 @@ function inject (bot, { version, hideErrors }) {
 
     function onRejected () {
       bot._client.write('transaction', {
-        windowId: 0,
+        windowId: click.windowId,
         action: click.id,
-        accepted: false
+        accepted: true
       })
       bot.emit(`confirmTransaction${click.id}`, false)
     }


### PR DESCRIPTION
When server rejects an inventory transaction packet, mineflayer sends a serverbound transaction packet to apologize. I noticed that the server seemed to not accept these apologies in some cases. This PR changes the apology packet to match apology packets sent by 1.16.5 vanilla client (as observed with a minecraft packet sniffer), which seems to make the apology system more reliable.