### PR TITLE
Don't include npcs from player_info

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -419,6 +419,8 @@ function inject (bot, { version }) {
   bot._client.on('player_info', (packet) => {
     // player list item(s)
     packet.data.forEach((item) => {
+      // COMMENT: NPC check
+      if (item.name === '§') return
       const playerEntity = bot.findPlayers(item.name)
       let player = bot.uuidToUsername[item.UUID] ? bot.players[bot.uuidToUsername[item.UUID]] : null
       if (packet.action === 0) {


### PR DESCRIPTION
I guess you could probably find common NPC names and exclude them.