### PR TITLE
Prevents exceeding Max Listeners when bot dies simultaneously digging

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -166,7 +166,12 @@ function inject (bot) {
     await diggingTask.promise
   }
 
-  bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
+  bot.on('death', () => {
+    bot.removeAllListeners('diggingAborted')
+    bot.removeAllListeners('diggingCompleted')
+    bot.stopDigging()
+  })
+
   function canDigBlock (block) {
     return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 1.65, 0)) <= 5.1
   }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -162,7 +162,7 @@ function inject (bot) {
       bot.emit('diggingCompleted', newBlock)
       diggingTask.finish()
     }
-  bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
+    bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
 
     await diggingTask.promise
   }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -162,6 +162,7 @@ function inject (bot) {
       bot.emit('diggingCompleted', newBlock)
       diggingTask.finish()
     }
+  bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
 
     await diggingTask.promise
   }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -166,6 +166,7 @@ function inject (bot) {
     await diggingTask.promise
   }
 
+  bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
   function canDigBlock (block) {
     return block && block.diggable && block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 1.65, 0)) <= 5.1
   }
@@ -188,7 +189,6 @@ function inject (bot) {
   bot.canDigBlock = canDigBlock
   bot.digTime = digTime
 }
-bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
 
 function callbackify (f) { // specifically for this function because cb could be the non-last parameter
   return function (...args) {

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -162,7 +162,6 @@ function inject (bot) {
       bot.emit('diggingCompleted', newBlock)
       diggingTask.finish()
     }
-    bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
 
     await diggingTask.promise
   }
@@ -189,6 +188,7 @@ function inject (bot) {
   bot.canDigBlock = canDigBlock
   bot.digTime = digTime
 }
+bot.on('death', () => { bot.removeAllListeners('diggingAborted'); bot.removeAllListeners('diggingCompleted') })
 
 function callbackify (f) { // specifically for this function because cb could be the non-last parameter
   return function (...args) {


### PR DESCRIPTION
Prevents MaxListenersExceededWarning _by not exceeding max listeners_ such as from when the bot dies while simultaneously digging  
```js
(node:6948) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 diggingAborted listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:451:17)
    at EventEmitter.addListener (node:events:467:10)
    at resetPath ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:90:11)
    at EventEmitter.<anonymous> ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:294:5)
    at EventEmitter.emit (node:events:376:20)
    at addColumn ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:111:9)
    at Client.<anonymous> ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:327:5)
    at Client.emit (node:events:376:20)
    at FullPacketParser.<anonymous> ({ProjectPath}\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:376:20)
(node:6948) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 diggingCompleted listeners added to [EventEmitter]. Use emitter.setMaxListeners() to increase limit
    at _addListener (node:events:451:17)
    at EventEmitter.addListener (node:events:467:10)
    at resetPath ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:91:11)
    at EventEmitter.<anonymous> ({ProjectPath}\node_modules\mineflayer-pathfinder\index.js:294:5)
    at EventEmitter.emit (node:events:376:20)
    at addColumn ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:111:9)
    at Client.<anonymous> ({ProjectPath}\node_modules\mineflayer\lib\plugins\blocks.js:327:5)
    at Client.emit (node:events:376:20)
    at FullPacketParser.<anonymous> ({ProjectPath}\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:376:20)
```
Removing pending listeners on death prevents the stack up of listeners as it would be unlikely the bot will be able to dig in same locations when dead. Therfore not having any MaxListenersExceededWarning from node, also improving performance. 

Note: The fix was initially presented for the path finder plugin https://github.com/PrismarineJS/mineflayer-pathfinder/pull/143 , however it was suggested to reopen the proposed changes in Mineflayer directly. So that it can benefit everyone, not just the users of pathfinder plugin.