### PR TITLE
Remove polling, recursive calling, rechecks

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -126,7 +126,7 @@ function inject (bot, { version, storageBuilder }) {
           resolve()
         }
       }
-      
+
       if (chunkPosToCheck.length > 0) { // begin listening for remaining chunks to load
         bot.world.on('chunkColumnLoad', waitForLoadEvents)
       } else { // all chunks were already loaded, skip listening for events

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -122,13 +122,13 @@ function inject (bot, { version, storageBuilder }) {
           chunkPosToCheck.splice(position, 1)
         }
         if (chunkPosToCheck.length === 0) { // no chunks left to find
-          this.bot.world.off('chunkColumnLoad', waitForLoadEvents) // remove this listener instance
+          bot.world.off('chunkColumnLoad', waitForLoadEvents) // remove this listener instance
           resolve()
         }
       }
       
       if (chunkPosToCheck.length > 0) { // begin listening for remaining chunks to load
-        this.bot.world.on('chunkColumnLoad', waitForLoadEvents)
+        bot.world.on('chunkColumnLoad', waitForLoadEvents)
       } else { // all chunks were already loaded, skip listening for events
         resolve()
       }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -1,7 +1,7 @@
 const Vec3 = require('vec3').Vec3
 const assert = require('assert')
 const Painting = require('../painting')
-const { callbackify, sleep } = require('../promise_utils')
+const { callbackify } = require('../promise_utils')
 
 const { OctahedronIterator } = require('prismarine-world').iterators
 
@@ -104,16 +104,35 @@ function inject (bot, { version, storageBuilder }) {
   }
 
   async function waitForChunksToLoad () {
-    // check 5x5 chunks around us
-    for (let x = -2; x <= 2; x++) {
-      for (let y = -2; y <= 2; y++) {
-        if (bot.world.getColumnAt(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16))) == null) {
-          // keep wait
-          await sleep(100)
-          await waitForChunksToLoad()
+    return new Promise((resolve) => {
+      // get corner coords of 5x5 chunks around us
+      let chunkPosToCheck = []
+      for (let x = -2; x <= 2; x++) {
+        for (let y = -2; y <= 2; y++) {
+          chunkPosToCheck.push(bot.entity.position.plus(new Vec3(x, 0, y).scaled(16)))
         }
       }
-    }
+
+      // ignore any chunks which are already loaded
+      chunkPosToCheck = chunkPosToCheck.filter((vectorElement) => { return bot.world.getColumnAt(vectorElement) == null })
+
+      function waitForLoadEvents (columnCorner) {
+        const position = chunkPosToCheck.findIndex((vectorElement) => { return columnCorner.equals(vectorElement) })
+        if (position !== -1) { // loaded chunk was a desired chunk, no longer need to check it
+          chunkPosToCheck.splice(position, 1)
+        }
+        if (chunkPosToCheck.length === 0) { // no chunks left to find
+          this.bot.world.off('chunkColumnLoad', waitForLoadEvents) // remove this listener instance
+          resolve()
+        }
+      }
+      
+      if (chunkPosToCheck.length > 0) { // begin listening for remaining chunks to load
+        this.bot.world.on('chunkColumnLoad', waitForLoadEvents)
+      } else { // all chunks were already loaded, skip listening for events
+        resolve()
+      }
+    })
   }
 
   function getMatchingFunction (matching) {


### PR DESCRIPTION
This code is more complex but requires only a single lookup per chunk, does not poll, returns as soon as the chunk is loaded instead of at 1/10th second granularity, and does not fill the queue with recursive calls to itself.
In Rom's original waitForChunksToLoad if at least one chunk were unloaded when running the check, the code would poll the loaded chunks by waiting 100ms and then recursively calling waitForChunksToLoad() until each chunk loaded. That would fill up the task queue with recursive calls as well as repeat every check for the 5x5 area up until the blocking chunk each time it's called. Once that missing chunk finally loaded, as the functions complete and return they must complete the rest of the checks after the blocking chunk in each parent stack frame; the end result being continually checking those same chunks over and over until it finally drains the task queue. The worst case scenario for that code's chunk lookups until returning from the original waitForChunksToLoad() is 24 * 10 * length in seconds the chunk was unloaded.