### PR TITLE
Fix farmer example

### DIFF
--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
-const { once } = require('events')
-const { callbackify } = require('../promise_utils')
+const { onceWithCleanup, callbackify } = require('../promise_utils')
 
 module.exports = inject
 
@@ -71,7 +70,7 @@ function inject (bot, { version }) {
     const dest = pos.plus(faceVector)
     const eventName = `blockUpdate:${dest}`
 
-    const [oldBlock, newBlock] = await once(bot, eventName)
+    const [oldBlock, newBlock] = await onceWithCleanup(bot, eventName, { timeout: 5000 })
 
     if (oldBlock.type === newBlock.type) {
       throw new Error(`No block has been placed : the block is still ${oldBlock.name}`)


### PR DESCRIPTION
* findBlock was used incorrectly
* added maxDistance check to avoid trying to break out of reach blocks
* node's once is leaking! minimal reproduceable example:

```js
const { once, EventEmitter } = require('events')

async function run() {
  const A = new EventEmitter()
  const B = new EventEmitter()

  A.on('removeListener', (name, listener) => {
    console.log('remove', name)
    B.off(name, listener)
  })

  A.on('newListener', (name, listener) => {
    console.log('add', name)
    B.on(name, listener)
  })

  for (let i=0 ; i < 3 ; i++) {
    process.nextTick(() => {
      B.emit('e', 42)
    });

    console.log('before once', A._events['e'])
    const [value] = await once(A, 'e')
    console.log('after once', A._events['e'])
  }
}

run()
```
This happen only if we forward the event to an other eventemitter