### PR TITLE
Revert "Remove anvil tests from blocked list since their test works now"

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -13,7 +13,7 @@ const START_THE_SERVER = true
 const WAIT_TIME_BEFORE_STARTING = 5000
 const TEST_TIMEOUT_MS = 60000
 
-const excludedTests = ['digEverything', 'book']
+const excludedTests = ['digEverything', 'book', 'anvil']
 
 const propOverrides = {
   'level-type': 'FLAT',


### PR DESCRIPTION
Reverts PrismarineJS/mineflayer#1998 (broke ci on master as soon as committed)