### PR TITLE
Optimize findblock distance filter

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -176,11 +176,11 @@ function inject (bot, { version, storageBuilder }) {
     // the octahedron iterator can sometime go through the same section again
     // we use a set to keep track of visited sections
     const visitedSections = new Set()
+    const maxDistanceSquared = Math.pow(maxDistance, 2)
 
     let blocks = []
     let startedLayer = 0
     let next = start
-    let maxDistanceSquared = Math.pow(maxDistance, 2)
     while (next) {
       const column = bot.world.getColumn(next.x, next.z)
       if (next.y >= 0 && next.y < 16 && column && !visitedSections.has(next.toString())) {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -180,6 +180,7 @@ function inject (bot, { version, storageBuilder }) {
     let blocks = []
     let startedLayer = 0
     let next = start
+    let maxDistanceSquared = Math.pow(maxDistance, 2)
     while (next) {
       const column = bot.world.getColumn(next.x, next.z)
       if (next.y >= 0 && next.y < 16 && column && !visitedSections.has(next.toString())) {
@@ -189,7 +190,7 @@ function inject (bot, { version, storageBuilder }) {
           for (cursor.x = next.x * 16; cursor.x < next.x * 16 + 16; cursor.x++) {
             for (cursor.y = next.y * 16; cursor.y < next.y * 16 + 16; cursor.y++) {
               for (cursor.z = next.z * 16; cursor.z < next.z * 16 + 16; cursor.z++) {
-                if (fullMatcher(cursor) && cursor.distanceTo(point) <= maxDistance) blocks.push(cursor.clone())
+                if (fullMatcher(cursor) && cursor.distanceSquared(point) <= maxDistanceSquared) blocks.push(cursor.clone())
               }
             }
           }
@@ -204,7 +205,7 @@ function inject (bot, { version, storageBuilder }) {
       next = it.next()
     }
     blocks.sort((a, b) => {
-      return a.distanceTo(point) - b.distanceTo(point)
+      return a.distanceSquared(point) - b.distanceSquared(point)
     })
     // We found more blocks than needed, shorten the array to not confuse people
     if (blocks.length > count) {


### PR DESCRIPTION
by not using `distanceTo()`, we dont use `Math.sqrt()` which is costly in processing. Instead, we can square the `maxDistance` once before anything else and use distance squared for the distance from the beginning search point. This works because we are only comparing distances, not performing arithmetic or using it for anything significant.

This also works when sorting the blocks by distance because we only need a positive value, negative value, or `0`. Getting the difference between their exact euclidian distances is overkill.