### PR TITLE
patches window.withdraw

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -273,6 +273,10 @@ function inject (bot, { version, hideErrors }) {
       closeWindow(window)
     }
     window.withdraw = callbackify(async (itemType, metadata, count) => {
+      if (bot.inventory.emptySlotCount() === 0) {
+        throw new Error('Unable to withdraw, Bot inventory is full.')
+      }
+
       const options = {
         window,
         itemType,


### PR DESCRIPTION
stops the bot from 'picking' up / withdrawing an item out of a chest when the inventory is full.
stop #2020