### PR TITLE
Bypass anticheats that detect sensitivity

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -227,9 +227,9 @@ function inject (bot, { physicsEnabled }) {
 
     // this is done to bypass certain anticheat checks that detect the player's sensitivity
     // by calculating the gcd of how much they move the mouse each tick
-    const sensitivity = conv.fromNotchianPitch(.15) // this is equal to 100% sensitivity in vanilla
-    let yawChange = Math.round((yaw - bot.entity.yaw) / sensitivity) * sensitivity
-    let pitchChange = Math.round((pitch - bot.entity.pitch) / sensitivity) * sensitivity
+    const sensitivity = conv.fromNotchianPitch(0.15) // this is equal to 100% sensitivity in vanilla
+    const yawChange = Math.round((yaw - bot.entity.yaw) / sensitivity) * sensitivity
+    const pitchChange = Math.round((pitch - bot.entity.pitch) / sensitivity) * sensitivity
 
     bot.entity.yaw += yawChange
     bot.entity.pitch += pitchChange

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -127,8 +127,8 @@ function inject (bot, { physicsEnabled }) {
     const maxDeltaYaw = dt * physics.yawSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
 
-    const yaw = conv.toNotchianYaw(lastSentYaw)
-    const pitch = conv.toNotchianPitch(bot.entity.pitch)
+    const yaw = Math.fround(conv.toNotchianYaw(lastSentYaw))
+    const pitch = Math.fround(conv.toNotchianPitch(bot.entity.pitch))
     const position = bot.entity.position
     const onGround = bot.entity.onGround
 
@@ -225,8 +225,15 @@ function inject (bot, { physicsEnabled }) {
     }
     lookingTask = createTask()
 
-    bot.entity.yaw = yaw
-    bot.entity.pitch = pitch
+    // this is done to bypass certain anticheat checks that detect the player's sensitivity
+    // by calculating the gcd of how much they move the mouse each tick
+    const sensitivity = conv.fromNotchianPitch(.15) // this is equal to 100% sensitivity in vanilla
+    let yawChange = Math.round((yaw - bot.entity.yaw) / sensitivity) * sensitivity
+    let pitchChange = Math.round((pitch - bot.entity.pitch) / sensitivity) * sensitivity
+
+    bot.entity.yaw += yawChange
+    bot.entity.pitch += pitchChange
+
     if (force) {
       lastSentYaw = yaw
       return


### PR DESCRIPTION
Anticheats can detect the player's sensitivity by comparing how much the player's look direction changes each tick and getting the GCD of that. In vanilla when using 100% sensitivity, the player's look direction always changes by a multiple .15 when they're manually moving the camera with the mouse. This change makes mineflayer do that too. I have a proof-of-concept anticheat that does this (which is on my unfinished server, matdoes.dev) but there's likely other anticheats that do this as well.