### PR TITLE
Added containerItems() in class Chest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -666,6 +666,8 @@ export class Chest extends (EventEmitter as new () => TypedEmitter<StorageEvents
   count (itemType: number, metadata: number | null): number;
 
   items (): Item[];
+
+  containerItems (): Item[];
 }
 
 export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEvents>) {


### PR DESCRIPTION
Hi, in Chest's examples this containerItems () method was used, but ts file (in the tooltips) it is not there, so I decided to add