### PR TITLE
Fix removing many players at once from tab list

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -483,15 +483,15 @@ function inject (bot, { version }) {
         } else if (packet.action === 3 && item.displayName) {
           player.displayName = new ChatMessage(JSON.parse(item.displayName))
         } else if (packet.action === 4) {
-          if (player.entity === bot.entity) return
+          if (player.entity === bot.entity) continue
 
           player.entity = null
           delete bot.players[player.username]
           delete bot.uuidToUsername[item.UUID]
           bot.emit('playerLeft', player)
-          return
+          continue
         } else {
-          return
+          continue
         }
 
         bot.emit('playerUpdated', player)


### PR DESCRIPTION
When a server sends a packet to remove players, Mineflayer only removes the first player, causing bot.players to be wrong. This can be seen for example when you join a Hypixel duels game and check bot.players, almost all the players from the lobby you were in are still in tab when they shouldn't be.