### PR TITLE
Fix crash on blocks without registered blockId

### DIFF
--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -56,7 +56,7 @@ function inject (bot, { version }) {
     const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
     const block = bot.blockAt(pt)
 
-    if (block === null) { return }
+    if (block === null || !blocks[packet.blockId]) { return }
 
     const blockName = blocks[packet.blockId].name
 

--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -56,6 +56,7 @@ function inject (bot, { version }) {
     const pt = new Vec3(packet.location.x, packet.location.y, packet.location.z)
     const block = bot.blockAt(pt)
 
+    // Ignore on non-vanilla blocks 
     if (block === null || !blocks[packet.blockId]) { return }
 
     const blockName = blocks[packet.blockId].name


### PR DESCRIPTION
A simple addition to the already-existing if statement on line 59 ( !blocks[packet.blockId] ) to ignore handling packets coming from unregistered blocks that may have been introduced by protocol modifications (IE a Forge Protocol Extension, https://www.npmjs.com/package/minecraft-protocol-forge)