### PR TITLE
Advanced horse/donkey/llama support

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const plugins = {
   furnace: require('./lib/plugins/furnace'),
   game: require('./lib/plugins/game'),
   health: require('./lib/plugins/health'),
+  horse: require('./lib/plugins/horse'),
   inventory: require('./lib/plugins/inventory'),
   kick: require('./lib/plugins/kick'),
   physics: require('./lib/plugins/physics'),

--- a/lib/plugins/horse.js
+++ b/lib/plugins/horse.js
@@ -32,9 +32,9 @@ function inject (bot) {
   Object.assign(metadataMap.llama, metadataMap.base)
   metadataMap.mule = metadataMap.donkey
 
-  async function openHorse(horseEntity) {
+  async function openHorse (horseEntity) {
     if (!metadataMap[horseEntity.name]) return
-    const oldSneakState = bot.controlState['sneak']
+    const oldSneakState = bot.controlState.sneak
 
     bot.setControlState('sneak', true)
     const horse = await bot.openEntity(horseEntity)
@@ -43,7 +43,7 @@ function inject (bot) {
     return horse
   }
 
-  function getHorseProperties(horseEntity, property) {
+  function getHorseProperties (horseEntity, property) {
     const type = horseEntity.name
     if (!metadataMap[type]) return null
 
@@ -65,10 +65,10 @@ function inject (bot) {
   }
 
   bot.on('entityUpdate', entity => {
-    if (!metadataMap[entity.name]) return;
+    if (!metadataMap[entity.name]) return
 
     const props = getHorseProperties(entity)
-    if (!props) return;
+    if (!props) return
 
     Object.entries(props).forEach(([key, prop]) => {
       entity[key] = prop

--- a/lib/plugins/horse.js
+++ b/lib/plugins/horse.js
@@ -1,0 +1,80 @@
+const { callbackify } = require('../promise_utils')
+
+module.exports = inject
+
+function inject (bot) {
+  const metadataMap = {
+    base: {
+      health: [7],
+      baby: [12],
+      tame: [13, 0x02],
+      saddled: [13, 0x04],
+      hasBred: [13, 0x08],
+      eating: [13, 0x10],
+      rearing: [13, 0x20],
+      mouthOpen: [13, 0x40],
+      owner: [14]
+    },
+    horse: {
+      variant: [15]
+    },
+    donkey: {
+      chested: [15]
+    },
+    llama: {
+      strength: [16],
+      variant: [17]
+    }
+  }
+
+  Object.assign(metadataMap.horse, metadataMap.base)
+  Object.assign(metadataMap.donkey, metadataMap.base)
+  Object.assign(metadataMap.llama, metadataMap.base)
+  metadataMap.mule = metadataMap.donkey
+
+  async function openHorse(horseEntity) {
+    if (!metadataMap[horseEntity.name]) return
+    const oldSneakState = bot.controlState['sneak']
+
+    bot.setControlState('sneak', true)
+    const horse = await bot.openEntity(horseEntity)
+    bot.setControlState('sneak', oldSneakState)
+
+    return horse
+  }
+
+  function getHorseProperties(horseEntity, property) {
+    const type = horseEntity.name
+    if (!metadataMap[type]) return null
+
+    if (property !== undefined) {
+      const propPos = metadataMap[type][property]
+      if (!propPos) return null
+
+      const data = horseEntity.metadata[propPos[0]]
+
+      return propPos[1] ? !!(data & propPos[1]) : data
+    } else {
+      const result = {}
+      Object.keys(metadataMap[type]).forEach(prop => {
+        result[prop] = getHorseProperties(horseEntity, prop)
+      })
+
+      return result
+    }
+  }
+
+  bot.on('entityUpdate', entity => {
+    if (!metadataMap[entity.name]) return;
+
+    const props = getHorseProperties(entity)
+    if (!props) return;
+
+    Object.entries(props).forEach(([key, prop]) => {
+      entity[key] = prop
+    })
+    bot.emit('horseUpdate', entity)
+  })
+
+  bot.openHorse = callbackify(openHorse)
+}

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -168,7 +168,7 @@ function inject (bot, { version, hideErrors }) {
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 0,
-      sneaking: bot.controlState['sneak']
+      sneaking: bot.controlState.sneak
     })
   }
 
@@ -177,7 +177,7 @@ function inject (bot, { version, hideErrors }) {
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 2,
-      sneaking: bot.controlState['sneak'],
+      sneaking: bot.controlState.sneak,
       x: position.x - entity.position.x,
       y: position.y - entity.position.y,
       z: position.z - entity.position.z

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -164,22 +164,20 @@ function inject (bot, { version, hideErrors }) {
   }
 
   async function activateEntity (entity) {
-    // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(entity.position.offset(0, 1, 0), false)
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 0,
-      sneaking: false
+      sneaking: bot.controlState['sneak']
     })
   }
 
   async function activateEntityAt (entity, position) {
-    // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(position, false)
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 2,
-      sneaking: false,
+      sneaking: bot.controlState['sneak'],
       x: position.x - entity.position.x,
       y: position.y - entity.position.y,
       z: position.z - entity.position.z
@@ -470,8 +468,9 @@ function inject (bot, { version, hideErrors }) {
   })
   bot._client.on('open_horse_window', (packet) => {
     // open window
+    const horse = bot.entities[packet.entityId]
     bot.currentWindow = windows.createWindow(packet.windowId,
-      'HorseWindow', 'Horse', packet.nbSlots)
+      'EntityHorse', `{"text":"${horse ? horse.displayName : 'Horse'}"}`, packet.nbSlots)
     prepareWindow(bot.currentWindow)
   })
   bot._client.on('close_window', (packet) => {


### PR DESCRIPTION
1. Makes horse window name follow the same pattern in <1.14 and >=1.14 (window.type = EntityHorse and ChatMessage-like title)
2. Makes activateEntity follow the same pattern in <1.16 and >=1.16 (sneaking state sent in packet depends on bot's sneaking state)
3. Extends horse-like entities with all neccessary attributes (I'm not sure if you want it to be implemented this way, should I maybe move it into a separate object in entity or maybe don't modify entity at all? Will update the doc once this is clear)
4. Adds `bot.openHorse(entity)` allowing to reliably open horse-like entity inventories without mounting them