### PR TITLE
Changed deprecated function used in raycast.js

### DIFF
--- a/examples/raycast.js
+++ b/examples/raycast.js
@@ -19,7 +19,7 @@ bot.on('message', (cm) => {
 })
 
 function block () {
-  const block = bot.blockInSight()
+  const block = bot.blockAtCursor()
 
   if (!block) {
     return bot.chat('Looking at Air')

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,8 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   blockInSight(maxSteps: number, vectorLength: number): Block | null;
 
+  blockAtCursor(maxDistance: number, matcher?: Function): Block | null;
+
   canSeeBlock(block: Block): boolean;
 
   findBlock(options: FindBlockOptions): Block | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -186,7 +186,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   blockInSight(maxSteps: number, vectorLength: number): Block | null;
 
-  blockAtCursor(maxDistance: number, matcher?: Function): Block | null;
+  blockAtCursor(maxDistance?: number, matcher?: Function): Block | null;
 
   canSeeBlock(block: Block): boolean;
 


### PR DESCRIPTION
-Changed deprecated function used in raycast.js example from `blockInSight(maxSteps: number, vectorLength: number): Block | null` to `blockAtCursor(maxDistance: number, matcher?: Function): Block | null`

-Added blockAtCursor() to index.d.ts typing