### PR TITLE
Fix chest lid move

### DIFF
--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -19,6 +19,9 @@ const FACING_MAP = {
 function inject (bot, { version }) {
   const { instruments, blocks } = require('minecraft-data')(version)
 
+  // Stores how many players have currently open a container at a certain position
+  const openCountByPos = {}
+
   function parseChestMetadata (chestBlock) {
     const chestTypes = ['single', 'right', 'left']
 
@@ -68,18 +71,27 @@ function inject (bot, { version }) {
     } else if (blockName === 'sticky_piston' || blockName === 'piston') {
       bot.emit('pistonMove', block, packet.byte1, packet.byte2)
     } else {
+      let block2 = null
+
       if (blockName === 'chest' || blockName === 'trapped_chest') {
         const chestType = getChestType(block)
-        if (chestType === 'single') { // Omit left so 'chestLidMove' doesn't emit twice when it's a double chest
-          bot.emit('chestLidMove', block, packet.byte2, null)
-        } else if (chestType === 'right') {
+        if (chestType === 'right') {
           const index = Object.values(FACING_MAP[parseChestMetadata(block).facing]).indexOf('left')
           const cardinalBlock2 = Object.keys(FACING_MAP[parseChestMetadata(block).facing])[index]
           const block2Position = block.position.plus(CARDINALS[cardinalBlock2])
-          bot.emit('chestLidMove', block, packet.byte2, bot.blockAt(block2Position))
+          block2 = bot.blockAt(block2Position)
+        } else if (chestType === 'left') return // Omit left part of the chest so 'chestLidMove' doesn't emit twice when it's a double chest
+      }
+
+      // Emit 'chestLidMove' only if the number of players with the lid open changes
+      if (openCountByPos[block.position] !== packet.byte2) {
+        bot.emit('chestLidMove', block, packet.byte2, block2)
+
+        if (packet.byte2 > 0) {
+          openCountByPos[block.position] = packet.byte2
+        } else {
+          delete openCountByPos[block.position]
         }
-      } else {
-        bot.emit('chestLidMove', block, packet.byte2, null)
       }
     }
   })

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -77,7 +77,7 @@ module.exports = () => async (bot) => {
   // Test that "chestLidMove" is emitted only once when opening a double chest
   let emitted = false
   bot.on('chestLidMove', handler)
-  function handler (block, isOpen, block2) {
+  async function handler (block, isOpen, block2) {
     if (emitted) {
       assert.fail(new Error('chestLidMove emitted twice'))
     } else {
@@ -91,10 +91,10 @@ module.exports = () => async (bot) => {
       assert(blockAssert && block2Assert, new Error('The block instance emitted by chestLidMove is not part of the chest oppened'))
       assert.strictEqual(isOpen, 1, new Error('isOpen should be 1 when opened by one only player'))
 
-      setTimeout(() => {
-        bot.removeListener('chestLidMove', handler)
-        chest.close()
-      }, 500)
+      await bot.test.wait(500)
+
+      bot.removeListener('chestLidMove', handler)
+      chest.close()
     }
   }
   const chest = await bot.openChest(bot.blockAt(largeChestLocations[0]))

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -24,6 +24,9 @@ module.exports = () => async (bot) => {
     blockItemsByName = 'blocksByName'
   }
 
+  const chestBlockId = mcData.blocksByName.chest.id
+  const trappedChestBlockId = mcData.blocksByName.trapped_chest.id
+
   function itemByName (items, name) {
     for (let i = 0; i < items.length; ++i) {
       const item = items[i]
@@ -73,6 +76,13 @@ module.exports = () => async (bot) => {
   await bot.test.placeBlock(trappedChestSlot, largeTrappedChestLocations[0])
   await bot.test.placeBlock(trappedChestSlot, largeTrappedChestLocations[1])
   await bot.test.placeBlock(trappedChestSlot, smallTrappedChestLocation)
+
+  assert.strictEqual(bot.blockAt(largeChestLocations[0]).type, chestBlockId)
+  assert.strictEqual(bot.blockAt(largeChestLocations[1]).type, chestBlockId)
+  assert.strictEqual(bot.blockAt(smallChestLocation).type, chestBlockId)
+  assert.strictEqual(bot.blockAt(largeTrappedChestLocations[0]).type, trappedChestBlockId)
+  assert.strictEqual(bot.blockAt(largeTrappedChestLocations[1]).type, trappedChestBlockId)
+  assert.strictEqual(bot.blockAt(smallTrappedChestLocation).type, trappedChestBlockId)
 
   // Test that "chestLidMove" is emitted only once when opening a double chest
   let emitted = false


### PR DESCRIPTION
Apparently since 1.17, when a chest is opened/closed 'block_action'  is emitted every 200ms (instead of once every time the chest is opened/closed), which was triggering multiple 'chestLidMove' events. Since useChests.js checks that 'chestLidMove' is only emitted once (even if it's a double chest) it was failing.

I've updated it so that it keeps track of how many players are looking at a chest (`openCountByPos`). And 'chestLidMove' is only emitted once the amount of players looking at that chest changes.

useChests.js seem to pass now