### PR TITLE
Change scope of createActionNumber

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -265,6 +265,7 @@
       - [bot.clickWindow(slot, mouseButton, mode, cb)](#botclickwindowslot-mousebutton-mode-cb)
       - [bot.putSelectedItemRange(start, end, window, slot, cb)](#botputselecteditemrangestart-end-window-slot-cb)
       - [bot.putAway(slot, cb)](#botputawayslot-cb)
+      - [bot.createActionNumber()](#botcreateactionnumber)
       - [bot.closeWindow(window)](#botclosewindowwindow)
       - [bot.transfer(options, cb)](#bottransferoptions-cb)
       - [bot.openBlock(block)](#botopenblockblock)
@@ -1805,6 +1806,10 @@ This function also returns a `Promise`, with `void` as its argument upon complet
 Can be useful in case the client is supposed to simulate without feedback from the server.
 
 Put the item at `slot` in the inventory.
+
+#### bot.createActionNumber()
+
+Create a valid actionId for lower level window operations
 
 #### bot.closeWindow(window)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -374,6 +374,8 @@ export interface Bot extends TypedEmitter<BotEvents> {
   putAway(slot: number, cb?: (err?: Error) => void): Promise<void>;
 
   closeWindow(window: Window): void;
+  
+  createActionNumber(): void;
 
   transfer(options: TransferOptions, cb?: (err?: Error) => void): Promise<void>;
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -522,6 +522,7 @@ function inject (bot, { version, hideErrors }) {
   bot.clickWindow = callbackify(clickWindow)
   bot.putSelectedItemRange = putSelectedItemRange
   bot.putAway = putAway
+  bot.createActionNumber = createActionNumber
   bot.closeWindow = closeWindow
   bot.transfer = callbackify(transfer)
   bot.openBlock = callbackify(openBlock)


### PR DESCRIPTION
Allows for low level client window packet transactions to be made by specifying a valid actionId