### PR TITLE
Change bot.quit() to run bot.end() instead of bot._client.end()

### DIFF
--- a/lib/plugins/kick.js
+++ b/lib/plugins/kick.js
@@ -9,6 +9,6 @@ function inject (bot) {
   })
   bot.quit = (reason) => {
     reason = reason ?? 'disconnect.quitting'
-    bot._client.end(reason)
+    bot.end(reason)
   }
 }


### PR DESCRIPTION
changes bot.quit to run bot.end() instead of bot._client.end() because the bot#end event is listened to when used here in cleaning up physics: https://github.com/PrismarineJS/mineflayer/blob/ad32b6a3d6945b86b118515f45bc13b6af1b6133/lib/plugins/physics.js#L291

closes https://github.com/PrismarineJS/mineflayer/issues/1863