### PR TITLE
Add inventory item click delay

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -30,6 +30,7 @@ function inject (bot, { version, hideErrors }) {
   bot.inventory = windows.createWindow(0, 'minecraft:inventory', 'Inventory')
   bot.currentWindow = null
   bot.heldItem = null
+  bot.clickWaitTime = 50
 
   bot._client.on('entity_status', (packet) => {
     if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && !eatingTask.done) {
@@ -419,6 +420,7 @@ function inject (bot, { version, hideErrors }) {
     if (!success) {
       throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots, null, 2)}.`)
     }
+    if (bot.clickWaitTime) await sleep(bot.clickWaitTime)
   }
 
   async function putAway (slot, noWaiting = false) {


### PR DESCRIPTION
Adds a delay to every clickWindow function call to lower the cance of inventory desync, rejected transactions or anti cheat detection. 