### PR TITLE
Mitigate error from chat parser

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -59,9 +59,11 @@ function inject (bot, options) {
     for (const [indexString, pattern] of Object.entries(_patterns)) {
       if (!pattern) continue
       const { position, patterns } = pattern
-      if (patterns[position].test(msg)) {
-        found.push(+indexString)
-      }
+      try {
+        if (patterns[position].test(msg)) {
+          found.push(+indexString)
+        }
+      } catch (e) {}
     }
     return found
   }


### PR DESCRIPTION
Mitigates the fatal error:
```
TypeError: patterns[position].test is not a function
    at findMatchingPatterns (D:\ZykoBotv2\node_modules\mineflayer\lib\plugins\chat.js:62:30)
    at EventEmitter.<anonymous> (D:\ZykoBotv2\node_modules\mineflayer\lib\plugins\chat.js:70:27)
    at EventEmitter.emit (events.js:315:20)
    at Client.<anonymous> (D:\ZykoBotv2\node_modules\mineflayer\lib\plugins\chat.js:122:9)
    at Client.emit (events.js:315:20)
    at FullPacketParser.<anonymous> (D:\ZykoBotv2\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (events.js:315:20)
    at addChunk (D:\ZykoBotv2\node_modules\readable-stream\lib\_stream_readable.js:298:12)
    at readableAddChunk (D:\ZykoBotv2\node_modules\readable-stream\lib\_stream_readable.js:280:11)
    at FullPacketParser.Readable.push (D:\ZykoBotv2\node_modules\readable-stream\lib\_stream_readable.js:241:10)
```