### PR TITLE
Respawn event now correctly parsed + added test

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -63,9 +63,11 @@ function inject (bot) {
       bot.game.dimension = dimensionNames[packet.dimension]
     } else if (bot.supportFeature('dimensionIsAString')) {
       bot.game.dimension = packet.dimension
+    } else if (bot.supportFeature('dimensionIsAWorld')) {
+      bot.game.dimension = packet.worldName
     }
     bot.game.difficulty = difficultyNames[packet.difficulty]
-    bot.game.gameMode = parseGameMode(packet.gameMode)
+    bot.game.gameMode = parseGameMode(packet.gameMode ?? packet.gamemode)
     bot.game.hardcore = parseHardcore(packet.gameMode)
     bot.emit('game')
   })

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -67,8 +67,8 @@ function inject (bot) {
       bot.game.dimension = packet.worldName
     }
     bot.game.difficulty = difficultyNames[packet.difficulty]
-    bot.game.gameMode = parseGameMode(packet.gameMode ?? packet.gamemode)
-    bot.game.hardcore = parseHardcore(packet.gameMode)
+    bot.game.gameMode = parseGameMode(packet.gamemode)
+    bot.game.hardcore = parseHardcore(packet.gamemode)
     bot.emit('game')
   })
 

--- a/test/externalTests/gamemode.js
+++ b/test/externalTests/gamemode.js
@@ -1,0 +1,10 @@
+// test to see if bot retains creative gamemode in bot object on death
+
+const assert = require('assert')
+
+module.exports = async (bot) => {
+  bot.test.becomeCreative()
+  bot.chat(`/kill ${bot.username}`)
+  await new Promise((resolve, reject) => setTimeout(resolve, 5000))
+  assert.strictEqual(bot.game.gameMode, 'creative', 'Failed to parse respawn packet')
+}


### PR DESCRIPTION
Before now there was a bug where gamemode was being set to survival when the bot died in creative because the packet's `packet.gameMode` would be undefined (and added a test since this was tricky to fix), this fixes that + adds the newest supportfeature for dimension parsing as it was missing.