### PR TITLE
added rejection of invalid transaction packets (anticheat fix)

### DIFF
--- a/lib/features.json
+++ b/lib/features.json
@@ -318,5 +318,10 @@
     "name": "setSlotAsTransaction",
     "description": "use setslot as transaction instead of just hoping it'll work",
     "versions": ["1.17", "1.17.1"]
+  },
+  {
+    "name": "pingPacket",
+    "description": "ping instead of transaction in 1.17",
+    "versions": ["1.17", "1.17.1"]
   }
 ]

--- a/lib/features.json
+++ b/lib/features.json
@@ -318,10 +318,5 @@
     "name": "setSlotAsTransaction",
     "description": "use setslot as transaction instead of just hoping it'll work",
     "versions": ["1.17", "1.17.1"]
-  },
-  {
-    "name": "pingPacket",
-    "description": "ping instead of transaction in 1.17",
-    "versions": ["1.17", "1.17.1"]
   }
 ]

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -90,4 +90,12 @@ function inject (bot, options) {
   bot._client.on(brandChannel, (serverBrand) => {
     bot.game.serverBrand = serverBrand
   })
+  
+  if (bot.supportFeature('pingPacket') {
+    bot._client.on('ping', (packet) => {
+      bot._client.write('pong', {
+        id: packet.id
+      })
+    })    
+  }
 }

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -91,11 +91,9 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
 
-  if (bot.supportFeature('pingPacket')) {
-    bot._client.on('ping', (data) => {
-      bot._client.write('pong', {
-        id: data.id
-      })
+  bot._client.on('ping', (data) => {
+    bot._client.write('pong', {
+      id: data.id
     })
-  }
+  })
 }

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -90,11 +90,7 @@ function inject (bot, options) {
   bot._client.on(brandChannel, (serverBrand) => {
     bot.game.serverBrand = serverBrand
   })
-  bot._client.on('ping', (data) => {
-    bot._client.write('pong', {
-      id: data.id
-    })
-  })
+
   if (bot.supportFeature('pingPacket')) {
     bot._client.on('ping', (data) => {
       bot._client.write('pong', {

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -91,7 +91,7 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
   
-  if (bot.supportFeature('pingPacket') {
+  if (bot.supportFeature('pingPacket')) {
     bot._client.on('ping', (packet) => {
       bot._client.write('pong', {
         id: packet.id

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -90,12 +90,16 @@ function inject (bot, options) {
   bot._client.on(brandChannel, (serverBrand) => {
     bot.game.serverBrand = serverBrand
   })
-  
+  bot._client.on('ping', (data) => {
+    bot._client.write('pong', {
+      id: data.id
+    })
+  })
   if (bot.supportFeature('pingPacket')) {
-    bot._client.on('ping', (packet) => {
+    bot._client.on('ping', (data) => {
       bot._client.write('pong', {
-        id: packet.id
+        id: data.id
       })
-    })    
+    })
   }
 }

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -91,6 +91,7 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
 
+  // mimic the vanilla 1.17 client to prevent anticheat kicks
   bot._client.on('ping', (data) => {
     bot._client.write('pong', {
       id: data.id

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -435,6 +435,7 @@ function inject (bot, { version, hideErrors }) {
         windowId: windowId,
         action: actionId,
         accepted: true
+        // bot.emit(`confirmTransaction${click.id}`, false)
       })
       if (!hideErrors) {
         console.log(`WARNING : unknown transaction confirmation for window ${windowId}, action ${actionId} and accepted ${accepted}`)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -431,7 +431,11 @@ function inject (bot, { version, hideErrors }) {
     let click = windowClickQueue[0]
     if (click === undefined || !windowClickQueue.some(clicks => clicks.id === actionId)) {
       // mimic vanilla client and send a rejection for faulty transaction packets
-      onRejectedError()
+      bot._client.write('transaction', {
+        windowId: windowId,
+        action: actionId,
+        accepted: true
+      })
       if (!hideErrors) {
         console.log(`WARNING : unknown transaction confirmation for window ${windowId}, action ${actionId} and accepted ${accepted}`)
       }
@@ -468,15 +472,6 @@ function inject (bot, { version, hideErrors }) {
         accepted: true
       })
       bot.emit(`confirmTransaction${click.id}`, false)
-    }
-
-    function onRejectedError () {
-      bot._client.write('transaction', {
-        windowId: windowId,
-        action: actionId,
-        accepted: true
-      })
-      // bot.emit(`confirmTransaction${click.id}`, false)
     }
   }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -427,14 +427,18 @@ function inject (bot, { version, hideErrors }) {
   function confirmTransaction (windowId, actionId, accepted) {
     // drop the queue entries for all the clicks that the server did not send
     // transaction packets for.
-    let click = windowClickQueue.shift()
-    if (click === undefined) {
+    let click = windowClickQueue[0]
+    if (click === undefined || actionId !== click?.id) {
+      // mimic vanilla client and send a rejection for faulty transaction packets
       onRejectedError()
       if (!hideErrors) {
         console.log(`WARNING : unknown transaction confirmation for window ${windowId}, action ${actionId} and accepted ${accepted}`)
       }
       return
     }
+    // shift it later if packets are sent out of order
+    click = windowClickQueue.shift()
+    
     assert.ok(click.id <= actionId)
     while (actionId > click.id) {
       onAccepted()

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -429,6 +429,7 @@ function inject (bot, { version, hideErrors }) {
     // transaction packets for.
     let click = windowClickQueue.shift()
     if (click === undefined) {
+      onRejectedError()
       if (!hideErrors) {
         console.log(`WARNING : unknown transaction confirmation for window ${windowId}, action ${actionId} and accepted ${accepted}`)
       }
@@ -462,6 +463,15 @@ function inject (bot, { version, hideErrors }) {
         accepted: true
       })
       bot.emit(`confirmTransaction${click.id}`, false)
+    }
+
+    function onRejectedError () {
+      bot._client.write('transaction', {
+        windowId: windowId,
+        action: actionId,
+        accepted: true
+      })
+      // bot.emit(`confirmTransaction${click.id}`, false)
     }
   }
 
@@ -564,9 +574,6 @@ function inject (bot, { version, hideErrors }) {
 
   bot._client.on('transaction', (packet) => {
     // confirm transaction
-    if (packet.action < 0) {
-      return
-    }
     confirmTransaction(packet.windowId, packet.action, packet.accepted)
   })
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -427,8 +427,9 @@ function inject (bot, { version, hideErrors }) {
   function confirmTransaction (windowId, actionId, accepted) {
     // drop the queue entries for all the clicks that the server did not send
     // transaction packets for.
+    // Also reject transactions that aren't sent from mineflayer
     let click = windowClickQueue[0]
-    if (click === undefined || actionId !== click?.id) {
+    if (click === undefined || !windowClickQueue.some(clicks => clicks.id === actionId)) {
       // mimic vanilla client and send a rejection for faulty transaction packets
       onRejectedError()
       if (!hideErrors) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -438,7 +438,7 @@ function inject (bot, { version, hideErrors }) {
     }
     // shift it later if packets are sent out of order
     click = windowClickQueue.shift()
-    
+
     assert.ok(click.id <= actionId)
     while (actionId > click.id) {
       onAccepted()

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -216,6 +216,28 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
     })
+    describe('game', () => {
+      it('responds to ping / transaction packets', (done) => { // only on 1.17
+        server.on('login', async (client) => {
+          if (bot.supportFeature('transactionPacketExists')) {
+            const transactionPacket = { windowId: 0, action: 42, accepted: false }
+            client.once('transaction', (data, meta) => {
+              assert.ok(meta.name === 'transaction')
+              assert.ok(data.action === 42)
+              assert.ok(data.accepted === true)
+              done()
+            })
+            client.write('transaction', transactionPacket)
+          } else {
+            client.once('pong', (data) => {
+              assert(data.id === 42)
+              done()
+            })
+            client.write('ping', { id: 42 })
+          }
+        })
+      })
+    })
     describe('entities', () => {
       it('player displayName', (done) => {
         server.on('login', (client) => {


### PR DESCRIPTION
For servers with anticheats that send actionIds like
```{ windowId: 0, action: 16707, accepted: false }```
or
```{ windowId: 0, action: -7967, accepted: false }```

Fixes https://github.com/PrismarineJS/mineflayer/issues/2189