### PR TITLE
Console spam fix

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -534,7 +534,11 @@ function inject (bot, { version, hideErrors }) {
       }
       const [success] = await response
       if (!success) {
-        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots, null, 2)}.`)
+        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => {
+          return !!s
+        }).map(s => {
+          return s.map(e => typeof e === 'object' ? {} : e)
+        }), null, 2)}.`)
       }
     } else {
       await waitForWindowUpdate(window, slot)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -534,9 +534,7 @@ function inject (bot, { version, hideErrors }) {
       }
       const [success] = await response
       if (!success) {
-        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => !!s).map(s => {
-          return s.nbt ? { ...s, nbt: '[truncated]' } : s
-        }), null, 2)}.`)
+        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window with id ${window?.id}.`)
       }
     } else {
       await waitForWindowUpdate(window, slot)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -534,10 +534,8 @@ function inject (bot, { version, hideErrors }) {
       }
       const [success] = await response
       if (!success) {
-        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => {
-          return !!s
-        }).map(s => {
-          return s.map(e => typeof e === 'object' ? '[truncated]' : e)
+        throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => !!s).map(s => {
+          return s.nbt ? {...s, nbt: '[truncated]'} : s 
         }), null, 2)}.`)
       }
     } else {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -535,7 +535,7 @@ function inject (bot, { version, hideErrors }) {
       const [success] = await response
       if (!success) {
         throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => !!s).map(s => {
-          return s.nbt ? {...s, nbt: '[truncated]'} : s 
+          return s.nbt ? { ...s, nbt: '[truncated]' } : s
         }), null, 2)}.`)
       }
     } else {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -537,7 +537,7 @@ function inject (bot, { version, hideErrors }) {
         throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window ${JSON.stringify(window.slots.filter(s => {
           return !!s
         }).map(s => {
-          return s.map(e => typeof e === 'object' ? {} : e)
+          return s.map(e => typeof e === 'object' ? '[truncated]' : e)
         }), null, 2)}.`)
       }
     } else {


### PR DESCRIPTION
When mineflayer tries to move items in its inventory the server sometimes rejects the inventory clicks. 
Mineflayer then json stringifys the entire inventory content including item meta and nbt data. This can result in mineflayer printing out more then 5000 lines of json if the inventory is really full.