### PR TITLE
automatic port discovery for tests

### DIFF
--- a/test/common/util.js
+++ b/test/common/util.js
@@ -1,0 +1,13 @@
+
+const net = require('net')
+
+const getPort = () => new Promise(resolve => {
+  const server = net.createServer()
+  server.listen(0, '127.0.0.1')
+  server.on('listening', () => {
+    const { port } = server.address()
+    server.close(() => resolve(port))
+  })
+})
+
+module.exports = { getPort }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -7,6 +7,8 @@ const mc = require('minecraft-protocol')
 const fs = require('fs')
 const path = require('path')
 
+const { getPort } = require('./common/util')
+
 // set this to false if you want to test without starting a server automatically
 const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
@@ -32,7 +34,7 @@ const download = require('minecraft-wrap').download
 const MC_SERVER_PATH = path.join(__dirname, 'server')
 
 for (const supportedVersion of mineflayer.testedVersions) {
-  const PORT = Math.round(30000 + Math.random() * 20000)
+  let PORT = 25565
   const mcData = require('minecraft-data')(supportedVersion)
   const version = mcData.version
   const MC_SERVER_JAR_DIR = process.env.MC_SERVER_JAR_DIR || `${process.cwd()}/server_jars`
@@ -45,6 +47,10 @@ for (const supportedVersion of mineflayer.testedVersions) {
   describe(`mineflayer_external ${version.minecraftVersion}`, function () {
     let bot
     this.timeout(10 * 60 * 1000)
+    before(async function () {
+      PORT = await getPort()
+      console.log(`Port chosen: ${PORT}`)
+    })
     before((done) => {
       function begin () {
         bot = mineflayer.createBot({


### PR DESCRIPTION
Address #2002 

Using identical fix from https://github.com/PrismarineJS/node-minecraft-protocol/pull/870