### PR TITLE
Add `mineflayer-autocrystal` to plugins list.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -184,7 +184,8 @@ The most updated and useful are :
  * [Collect Block](https://github.com/TheDudeFromCI/mineflayer-collectblock) - Quick and simple block collection API.
  * [Dashboard](https://github.com/wvffle/mineflayer-dashboard) - Frontend dashboard for mineflayer bot
  * [PVP](https://github.com/TheDudeFromCI/mineflayer-pvp) - Easy API for basic PVP and PVE.
- * [auto-eat](https://github.com/link-discord/mineflayer-auto-eat) - Automatic eating of food.
+ * [Auto Eat](https://github.com/link-discord/mineflayer-auto-eat) - Automatic eating of food.
+ * [Auto Crystal](https://github.com/link-discord/mineflayer-autocrystal) - Automatic placing & breaking of end crystals.
  * [Tool](https://github.com/TheDudeFromCI/mineflayer-tool) - A utility for automatic tool/weapon selection with a high level API.
  * [Hawkeye](https://github.com/sefirosweb/minecraftHawkEye) - A utility for using auto-aim with bows.
 


### PR DESCRIPTION
I would like to add my `mineflayer-autocrystal` plugin to the list of existing mineflayer plugins.
I also renamed the hyperlink text to match the others.