### PR TITLE
Add timeout to #consume()

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -1,13 +1,17 @@
 const assert = require('assert')
 const { Vec3 } = require('vec3')
 const { once } = require('events')
-const { callbackify, sleep, createDoneTask, createTask } = require('../promise_utils')
+const { callbackify, sleep, createDoneTask, createTask, withTimeout } = require('../promise_utils')
 
 module.exports = inject
 
 // ms to wait before clicking on a tool so the server can send the new
 // damage information
 const DIG_CLICK_TIMEOUT = 500
+// The number of milliseconds to wait for the server to respond with consume completion.
+// This number is larger than the eat time of 1.61 seconds to account for latency and low tps.
+// The eat time comes from https://minecraft.fandom.com/wiki/Food#Usage
+const CONSUME_TIMEOUT = 2500
 
 function inject (bot, { version, hideErrors }) {
   const Item = require('prismarine-item')(version)
@@ -46,7 +50,7 @@ function inject (bot, { version, hideErrors }) {
 
     activateItem()
 
-    await eatingTask.promise
+    await withTimeout(eatingTask.promise, CONSUME_TIMEOUT)
   }
 
   function activateItem (offHand = false) {


### PR DESCRIPTION
There are currently many ways the bot could be interrupted during consume. Examples include activating another item, being killed, etc. This change is meant as a robust fallback in case the server does not acknowledge the consumption.