### PR TITLE
Fix bot not swinging arm on block place

### DIFF
--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -7,7 +7,7 @@ function inject (bot, { version }) {
    *
    * @param {import('prismarine-block').Block} referenceBlock
    * @param {import('vec3').Vec3} faceVector
-   * @param {{half?: 'top'|'bottom', delta?: import('vec3').Vec3, forceLook?: boolean | 'ignore', offhand?: boolean}} options
+   * @param {{half?: 'top'|'bottom', delta?: import('vec3').Vec3, forceLook?: boolean | 'ignore', offhand?: boolean, swingArm?: 'right' | 'left', showHand?: boolean}} options
    */
   async function _genericPlace (referenceBlock, faceVector, options) {
     let handToPlaceWith = 0
@@ -38,6 +38,10 @@ function inject (bot, { version }) {
     }
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
+
+    if (options.swingArm) {
+      bot.swingArm(options.swingArm, options.showHand)
+    }
 
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -6,6 +6,7 @@ function inject (bot) {
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
     let oldBlock = bot.blockAt(dest)
+    bot.swingArm()
     await bot._genericPlace(referenceBlock, faceVector, options)
 
     let newBlock = bot.blockAt(dest)

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -6,8 +6,8 @@ function inject (bot) {
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
     let oldBlock = bot.blockAt(dest)
-    bot.swingArm()
     await bot._genericPlace(referenceBlock, faceVector, options)
+    bot.swingArm()
 
     let newBlock = bot.blockAt(dest)
     if (oldBlock.type === newBlock.type) {

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -7,7 +7,6 @@ function inject (bot) {
     const dest = referenceBlock.position.plus(faceVector)
     let oldBlock = bot.blockAt(dest)
     await bot._genericPlace(referenceBlock, faceVector, options)
-    bot.swingArm()
 
     let newBlock = bot.blockAt(dest)
     if (oldBlock.type === newBlock.type) {
@@ -22,7 +21,7 @@ function inject (bot) {
   }
 
   async function placeBlock (referenceBlock, faceVector) {
-    await placeBlockWithOptions(referenceBlock, faceVector, {})
+    await placeBlockWithOptions(referenceBlock, faceVector, { swingArm: 'right' })
   }
 
   bot.placeBlock = callbackify(placeBlock)

--- a/lib/plugins/place_entity.js
+++ b/lib/plugins/place_entity.js
@@ -5,6 +5,12 @@ module.exports = inject
 function inject (bot, { version }) {
   const Item = require('prismarine-item')(version)
 
+  /**
+   *
+   * @param {import('prismarine-block').Block} referenceBlock
+   * @param {import('vec3').Vec3} faceVector
+   * @param {{forceLook?: boolean | 'ignore', offhand?: boolean, swingArm?: 'right' | 'left', showHand?: boolean}} options
+   */
   async function placeEntityWithOptions (referenceBlock, faceVector, options) {
     if (!bot.heldItem) throw new Error('must be holding an item to place an entity')
 
@@ -20,13 +26,13 @@ function inject (bot, { version }) {
       name = bot.heldItem.spawnEggMobName
     }
 
-    const pos = await bot._genericPlace(referenceBlock, faceVector, options)
-
     if (type === 'spawn_egg') {
-      bot.swingArm(undefined, false)
-    } else {
-      bot.swingArm()
+      options.showHand = false
     }
+
+    if (!options.swingArm) options.swingArm = options.offhand ? 'left' : 'right'
+
+    const pos = await bot._genericPlace(referenceBlock, faceVector, options)
 
     if (type === 'boat') {
       if (bot.supportFeature('useItemWithOwnPacket')) {


### PR DESCRIPTION
placeEntity has its own armSwing call so placeBlock has to have its own arm swing function call too. The only issue is that I am pretty sure that arm swing animation packets are send before block placement packets. Some servers reject block placement if arm swing animations are not send. It seams like with my testing that the server should not be able to tell the difference between arm swing packets being send before or after block placement packets. But this may cause issues as it should be easily detectable by servers. A real fix should be giving _genericPlace an extra option to specify what arm to swing if block placement should be valid just before sending block placement packets. 