### PR TITLE
Refactor chat.js (explained)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1435,6 +1435,8 @@ the event will be called `"chat:name"`, with name being the name passed
   * `parse` - instead of returning the actual message that was matched, return the capture groups from the regex
   * `deprecated` - (**unstable**) used by bot.chatAddPattern to keep compatability, likely to be removed
 
+returns a number which can be used with bot.removeChatPattern() to only delete this pattern
+
 #### bot.addChatPatternSet(name, patterns, chatPatternOptions)
 
 make an event that is called every time all patterns havee been matched to messages,
@@ -1445,10 +1447,15 @@ the event will be called `"chat:name"`, with name being the name passed
   * `repeat` - defaults to true, whether to listen for this event after the first match
   * `parse` - instead of returning the actual message that was matched, return the capture groups from the regex
 
+returns a number which can be used with bot.removeChatPattern() to only delete this patternset
+
 #### bot.removeChatPattern(name)
 
-removes a chat pattern
-* `name` the name of the chat pattern
+removes a chat pattern(s)
+* `name` : string or number
+
+if name is a string, all patterns that have that name will be removed
+else if name is a number, only that exact pattern will be removed
 
 #### bot.awaitMessage(...args)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -224,7 +224,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   whisper: (username: string, message: string) => void
 
-  chatAddPattern: (pattern: RegExp, chatType: string, description?: string) => void
+  chatAddPattern: (pattern: RegExp, chatType: string, description?: string) => number
 
   setSettings: (options: Partial<GameSettings>) => void
 
@@ -390,11 +390,11 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   waitForTicks: (ticks: number) => Promise<void>
 
-  addChatPattern: (name: string, pattern: RegExp, options?: chatPatternOptions) => void
+  addChatPattern: (name: string, pattern: RegExp, options?: chatPatternOptions) => number
 
-  addChatPatternSet: (name: string, patterns: RegExp[], options?: chatPatternOptions) => void
+  addChatPatternSet: (name: string, patterns: RegExp[], options?: chatPatternOptions) => number
 
-  removeChatPattern: (name: string) => void
+  removeChatPattern: (name: string | number) => void
 
   awaitMessage: (...args: string[] | RegExp[]) => Promise<string>
 

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -7,28 +7,31 @@ function inject (bot, options) {
 
   const ChatMessage = require('prismarine-chat')(bot.version)
   // chat.pattern.type will emit an event for bot.on() of the same type, eg chatType = whisper will trigger bot.on('whisper')
-  let _chatRegex = []
+  const _patterns = {}
+  let _length = 0
   // deprecated
   bot.chatAddPattern = (patternValue, typeValue) => {
-    bot.addChatPattern(typeValue, patternValue, { deprecated: true })
+    return bot.addChatPattern(typeValue, patternValue, { deprecated: true })
   }
 
   bot.addChatPatternSet = (name, patterns, opts = {}) => {
     const { repeat = true, parse = false } = opts
-    _chatRegex.push({
+    _patterns[_length++] = {
       name,
       patterns,
       position: 0,
       matches: [],
       messages: [],
       repeat,
-      parse
-    })
+      parse,
+      active: true
+    }
+    return _length
   }
 
   bot.addChatPattern = (name, pattern, opts = {}) => {
     const { repeat = true, deprecated = false, parse = false } = opts
-    _chatRegex.push({
+    _patterns[_length++] = {
       name,
       patterns: [pattern],
       position: 0,
@@ -36,20 +39,31 @@ function inject (bot, options) {
       messages: [],
       deprecated,
       repeat,
-      parse
-    })
+      parse,
+      active: true
+    }
+    return _length
   }
 
-  bot.removeChatPattern = (name) => {
-    _chatRegex = _chatRegex.filter(pattern => pattern.name !== name)
+  bot.removeChatPattern = name => {
+    if (typeof name === 'number') {
+      _patterns[name] = undefined
+    } else {
+      const matchingPatterns = Object.entries(_patterns).filter(pattern => pattern[1].name === name)
+      matchingPatterns.forEach(([indexString]) => {
+        _patterns[+indexString] = undefined
+      })
+    }
   }
 
   function findMatchingPatterns (msg) {
     const found = []
-    for (const [ix, { patterns, position }] of _chatRegex.entries()) {
+    for (const [indexString, pattern] of Object.entries(_patterns)) {
+      if (!pattern) continue
+      const { position, patterns } = pattern
       if (position >= patterns.length) continue // sometimes the cleanup isn't called quick enough
       if (patterns[position].test(msg)) {
-        found.push(ix)
+        found.push(+indexString)
       }
     }
     return found
@@ -60,38 +74,32 @@ function inject (bot, options) {
     if (foundPatterns.length === 0) return
 
     for (const ix of foundPatterns) {
-      _chatRegex[ix].matches.push(msg)
-      _chatRegex[ix].messages.push(originalMsg)
-      _chatRegex[ix].position++
-    }
+      _patterns[ix].matches.push(msg)
+      _patterns[ix].messages.push(originalMsg)
+      _patterns[ix].position++
 
-    _chatRegex.forEach((o, ix) => {
-      // we have all messages needed
-      if (o.patterns.length !== o.position) return
-
-      if (o.deprecated) { // compatability layer for bot.chataddpattern
-        const matches = o.matches[0].match(o.patterns[0])
+      if (_patterns[ix].deprecated) {
+        const matches = _patterns[ix].matches[0].match(_patterns[ix].patterns[0])
         matches.splice(0, 1)
-        bot.emit(`${o.name}`, ...matches, o.messages[0].translate, ...o.messages)
-        o.messages.length = 0 // clear out old messages
+        bot.emit(_patterns[ix].name, ...matches, _patterns[ix].messages[0].translate, ..._patterns[ix].messages)
+        _patterns[ix].messages.length = 0 // clear out old messages
       } else { // regular parsing
-        if (o.parse) {
-          const matches = o.patterns.map((pattern, i) => _chatRegex[ix].matches[i].match(pattern))
+        if (_patterns[ix].parse) {
+          const matches = _patterns[ix].patterns.map((pattern, i) => _patterns[ix].matches[i].match(pattern))
           matches.forEach(o => o.splice(0, 1)) // delete full message match
-          bot.emit(`chat:${o.name}`, matches)
+          bot.emit(`chat:${_patterns[ix].name}`, matches)
         } else {
-          bot.emit(`chat:${o.name}`, o.matches)
+          bot.emit(`chat:${_patterns[ix].name}`, _patterns[ix].matches)
+        }
+        // these are possibly null-ish if the user deletes them as soon as the event for the match is emitted
+        if (_patterns[ix]?.repeat) {
+          _patterns[ix].position = 0
+          _patterns[ix].matches = []
+        } else {
+          _patterns[ix] = undefined
         }
       }
-
-      // run again
-      if (o.repeat) {
-        _chatRegex[ix].position = 0
-        _chatRegex[ix].matches = []
-      } else {
-        _chatRegex.splice(ix, 1)
-      }
-    })
+    }
   })
 
   addDefaultPatterns()

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -77,25 +77,27 @@ function inject (bot, options) {
       _patterns[ix].position++
 
       if (_patterns[ix].deprecated) {
-        const matches = _patterns[ix].matches[0].match(_patterns[ix].patterns[0])
-        matches.splice(0, 1)
+        const [, ...matches] = _patterns[ix].matches[0].match(_patterns[ix].patterns[0])
         bot.emit(_patterns[ix].name, ...matches, _patterns[ix].messages[0].translate, ..._patterns[ix].messages)
-        _patterns[ix].messages.length = 0 // clear out old messages
+        _patterns[ix].messages = [] // clear out old messages
       } else { // regular parsing
         if (_patterns[ix].parse) {
-          const matches = _patterns[ix].patterns.map((pattern, i) => _patterns[ix].matches[i].match(pattern))
-          matches.forEach(o => o.splice(0, 1)) // delete full message match
+          const matches = _patterns[ix].patterns.map((pattern, i) => {
+            const [, ...matches] = _patterns[ix].matches[i].match(pattern) // delete full message match
+            return matches
+          })
           bot.emit(`chat:${_patterns[ix].name}`, matches)
         } else {
           bot.emit(`chat:${_patterns[ix].name}`, _patterns[ix].matches)
         }
         // these are possibly null-ish if the user deletes them as soon as the event for the match is emitted
-        if (_patterns[ix]?.repeat) {
-          _patterns[ix].position = 0
-          _patterns[ix].matches = []
-        } else {
-          _patterns[ix] = undefined
-        }
+      }
+
+      if (_patterns[ix]?.repeat) {
+        _patterns[ix].position = 0
+        _patterns[ix].matches = []
+      } else {
+        _patterns[ix] = undefined
       }
     }
   })

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -23,8 +23,7 @@ function inject (bot, options) {
       matches: [],
       messages: [],
       repeat,
-      parse,
-      active: true
+      parse
     }
     return _length
   }
@@ -39,8 +38,7 @@ function inject (bot, options) {
       messages: [],
       deprecated,
       repeat,
-      parse,
-      active: true
+      parse
     }
     return _length
   }

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -47,7 +47,7 @@ function inject (bot, options) {
     if (typeof name === 'number') {
       _patterns[name] = undefined
     } else {
-      const matchingPatterns = Object.entries(_patterns).filter(pattern => pattern[1].name === name)
+      const matchingPatterns = Object.entries(_patterns).filter(pattern => pattern[1]?.name === name)
       matchingPatterns.forEach(([indexString]) => {
         _patterns[+indexString] = undefined
       })
@@ -59,7 +59,6 @@ function inject (bot, options) {
     for (const [indexString, pattern] of Object.entries(_patterns)) {
       if (!pattern) continue
       const { position, patterns } = pattern
-      if (position >= patterns.length) continue // sometimes the cleanup isn't called quick enough
       if (patterns[position].test(msg)) {
         found.push(+indexString)
       }
@@ -69,7 +68,6 @@ function inject (bot, options) {
 
   bot.on('messagestr', (msg, _, originalMsg) => {
     const foundPatterns = findMatchingPatterns(msg)
-    if (foundPatterns.length === 0) return
 
     for (const ix of foundPatterns) {
       _patterns[ix].matches.push(msg)
@@ -81,6 +79,7 @@ function inject (bot, options) {
         bot.emit(_patterns[ix].name, ...matches, _patterns[ix].messages[0].translate, ..._patterns[ix].messages)
         _patterns[ix].messages = [] // clear out old messages
       } else { // regular parsing
+        if (_patterns[ix].patterns.length > _patterns[ix].matches.length) return // we have all the matches, so we can emit the done event
         if (_patterns[ix].parse) {
           const matches = _patterns[ix].patterns.map((pattern, i) => {
             const [, ...matches] = _patterns[ix].matches[i].match(pattern) // delete full message match
@@ -92,7 +91,6 @@ function inject (bot, options) {
         }
         // these are possibly null-ish if the user deletes them as soon as the event for the match is emitted
       }
-
       if (_patterns[ix]?.repeat) {
         _patterns[ix].position = 0
         _patterns[ix].matches = []

--- a/test/externalTests/chat.js
+++ b/test/externalTests/chat.js
@@ -89,5 +89,16 @@ module.exports = () => {
     await p4
   })
 
+  addTest('test removechatpattern with a number input', async (bot) => {
+    const patternIndex = bot.addChatPattern('hello', /hello/)
+    bot.chat('hello')
+    await once(bot, 'chat:hello')
+    bot.removeChatPattern(patternIndex)
+    await new Promise((resolve, reject) => {
+      setTimeout(() => resolve(), 5000)
+      bot.on('chat:hello', reject(new Error("Hello event shouldn't work after removing it")))
+    })
+  })
+
   return tests
 }

--- a/test/externalTests/chat.js
+++ b/test/externalTests/chat.js
@@ -96,7 +96,7 @@ module.exports = () => {
     bot.removeChatPattern(patternIndex)
     await new Promise((resolve, reject) => {
       setTimeout(() => resolve(), 5000)
-      bot.on('chat:hello', reject(new Error("Hello event shouldn't work after removing it")))
+      bot.on('chat:hello', () => reject(new Error("Hello event shouldn't work after removing it")))
     })
   })
 


### PR DESCRIPTION
What does this pr do:

1. internally the chat.js plugin no longer uses an array for storing chatpattern(set)s, they are stored in an object with a length variable that is incremented with each addition. the actual object is now called `_patterns` and the length is called `_length`.
2. internally, when the chat.js plugin gets a new message, it only processes the chatpattern(set) that the message in chat matches instead of processing every single stored pattern.
3. when registering a chat pattern with addChatPattern()/addChatPatternSet()/chatAddPattern() a number is now returned, this number is the index of that pattern in the internal _patterns object
4. removeChatPattern() now works based on what's passed to it for the name parameter: if name is a string, all patterns that have that name will be removed, else if name is a number, only that exact pattern will be removed


closes https://github.com/PrismarineJS/mineflayer/issues/1981