### PR TITLE
Change entity.vehicle implementation

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -333,19 +333,6 @@ function inject (bot, { version }) {
     if (eventName) bot.emit(eventName, entity)
   })
 
-  bot._client.on('attach_entity', (packet) => {
-    // attach entity
-    const entity = fetchEntity(packet.entityId)
-    if (packet.vehicleId === -1) {
-      const vehicle = entity.vehicle
-      delete entity.vehicle
-      bot.emit('entityDetach', entity, vehicle)
-    } else {
-      entity.vehicle = fetchEntity(packet.vehicleId)
-      bot.emit('entityAttach', entity, entity.vehicle)
-    }
-  })
-
   bot._client.on('entity_metadata', (packet) => {
     // entity metadata
     const entity = fetchEntity(packet.entityId)
@@ -499,28 +486,91 @@ function inject (bot, { version }) {
     }
   })
 
+  // <= 1.8 support
+  bot._client.on('attach_entity', (packet) => {
+    // attach entity
+    if (!packet.leash) { // Makes sure entity is mounting other entity
+      const entityId = packet.entityId // Passenger
+      const vehicleId = packet.vehicleId // Vehicle, set to -1 if dismounting
+
+      const passenger = bot.entities[entityId] // Passenger entity
+
+      if (vehicleId === -1) { // Entity Dismount
+        const vehicle = passenger.vehicle
+        if (passenger.vehicle) {
+          passenger.vehicle.passenger = null
+        }
+        passenger.vehicle = null
+        bot.emit('entityDetach', passenger, vehicle)
+      } else {
+        const vehicle = bot.entities[vehicleId]
+
+        if (passenger.vehicle) {
+          passenger.vehicle.passenger = null
+        }
+        if (vehicle.passenger) {
+          vehicle.passenger.vehicle = null
+        }
+
+        passenger.vehicle = vehicle
+        vehicle.passenger = passenger
+
+        bot.emit('entityAttach', passenger, passenger.vehicle)
+      }
+    }
+  })
+
+  // 1.9+ support
+  bot._client.on('set_passengers', ({ entityId, passengers }) => {
+    // boat can have multiple passengers, ignoring for now
+    const vehicle = bot.entities[entityId]
+    if (passengers.length === 0) {
+      const passenger = vehicle.passenger
+      if (vehicle.passenger) {
+        vehicle.passenger.vehicle = null
+      }
+      vehicle.passenger = null
+      bot.emit('entityDetach', passenger, vehicle)
+    } else {
+      const passenger = bot.entities[passengers[0]]
+
+      if (passenger.vehicle) { // duplicate code, oh well /shrug - don't really want to create a new func
+        passenger.vehicle.passenger = null
+      }
+      if (vehicle.passenger) {
+        vehicle.passenger.vehicle = null
+      }
+
+      passenger.vehicle = vehicle
+      vehicle.passenger = passenger
+      bot.emit('entityAttach', passenger, passenger.vehicle)
+    }
+  })
+
   // attaching to a vehicle
   bot._client.on('attach_entity', (packet) => {
-    if (packet.entityId !== bot.entity.id) return
-    const vehicle = bot.vehicle
-    if (packet.vehicleId === -1) {
-      bot.vehicle = null
-      bot.emit('dismount', vehicle)
-    } else {
-      bot.vehicle = bot.entities[packet.vehicleId]
-      bot.emit('mount')
+    if (packet.entityId === bot.entity.id) {
+      const vehicle = bot.vehicle
+      if (packet.vehicleId === -1) {
+        bot.vehicle = null
+        bot.emit('dismount', vehicle)
+      } else {
+        bot.vehicle = bot.entities[packet.vehicleId]
+        bot.emit('mount')
+      }
     }
   })
 
   bot._client.on('set_passengers', ({ entityId, passengers }) => {
-    if (passengers[0] !== bot.entity.id) return
-    const vehicle = bot.vehicle
-    if (entityId === -1) {
-      bot.vehicle = null
-      bot.emit('dismount', vehicle)
-    } else {
-      bot.vehicle = bot.entities[entityId]
-      bot.emit('mount')
+    if (passengers[0] === bot.entity.id) {
+      const vehicle = bot.vehicle
+      if (entityId === -1) {
+        bot.vehicle = null
+        bot.emit('dismount', vehicle)
+      } else {
+        bot.vehicle = bot.entities[entityId]
+        bot.emit('mount')
+      }
     }
   })
 


### PR DESCRIPTION
`entity.vehicle` was only set when receiving the `set_passengers` packet, which only is sent in versions 1.9+, so an extra listener was added to the `attach_entity` packet

`entity.vehicle` was deleted after entity dismounts. Instead, I set it to null

`entity.passenger` was added to circumvent the need to iterate through all the loaded entities to find the passenger of an entity.
