### PR TITLE
Add window parameter to clickWindow function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -262,7 +262,7 @@
       - [bot.supportFeature(name)](#botsupportfeaturename)
       - [bot.waitForTicks(ticks)](#botwaitforticksticks)
     - [Lower level inventory methods](#lower-level-inventory-methods)
-      - [bot.clickWindow(slot, mouseButton, mode, cb)](#botclickwindowslot-mousebutton-mode-cb)
+      - [bot.clickWindow(window, slot, mouseButton, mode, cb)](#botclickwindowslot-mousebutton-mode-cb)
       - [bot.putSelectedItemRange(start, end, window, slot, cb)](#botputselecteditemrangestart-end-window-slot-cb)
       - [bot.putAway(slot, cb)](#botputawayslot-cb)
       - [bot.closeWindow(window)](#botclosewindowwindow)
@@ -1788,11 +1788,11 @@ This is a promise-based function that waits for a given number of in-game ticks 
 
 These are lower level methods for the inventory, they can be useful sometimes but prefer the inventory methods presented above if you can.
 
-#### bot.clickWindow(slot, mouseButton, mode, cb)
+#### bot.clickWindow(window, slot, mouseButton, mode, cb)
 
 This function also returns a `Promise`, with `void` as its argument upon completion.
 
-Click on the current window. See details at https://wiki.vg/Protocol#Click_Window
+Click on the specified window. See details at https://wiki.vg/Protocol#Click_Window
 
 #### bot.putSelectedItemRange(start, end, window, slot, noWaiting)
 

--- a/examples/advanced/chest_confirm.md
+++ b/examples/advanced/chest_confirm.md
@@ -5,7 +5,7 @@ This code snippet will tell the bot not to wait for chest confirmations that som
 ```js
 bot.on('windowOpen', async (window) => {
   window.requiresConfirmation = false // fix
-  await bot.clickWindow(13, 0, 0)
+  await bot.clickWindow(window, 13, 0, 0)
   console.log(bot._events) // without the fix this code is unreachable, the promise never resolve
 })
 bot.on('windowClose', () => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -357,6 +357,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   setCommandBlock(pos: Vec3, command: string, trackOutput: boolean): void;
 
   clickWindow(
+    window: Window,
     slot: number,
     mouseButton: number,
     mode: number,

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -79,9 +79,9 @@ function inject (bot, { version }) {
           const sourceItem = window.findInventoryItem(ingredient.id, ingredient.metadata)
           if (!sourceItem) throw new Error('missing ingredient')
           if (originalSourceSlot == null) originalSourceSlot = sourceItem.slot
-          await bot.clickWindow(sourceItem.slot, 0, 0)
+          await bot.clickWindow(window, sourceItem.slot, 0, 0)
         }
-        await bot.clickWindow(destSlot, 1, 0)
+        await bot.clickWindow(window, destSlot, 1, 0)
         await nextShapeClick()
       }
 
@@ -95,9 +95,9 @@ function inject (bot, { version }) {
           const sourceItem = window.findInventoryItem(ingredient.id, ingredient.metadata)
           if (!sourceItem) throw new Error('missing ingredient')
           if (originalSourceSlot == null) originalSourceSlot = sourceItem.slot
-          await bot.clickWindow(sourceItem.slot, 0, 0)
+          await bot.clickWindow(window, sourceItem.slot, 0, 0)
         }
-        await bot.clickWindow(destSlot, 1, 0)
+        await bot.clickWindow(window, destSlot, 1, 0)
         if (++ingredientIndex < recipe.ingredients.length) {
           await nextIngredientsClick()
         } else {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -85,9 +85,9 @@ function inject (bot, { version, hideErrors }) {
 
       if (item && item.stackSize !== item.count) { // something to join with
         if (noWaiting) {
-          await clickWindow(item.slot, 0, 0)
+          await clickWindow(window, item.slot, 0, 0)
         } else {
-          await Promise.all([clickWindow(item.slot, 0, 0), once(window, `updateSlot:${item.slot}`)])
+          await Promise.all([clickWindow(window, item.slot, 0, 0), once(window, `updateSlot:${item.slot}`)])
         }
       } else { // nothing to join with
         const emptySlot = window.firstEmptySlotRange(start, end)
@@ -95,14 +95,14 @@ function inject (bot, { version, hideErrors }) {
           if (slot === null) { // no room => drop it
             await tossLeftover()
           } else { // if there is still some leftover and slot is not null, click slot
-            await clickWindow(slot, 0, 0)
+            await clickWindow(window, slot, 0, 0)
             await tossLeftover()
           }
         } else {
           if (noWaiting) {
-            await Promise.all([clickWindow(emptySlot, 0, 0), once(window, `updateSlot:${emptySlot}`)])
+            await Promise.all([clickWindow(window, emptySlot, 0, 0), once(window, `updateSlot:${emptySlot}`)])
           } else {
-            await clickWindow(emptySlot, 0, 0)
+            await clickWindow(window, emptySlot, 0, 0)
           }
         }
       }
@@ -110,7 +110,7 @@ function inject (bot, { version, hideErrors }) {
 
     async function tossLeftover () {
       if (window.selectedItem) {
-        await clickWindow(-999, 0, 0)
+        await clickWindow(bot.currentWindow || bot.inventory, -999, 0, 0)
       }
     }
   }
@@ -218,7 +218,7 @@ function inject (bot, { version, hideErrors }) {
         if (!sourceItem) throw new Error(`Can't find ${mcDataEntry.name} in slots [${sourceStart} - ${sourceEnd}], (item id: ${itemType})`)
         if (firstSourceSlot === null) firstSourceSlot = sourceItem.slot
         // number of item that can be moved from that slot
-        await clickWindow(sourceItem.slot, 0, 0)
+        await clickWindow(window, sourceItem.slot, 0, 0)
       }
       await clickDest()
 
@@ -249,13 +249,13 @@ function inject (bot, { version, hideErrors }) {
         // if the number of item the left click moves is less than the number of item we want to move
         // several at the same time (left click)
         if (movedItems <= count) {
-          await clickWindow(destSlot, 0, 0)
+          await clickWindow(window, destSlot, 0, 0)
           // update the number of item we want to move (count)
           count -= movedItems
           await transferOne()
         } else {
           // one by one (right click)
-          await clickWindow(destSlot, 1, 0)
+          await clickWindow(window, destSlot, 1, 0)
           count -= 1
           await transferOne()
         }
@@ -370,7 +370,7 @@ function inject (bot, { version, hideErrors }) {
     }
   }
 
-  async function clickWindow (slot, mouseButton, mode) {
+  async function clickWindow (window, slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
     if (slot >= bot.QUICK_BAR_START && bot.lastDigTime != null) {
@@ -379,7 +379,6 @@ function inject (bot, { version, hideErrors }) {
         await sleep(DIG_CLICK_TIMEOUT - timeSinceLastDig)
       }
     }
-    const window = bot.currentWindow || bot.inventory
 
     assert.ok(mouseButton === 0 || mouseButton === 1)
     assert.strictEqual(mode, 0)
@@ -420,7 +419,7 @@ function inject (bot, { version, hideErrors }) {
   async function putAway (slot, noWaiting = false) {
     const window = bot.currentWindow || bot.inventory
     const promisePutAway = once(window, `updateSlot:${slot}`)
-    await clickWindow(slot, 0, 0)
+    await clickWindow(window, slot, 0, 0)
     const start = window.inventoryStart
     const end = window.inventoryEnd
     await putSelectedItemRange(start, end, window, null, noWaiting)
@@ -428,13 +427,14 @@ function inject (bot, { version, hideErrors }) {
   }
 
   async function moveSlotItem (sourceSlot, destSlot) {
-    await clickWindow(sourceSlot, 0, 0)
-    await clickWindow(destSlot, 0, 0)
+    const window = bot.currentWindow || bot.inventory
+    await clickWindow(window, sourceSlot, 0, 0)
+    await clickWindow(window, destSlot, 0, 0)
     // if we're holding an item, put it back where the source item was.
     // otherwise we're done.
     updateHeldItem()
     if (bot.inventory.selectedItem) {
-      await clickWindow(sourceSlot, 0, 0)
+      await clickWindow(window, sourceSlot, 0, 0)
     }
   }
 

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -22,8 +22,8 @@ function inject (bot) {
 
   async function tossStack (item) {
     assert.ok(item)
-    await bot.clickWindow(item.slot, 0, 0)
-    await bot.clickWindow(-999, 0, 0)
+    await bot.clickWindow(bot.currentWindow || bot.inventory, item.slot, 0, 0)
+    await bot.clickWindow(bot.currentWindow || bot.inventory, -999, 0, 0)
     bot.closeWindow(bot.currentWindow || bot.inventory)
   }
 
@@ -73,10 +73,10 @@ function inject (bot) {
       return
     }
     const equipSlot = QUICK_BAR_START + bot.quickBarSlot
-    await bot.clickWindow(equipSlot, 0, 0)
-    await bot.clickWindow(slot, 0, 0)
+    await bot.clickWindow(bot.currentWindow || bot.inventory, equipSlot, 0, 0)
+    await bot.clickWindow(bot.currentWindow || bot.inventory, slot, 0, 0)
     if (bot.inventory.selectedItem) {
-      await bot.clickWindow(-999, 0, 0)
+      await bot.clickWindow(bot.currentWindow || bot.inventory, -999, 0, 0)
     }
   }
 


### PR DESCRIPTION
closeWindow has it, so why doesn't this?

By default, clickWindow would use the currently open window or player inventory for packet transactions. By specifying a parameter, windows can be passed down directly from the windowOpen event.