### PR TITLE
add pviewer recording to ci

### DIFF
--- a/lib/plugins/kick.js
+++ b/lib/plugins/kick.js
@@ -9,6 +9,6 @@ function inject (bot) {
   })
   bot.quit = (reason) => {
     reason = reason ?? 'disconnect.quitting'
-    bot._client.end(reason)
+    bot.end(reason)
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "mocha_test": "mocha --reporter spec --exit",
+    "mocha_test": "mocha --reporter spec",
     "test": "npm run mocha_test",
     "pretest": "npm run lint",
     "lint": "standard && ts-standard *.d.ts && standard-markdown",
@@ -43,9 +43,11 @@
     "minecraft-wrap": "^1.2.1",
     "mineflayer": "file:.",
     "mocha": "^9.0.0",
+    "node-canvas-webgl": "^0.2.6",
+    "prismarine-viewer": "^1.19.3",
     "standard": "^16.0.1",
+    "standard-markdown": "^6.0.0",
     "ts-standard": "^10.0.0",
-    "typescript": "^4.3.2",
-    "standard-markdown": "^6.0.0"
+    "typescript": "^4.3.2"
   }
 }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -6,7 +6,24 @@ const commonTest = require('./externalTests/plugins/testCommon')
 const mc = require('minecraft-protocol')
 const fs = require('fs')
 const path = require('path')
+// prismarine-viewer setup
+const mineflayerViewer = require('prismarine-viewer').headless
+global.THREE = require('three')
+global.Worker = require('worker_threads').Worker
+const { createCanvas, ImageData } = require('node-canvas-webgl/lib')
 
+// Patch global scope to imitate browser environment.
+global.window = global
+global.THREE = THREE
+global.ImageData = ImageData
+global.document = {
+  createElement: (nodeName) => {
+    if (nodeName !== 'canvas') throw new Error(`Cannot create node ${nodeName}`)
+    const canvas = createCanvas(256, 256)
+    return canvas
+  }
+}
+// end prismarine-viewer setup
 // set this to false if you want to test without starting a server automatically
 const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
@@ -23,7 +40,8 @@ const propOverrides = {
   gamemode: '1',
   'spawn-monsters': 'false',
   'generate-structures': 'false',
-  'enable-command-block': 'true'
+  'enable-command-block': 'true',
+  'use-native-transport': 'false' // java 16 throws errors without this, https://www.spigotmc.org/threads/unable-to-access-address-of-buffer.311602
 }
 
 const Wrap = require('minecraft-wrap').Wrap
@@ -59,6 +77,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
         console.log('starting bot')
         bot.once('login', () => {
+          mineflayerViewer(bot, { output: 'output.mp4', frames: -1, width: 512, height: 512 })
           wrap.writeServer('op flatbot\n')
           console.log('waiting a second...')
           // this wait is to get all the window updates out of the way before we start expecting exactly what we cause.


### PR DESCRIPTION
This does work, but I don't think it is helpful after watching it

to make this work:
1. run: 
```
sudo apt update
sudo apt-get install ffmpeg xvfb -y 
```
2. change https://github.com/PrismarineJS/prismarine-viewer/blob/691dd688ee56ea823caca6f3540475eb8f92e686/viewer/lib/worldrenderer.js#L22-L23 to 
```js
src += '/worker.js'
```
3. run mocha with: `xvfb-run -s "-ac -screen 0 1280x1024x24"  npm run mocha_test`