### PR TITLE
increase position packet accuracy

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -121,18 +121,16 @@ function inject (bot, { physicsEnabled }) {
     bot.emit('move', oldPos)
   }
 
-  function lastSentPosition (position, onGround, now) {
+  function lastSentPosition (position, now) {
     lastSent.x = position.x
     lastSent.y = position.y
     lastSent.z = position.z
-    lastSent.onGround = onGround
     lastSent.time = now
   }
 
-  function lastSentLook (yaw, pitch, onGround) {
+  function lastSentLook (yaw, pitch) {
     lastSent.yaw = yaw
     lastSent.pitch = pitch
-    lastSent.onGround = onGround
   }
 
   function deltaYaw (yaw1, yaw2) {
@@ -146,7 +144,7 @@ function inject (bot, { physicsEnabled }) {
   function updatePosition (now) {
     // If you're dead, you're probably on the ground though ...
     // You can be dead in the air however
-    if (!isAlive) bot.entity.onGround = true
+    // if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
     const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)
@@ -174,16 +172,16 @@ function inject (bot, { physicsEnabled }) {
       sendPacketPosition(position, onGround)
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (bot.supportFeature('positionUpdateSentEveryTick')) {
+    } else if (bot.supportFeature('positionUpdateSentEveryTick') || onGround !== lastSent.onGround) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
       // For versions >= 1.12, onGround !== lastSent.onGround should be used, but it doesn't ever trigger outside of login
       bot._client.write('flying', { onGround: bot.entity.onGround })
-      lastSent.onGround = bot.entity.onGround // this could be outside the if loop
     }
     // mimic vanilla client by setting lastSent after sending
-    if (positionUpdated) lastSentPosition(position, onGround, now)
-    if (lookUpdated) lastSentLook(yaw, pitch, onGround)
+    if (positionUpdated) lastSentPosition(position, now)
+    if (lookUpdated) lastSentLook(yaw, pitch)
+    lastSent.onGround = bot.entity.onGround
   }
 
   bot.physics = physics
@@ -287,15 +285,20 @@ function inject (bot, { physicsEnabled }) {
   bot._client.on('position', (packet) => {
     const now = performance.now()
     bot.entity.height = 1.62
-    bot.entity.velocity.set(0, 0, 0)
 
     // If flag is set, then the corresponding value is relative, else it is absolute
+    // Velocity is only set to 0 if the packet is absolute, otherwise keep current velocity
+    const vel = bot.entity.velocity
     const pos = bot.entity.position
-
     pos.set(
       packet.flags & 1 ? (pos.x + packet.x) : packet.x,
       packet.flags & 2 ? (pos.y + packet.y) : packet.y,
       packet.flags & 4 ? (pos.z + packet.z) : packet.z
+    )
+    vel.set(
+      packet.flags & 1 ? vel.x : 0,
+      packet.flags & 2 ? vel.y : 0,
+      packet.flags & 4 ? vel.z : 0
     )
 
     const newYaw = (packet.flags & 8 ? conv.toNotchianYaw(bot.entity.yaw) : 0) + packet.yaw
@@ -308,18 +311,14 @@ function inject (bot, { physicsEnabled }) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })
     }
     sendPacketPositionAndLook(pos, newYaw, newPitch, false) // this doesn't reset position timer or adjust lastSent values
-    // lastSentPosition(pos, bot.entity.onGround, now)
-    // lastSentLook(newYaw, newPitch, bot.entity.onGround)
 
-    isAlive = true // if a position packet was sent, you are alive wow
+    isAlive = true // if a position packet was sent, you are alive
     shouldUsePhysics = true
     bot.entity.timeSinceOnGround = 0
     lastSentYaw = bot.entity.yaw
 
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = now
-      // Force send an extra packet to be like vanilla client
-      // Vanilla client only sends this once on physics engine startup
       doPhysics()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -84,7 +84,7 @@ function inject (bot, { physicsEnabled }) {
     lastSent.z = position.z
     lastSent.onGround = onGround
     bot._client.write('position', lastSent)
-    lastSent.time = now
+    lastSent.time = now // Reset position timer
     bot.emit('move', oldPos)
   }
 
@@ -108,7 +108,7 @@ function inject (bot, { physicsEnabled }) {
     lastSent.pitch = pitch
     lastSent.onGround = onGround
     bot._client.write('position_look', lastSent)
-    lastSent.time = now
+    lastSent.time = now // Reset position timer
     bot.emit('move', oldPos)
   }
 
@@ -119,9 +119,13 @@ function inject (bot, { physicsEnabled }) {
 
     return dYaw
   }
-
+  let ticksDead = 0
   function updatePosition (now) {
+    // Reset counter if you are alive
+    if (bot.isAlive === true) ticksDead = 0
+
     // If you're dead, you're probably on the ground though ...
+    // You can be dead in the air however
     if (!bot.isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
@@ -140,17 +144,20 @@ function inject (bot, { physicsEnabled }) {
     const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
+    if (bot.isAlive === false) ticksDead++ // vanilla sends physics for 20 ticks after dying
+    if (ticksDead <= 20) return // return when threshold reached
+
     if (positionUpdated && lookUpdated) {
       sendPacketPositionAndLook(position, yaw, pitch, onGround, now)
     } else if (positionUpdated) {
       sendPacketPosition(position, onGround, now)
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (now - lastSent.time >= 998 && bot.isAlive) {
-      // account for jitter from doPhysics() and other calculations (sometimes it is 999.999 or 998.999)
+    } else if (now - lastSent.time >= 998) {
+      // Account for jitter from doPhysics() and other calculations (sometimes it is 999.999 or 998.999)
       // Send a position packet every second, even if no update was made
       sendPacketPosition(position, onGround, now)
-    } else if (bot.supportFeature('positionUpdateSentEveryTick') && bot.isAlive) {
+    } else if (bot.supportFeature('positionUpdateSentEveryTick')) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
       bot._client.write('flying', { onGround: bot.entity.onGround })

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -50,6 +50,8 @@ function inject (bot, { physicsEnabled }) {
 
   // This function should be executed each tick (every 0.05 seconds)
   // How it works: https://gafferongames.com/post/fix_your_timestep/
+  // WARNING: THIS IS NOT ACCURATE ON WINDOWS
+  // use WSL or switch to the superior OS
   let timeAccumulator = 0
   function doPhysics () {
     const now = performance.now()
@@ -64,7 +66,7 @@ function inject (bot, { physicsEnabled }) {
         bot.emit('physicsTick')
         bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
       }
-      updatePosition(PHYSICS_TIMESTEP)
+      updatePosition(now)
       timeAccumulator -= PHYSICS_TIMESTEP
     }
   }
@@ -74,7 +76,7 @@ function inject (bot, { physicsEnabled }) {
     doPhysicsTimer = null
   }
 
-  function sendPacketPosition (position, onGround) {
+  function sendPacketPosition (position, onGround, now) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.x = position.x
@@ -82,6 +84,7 @@ function inject (bot, { physicsEnabled }) {
     lastSent.z = position.z
     lastSent.onGround = onGround
     bot._client.write('position', lastSent)
+    lastSent.time = now
     bot.emit('move', oldPos)
   }
 
@@ -95,7 +98,7 @@ function inject (bot, { physicsEnabled }) {
     bot.emit('move', oldPos)
   }
 
-  function sendPacketPositionAndLook (position, yaw, pitch, onGround) {
+  function sendPacketPositionAndLook (position, yaw, pitch, onGround, now) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.x = position.x
@@ -105,6 +108,7 @@ function inject (bot, { physicsEnabled }) {
     lastSent.pitch = pitch
     lastSent.onGround = onGround
     bot._client.write('position_look', lastSent)
+    lastSent.time = now
     bot.emit('move', oldPos)
   }
 
@@ -116,7 +120,7 @@ function inject (bot, { physicsEnabled }) {
     return dYaw
   }
 
-  function updatePosition (dt) {
+  function updatePosition (now) {
     // If you're dead, you're probably on the ground though ...
     if (!bot.isAlive) bot.entity.onGround = true
 
@@ -124,7 +128,7 @@ function inject (bot, { physicsEnabled }) {
     const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
-    const maxDeltaYaw = dt * physics.yawSpeed
+    const maxDeltaYaw = PHYSICS_TIMESTEP * physics.yawSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
 
     const yaw = Math.fround(conv.toNotchianYaw(lastSentYaw))
@@ -136,16 +140,16 @@ function inject (bot, { physicsEnabled }) {
     const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
-    if (positionUpdated && lookUpdated && bot.isAlive) {
-      sendPacketPositionAndLook(position, yaw, pitch, onGround)
-    } else if (positionUpdated && bot.isAlive) {
-      sendPacketPosition(position, onGround)
-    } else if (lookUpdated && bot.isAlive) {
+    if (positionUpdated && lookUpdated) {
+      sendPacketPositionAndLook(position, yaw, pitch, onGround, now)
+    } else if (positionUpdated) {
+      sendPacketPosition(position, onGround, now)
+    } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (performance.now() - lastSent.time >= 1000) {
+    } else if (now - lastSent.time >= 998 && bot.isAlive) {
+      // account for jitter from doPhysics() and other calculations (sometimes it is 999.999 or 998.999)
       // Send a position packet every second, even if no update was made
-      sendPacketPosition(position, onGround)
-      lastSent.time = performance.now()
+      sendPacketPosition(position, onGround, now)
     } else if (bot.supportFeature('positionUpdateSentEveryTick') && bot.isAlive) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
@@ -252,9 +256,9 @@ function inject (bot, { physicsEnabled }) {
 
   // player position and look (clientbound)
   bot._client.on('position', (packet) => {
+    const now = performance.now()
     bot.entity.height = 1.62
     bot.entity.velocity.set(0, 0, 0)
-
     // If flag is set, then the corresponding value is relative, else it is absolute
     const pos = bot.entity.position
     pos.set(
@@ -272,17 +276,17 @@ function inject (bot, { physicsEnabled }) {
     if (bot.supportFeature('teleportUsesOwnPacket')) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })
       // Force send an extra packet to be like vanilla client
-      sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
+      sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround, now)
     }
-    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
+    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround, now)
 
     shouldUsePhysics = true
     bot.entity.timeSinceOnGround = 0
     lastSentYaw = bot.entity.yaw
 
     if (doPhysicsTimer === null) {
-      lastPhysicsFrameTime = performance.now()
-      doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
+      lastPhysicsFrameTime = now
+      doPhysicsTimer = setInterval(doPhysics, 50)
     }
     bot.emit('forcedMove')
   })
@@ -304,5 +308,6 @@ function inject (bot, { physicsEnabled }) {
 
   bot.on('mount', () => { shouldUsePhysics = false })
   bot.on('respawn', () => { shouldUsePhysics = false })
+  bot.on('login', () => { shouldUsePhysics = false })
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -52,6 +52,7 @@ function inject (bot, { physicsEnabled }) {
   // How it works: https://gafferongames.com/post/fix_your_timestep/
   // WARNING: THIS IS NOT ACCURATE ON WINDOWS
   // use WSL or switch to the superior OS
+  // see: https://discord.com/channels/413438066984747026/519952494768685086/901948718255833158
   let timeAccumulator = 0
   function doPhysics () {
     const now = performance.now()
@@ -153,8 +154,9 @@ function inject (bot, { physicsEnabled }) {
       sendPacketPosition(position, onGround, now)
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (now - lastSent.time >= 998) {
+    } else if (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS >= 1000) {
       // Account for jitter from doPhysics() and other calculations (sometimes it is 999.999 or 998.999)
+      // This rounds the value of (now - lastSent.time) to the nearest 50
       // Send a position packet every second, even if no update was made
       sendPacketPosition(position, onGround, now)
     } else if (bot.supportFeature('positionUpdateSentEveryTick')) {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -44,7 +44,8 @@ function inject (bot, { physicsEnabled }) {
     z: 0,
     yaw: 0,
     pitch: 0,
-    onGround: false
+    onGround: false,
+    time: 0
   }
 
   let ticksDead = 0
@@ -173,9 +174,10 @@ function inject (bot, { physicsEnabled }) {
       sendPacketPosition(position, onGround)
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (bot.supportFeature('positionUpdateSentEveryTick') || onGround !== lastSent.onGround) {
+    } else if (bot.supportFeature('positionUpdateSentEveryTick')) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
+      // For versions >= 1.12, onGround !== lastSent.onGround should be used, but it doesn't ever trigger outside of login
       bot._client.write('flying', { onGround: bot.entity.onGround })
       lastSent.onGround = bot.entity.onGround // this could be outside the if loop
     }
@@ -286,8 +288,10 @@ function inject (bot, { physicsEnabled }) {
     const now = performance.now()
     bot.entity.height = 1.62
     bot.entity.velocity.set(0, 0, 0)
+
     // If flag is set, then the corresponding value is relative, else it is absolute
     const pos = bot.entity.position
+
     pos.set(
       packet.flags & 1 ? (pos.x + packet.x) : packet.x,
       packet.flags & 2 ? (pos.y + packet.y) : packet.y,
@@ -298,12 +302,12 @@ function inject (bot, { physicsEnabled }) {
     const newPitch = (packet.flags & 16 ? conv.toNotchianPitch(bot.entity.pitch) : 0) + packet.pitch
     bot.entity.yaw = conv.fromNotchianYaw(newYaw)
     bot.entity.pitch = conv.fromNotchianPitch(newPitch)
-    bot.entity.onGround = false
+    // bot.entity.onGround = false
 
     if (bot.supportFeature('teleportUsesOwnPacket')) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })
     }
-    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround) // this doesn't reset position timer or adjust lastSent values
+    sendPacketPositionAndLook(pos, newYaw, newPitch, false) // this doesn't reset position timer or adjust lastSent values
     // lastSentPosition(pos, bot.entity.onGround, now)
     // lastSentLook(newYaw, newPitch, bot.entity.onGround)
 
@@ -316,7 +320,7 @@ function inject (bot, { physicsEnabled }) {
       lastPhysicsFrameTime = now
       // Force send an extra packet to be like vanilla client
       // Vanilla client only sends this once on physics engine startup
-      tick(lastPhysicsFrameTime)
+      doPhysics()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
     bot.emit('forcedMove')

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -315,6 +315,6 @@ function inject (bot, { physicsEnabled }) {
 
   bot.on('mount', () => { shouldUsePhysics = false })
   bot.on('respawn', () => { shouldUsePhysics = false })
-  bot.on('login', () => { shouldUsePhysics = false })
+  // bot.on('login', () => { shouldUsePhysics = false })
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -293,7 +293,7 @@ function inject (bot, { physicsEnabled }) {
 
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = now
-      doPhysicsTimer = setInterval(doPhysics, 50)
+      doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
     bot.emit('forcedMove')
   })

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -145,7 +145,7 @@ function inject (bot, { physicsEnabled }) {
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
     if (bot.isAlive === false) ticksDead++ // vanilla sends physics for 20 ticks after dying
-    if (ticksDead <= 20) return // return when threshold reached
+    if (ticksDead >= 20) return // return when threshold reached
 
     if (positionUpdated && lookUpdated) {
       sendPacketPositionAndLook(position, yaw, pitch, onGround, now)
@@ -315,6 +315,6 @@ function inject (bot, { physicsEnabled }) {
 
   bot.on('mount', () => { shouldUsePhysics = false })
   bot.on('respawn', () => { shouldUsePhysics = false })
-  // bot.on('login', () => { shouldUsePhysics = false })
+  bot.on('login', () => { shouldUsePhysics = false })
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -48,6 +48,9 @@ function inject (bot, { physicsEnabled }) {
     time: 0
   }
 
+  let ticksDead = 0
+  let isAlive = false // this is used instead of bot.isAlive because only send the position packet
+
   // This function should be executed each tick (every 0.05 seconds)
   // How it works: https://gafferongames.com/post/fix_your_timestep/
   // WARNING: THIS IS NOT ACCURATE ON WINDOWS
@@ -62,14 +65,18 @@ function inject (bot, { physicsEnabled }) {
     timeAccumulator += deltaSeconds
 
     while (timeAccumulator >= PHYSICS_TIMESTEP) {
-      if (bot.physicsEnabled && shouldUsePhysics) {
-        physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
-        bot.emit('physicsTick')
-        bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
-      }
-      updatePosition(now)
+      tick(now)
       timeAccumulator -= PHYSICS_TIMESTEP
     }
+  }
+
+  function tick (now) {
+    if (bot.physicsEnabled && shouldUsePhysics) {
+      physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
+      bot.emit('physicsTick')
+      bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
+    }
+    updatePosition(now)
   }
 
   function cleanup () {
@@ -77,40 +84,55 @@ function inject (bot, { physicsEnabled }) {
     doPhysicsTimer = null
   }
 
-  function sendPacketPosition (position, onGround, now) {
+  function sendPacketPosition (position, onGround) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
-    lastSent.x = position.x
-    lastSent.y = position.y
-    lastSent.z = position.z
-    lastSent.onGround = onGround
-    bot._client.write('position', lastSent)
-    lastSent.time = now // Reset position timer
+    const packet = {}
+    packet.x = position.x
+    packet.y = position.y
+    packet.z = position.z
+    packet.onGround = onGround
+    bot._client.write('position', packet)
     bot.emit('move', oldPos)
   }
 
   function sendPacketLook (yaw, pitch, onGround) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
-    lastSent.yaw = yaw
-    lastSent.pitch = pitch
-    lastSent.onGround = onGround
-    bot._client.write('look', lastSent)
+    const packet = {}
+    packet.yaw = yaw
+    packet.pitch = pitch
+    packet.onGround = onGround
+    bot._client.write('look', packet)
     bot.emit('move', oldPos)
   }
 
-  function sendPacketPositionAndLook (position, yaw, pitch, onGround, now) {
+  function sendPacketPositionAndLook (position, yaw, pitch, onGround) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
+    const packet = {}
+    packet.x = position.x
+    packet.y = position.y
+    packet.z = position.z
+    packet.yaw = yaw
+    packet.pitch = pitch
+    packet.onGround = onGround
+    bot._client.write('position_look', packet)
+    bot.emit('move', oldPos)
+  }
+
+  function lastSentPosition (position, onGround, now) {
     lastSent.x = position.x
     lastSent.y = position.y
     lastSent.z = position.z
+    lastSent.onGround = onGround
+    lastSent.time = now
+  }
+
+  function lastSentLook (yaw, pitch, onGround) {
     lastSent.yaw = yaw
     lastSent.pitch = pitch
     lastSent.onGround = onGround
-    bot._client.write('position_look', lastSent)
-    lastSent.time = now // Reset position timer
-    bot.emit('move', oldPos)
   }
 
   function deltaYaw (yaw1, yaw2) {
@@ -120,14 +142,11 @@ function inject (bot, { physicsEnabled }) {
 
     return dYaw
   }
-  let ticksDead = 0
-  function updatePosition (now) {
-    // Reset counter if you are alive
-    if (bot.isAlive === true) ticksDead = 0
 
+  function updatePosition (now) {
     // If you're dead, you're probably on the ground though ...
     // You can be dead in the air however
-    if (!bot.isAlive) bot.entity.onGround = true
+    if (!isAlive) bot.entity.onGround = true
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
     const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)
@@ -142,28 +161,28 @@ function inject (bot, { physicsEnabled }) {
     const onGround = bot.entity.onGround
 
     // Only send a position update if necessary, select the appropriate packet
-    const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z
+    const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z || (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS) >= 1000
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
-    if (bot.isAlive === false) ticksDead++ // vanilla sends physics for 20 ticks after dying
+    if (isAlive === false) ticksDead++ // vanilla sends physics for 20 ticks after dying
+    if (isAlive === true) ticksDead = 0
     if (ticksDead >= 20) return // return when threshold reached
 
     if (positionUpdated && lookUpdated) {
-      sendPacketPositionAndLook(position, yaw, pitch, onGround, now)
+      sendPacketPositionAndLook(position, yaw, pitch, onGround)
     } else if (positionUpdated) {
-      sendPacketPosition(position, onGround, now)
+      sendPacketPosition(position, onGround)
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS >= 1000) {
-      // Account for jitter from doPhysics() and other calculations (sometimes it is 999.999 or 998.999)
-      // This rounds the value of (now - lastSent.time) to the nearest 50
-      // Send a position packet every second, even if no update was made
-      sendPacketPosition(position, onGround, now)
-    } else if (bot.supportFeature('positionUpdateSentEveryTick')) {
+    } else if (bot.supportFeature('positionUpdateSentEveryTick') || onGround !== lastSent.onGround) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
       bot._client.write('flying', { onGround: bot.entity.onGround })
+      lastSent.onGround = bot.entity.onGround // this could be outside the if loop
     }
+    // mimic vanilla client by setting lastSent after sending
+    if (positionUpdated) lastSentPosition(position, onGround, now)
+    if (lookUpdated) lastSentLook(yaw, pitch, onGround)
   }
 
   bot.physics = physics
@@ -284,17 +303,21 @@ function inject (bot, { physicsEnabled }) {
 
     if (bot.supportFeature('teleportUsesOwnPacket')) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })
-      // Force send an extra packet to be like vanilla client
-      sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround, now)
     }
-    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround, now)
+    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround) // this doesn't reset position timer or adjust lastSent values
+    // lastSentPosition(pos, bot.entity.onGround, now)
+    // lastSentLook(newYaw, newPitch, bot.entity.onGround)
 
+    isAlive = true // if a position packet was sent, you are alive wow
     shouldUsePhysics = true
     bot.entity.timeSinceOnGround = 0
     lastSentYaw = bot.entity.yaw
 
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = now
+      // Force send an extra packet to be like vanilla client
+      // Vanilla client only sends this once on physics engine startup
+      tick(lastPhysicsFrameTime)
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
     bot.emit('forcedMove')
@@ -316,7 +339,16 @@ function inject (bot, { physicsEnabled }) {
   }
 
   bot.on('mount', () => { shouldUsePhysics = false })
-  bot.on('respawn', () => { shouldUsePhysics = false })
-  bot.on('login', () => { shouldUsePhysics = false })
+  bot.on('respawn', () => {
+    shouldUsePhysics = false
+    isAlive = false
+  })
+  bot.on('login', () => {
+    shouldUsePhysics = false
+    isAlive = false
+  })
+  bot.on('death', () => {
+    isAlive = false
+  })
   bot.on('end', cleanup)
 }


### PR DESCRIPTION
1. Changed position packet time to be more accurate, as it uses the same time as the timer

2. lastSent.time resets whenever a position or position_look packet is sent (matches vanilla behavior)

3. vanilla sends position packets when "dead" but only for  it is moving / has velocity for a full second and then stops

4. on login, shouldUsePhysics is set to false until a position packet is received

5. Changed time (for sending a postion packet every second) from 1000 to 998, as in testing, position packets sent by the bot could be 50ms delayed if the number was 999.99 or 998.99


Probably fixes https://github.com/PrismarineJS/mineflayer/issues/1582
