### PR TITLE
Add option to bot.look

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -249,12 +249,13 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   clearControlStates: () => void
 
-  lookAt: (point: Vec3, force?: boolean, callback?: () => void) => Promise<void>
+  lookAt: (point: Vec3, force?: boolean, snapYaw?: boolean, callback?: () => void) => Promise<void>
 
   look: (
     yaw: number,
     pitch: number,
     force?: boolean,
+    snapYaw?: boolean,
     callback?: () => void
   ) => Promise<void>
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -33,6 +33,7 @@ function inject (bot, { physicsEnabled }) {
     sneak: false
   }
   let lastSentYaw = null
+  let targetYaw = null
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
   let shouldUsePhysics = false
@@ -121,11 +122,15 @@ function inject (bot, { physicsEnabled }) {
     if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
-    const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)
+    const dYaw = deltaYaw(targetYaw, lastSentYaw)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
     const maxDeltaYaw = dt * physics.yawSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
+
+    if (bot.entity.yaw !== targetYaw) {
+      bot.entity.yaw = lastSentYaw
+    }
 
     const yaw = conv.toNotchianYaw(lastSentYaw)
     const pitch = conv.toNotchianPitch(bot.entity.pitch)
@@ -219,28 +224,32 @@ function inject (bot, { physicsEnabled }) {
     }
   })
 
-  bot.look = callbackify(async (yaw, pitch, force) => {
+  bot.look = callbackify(async (yaw, pitch, force, snapYaw) => {
     if (!lookingTask.done) {
       lookingTask.finish() // finish the previous one
     }
     lookingTask = createTask()
 
-    bot.entity.yaw = yaw
+    targetYaw = yaw
     bot.entity.pitch = pitch
     if (force) {
       lastSentYaw = yaw
+      bot.entity.yaw = yaw
       return
+    }
+    if (snapYaw ?? true) {
+      bot.entity.yaw = yaw
     }
 
     await lookingTask.promise
   })
 
-  bot.lookAt = callbackify(async (point, force) => {
+  bot.lookAt = callbackify(async (point, force, snapYaw = true) => {
     const delta = point.minus(bot.entity.position.offset(0, bot.entity.height, 0))
     const yaw = Math.atan2(-delta.x, -delta.z)
     const groundDistance = Math.sqrt(delta.x * delta.x + delta.z * delta.z)
     const pitch = Math.atan2(delta.y, groundDistance)
-    await bot.look(yaw, pitch, force)
+    await bot.look(yaw, pitch, force, snapYaw)
   })
 
   // player position and look (clientbound)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -122,13 +122,13 @@ function inject (bot, { physicsEnabled }) {
     if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
-    const dYaw = deltaYaw(targetYaw, lastSentYaw)
+    const dYaw = deltaYaw(targetYaw ?? lastSentYaw, lastSentYaw)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
     const maxDeltaYaw = dt * physics.yawSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
 
-    if (bot.entity.yaw !== targetYaw) {
+    if (!lookingTask.done) {
       bot.entity.yaw = lastSentYaw
     }
 
@@ -210,7 +210,7 @@ function inject (bot, { physicsEnabled }) {
   let lookingTask = createDoneTask()
 
   bot.on('move', () => {
-    if (!lookingTask.done && Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001) {
+    if (!lookingTask.done && Math.abs(deltaYaw(targetYaw ?? lastSentYaw, lastSentYaw)) < 0.001) {
       lookingTask.finish()
     }
   })
@@ -260,9 +260,9 @@ function inject (bot, { physicsEnabled }) {
     // If flag is set, then the corresponding value is relative, else it is absolute
     const pos = bot.entity.position
     pos.set(
-      packet.flags & 1 ? (pos.x + packet.x) : packet.x,
-      packet.flags & 2 ? (pos.y + packet.y) : packet.y,
-      packet.flags & 4 ? (pos.z + packet.z) : packet.z
+        packet.flags & 1 ? (pos.x + packet.x) : packet.x,
+        packet.flags & 2 ? (pos.y + packet.y) : packet.y,
+        packet.flags & 4 ? (pos.z + packet.z) : packet.z
     )
 
     const newYaw = (packet.flags & 8 ? conv.toNotchianYaw(bot.entity.yaw) : 0) + packet.yaw

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -260,9 +260,9 @@ function inject (bot, { physicsEnabled }) {
     // If flag is set, then the corresponding value is relative, else it is absolute
     const pos = bot.entity.position
     pos.set(
-        packet.flags & 1 ? (pos.x + packet.x) : packet.x,
-        packet.flags & 2 ? (pos.y + packet.y) : packet.y,
-        packet.flags & 4 ? (pos.z + packet.z) : packet.z
+      packet.flags & 1 ? (pos.x + packet.x) : packet.x,
+      packet.flags & 2 ? (pos.y + packet.y) : packet.y,
+      packet.flags & 4 ? (pos.z + packet.z) : packet.z
     )
 
     const newYaw = (packet.flags & 8 ? conv.toNotchianYaw(bot.entity.yaw) : 0) + packet.yaw


### PR DESCRIPTION
With the current codebase, when having a control state active and doing a bot.look, the physics simulation snaps the bot's yaw to what was set, rather than the direction the bot sent to the server. This change gives option to let the bot head in the direction it sent to the server. 