### PR TITLE
SkinsRestorer fix

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -527,7 +527,8 @@ function inject (bot, { version, storageBuilder }) {
       dimension = packet.dimension
     } else {
       if (dimension === packet.dimension) return
-      if (worldName === packet.worldName) return // dimension data can be different in newer versions so check worldName
+      if (worldName === packet.worldName && packet.copyMetadata === true) return // don't unload chunks if in same world and metaData is true
+      // Metadata is true when switching dimensions however, then the world name is different
       dimension = packet.dimension
       worldName = packet.worldName
     }

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -522,10 +522,10 @@ function inject (bot, { version, storageBuilder }) {
   })
 
   bot._client.on('respawn', (packet) => {
-    if (bot.supportFeature('dimensionIsAnInt')) {
+    if (bot.supportFeature('dimensionIsAnInt')) { // <=1.15.2
       if (dimension === packet.dimension) return
       dimension = packet.dimension
-    } else {
+    } else { // >= 1.15.2
       if (dimension === packet.dimension) return
       if (worldName === packet.worldName && packet.copyMetadata === true) return // don't unload chunks if in same world and metaData is true
       // Metadata is true when switching dimensions however, then the world name is different

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -476,6 +476,7 @@ function inject (bot, { version, storageBuilder }) {
   // if we get a respawn packet and the dimension is changed,
   // unload all chunks from memory.
   let dimension
+  let worldName
   function dimensionToFolderName (dimension) {
     if (bot.supportFeature('dimensionIsAnInt')) {
       return dimensionNames[dimension]
@@ -512,12 +513,15 @@ function inject (bot, { version, storageBuilder }) {
 
   bot._client.on('login', (packet) => {
     dimension = packet.dimension
+    worldName = packet.worldName
     switchWorld()
   })
 
   bot._client.on('respawn', (packet) => {
     if (dimension === packet.dimension) return
+    if (worldName === packet.worldName) return // dimension data can be different in newer versions so check worldName
     dimension = packet.dimension
+    worldName = packet.worldData
     switchWorld()
   })
 

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -512,16 +512,25 @@ function inject (bot, { version, storageBuilder }) {
   }
 
   bot._client.on('login', (packet) => {
-    dimension = packet.dimension
-    worldName = packet.worldName
+    if (bot.supportFeature('dimensionIsAnInt')) {
+      dimension = packet.dimension
+    } else {
+      dimension = packet.dimension
+      worldName = packet.worldName
+    }
     switchWorld()
   })
 
   bot._client.on('respawn', (packet) => {
-    if (dimension === packet.dimension) return
-    if (worldName === packet.worldName) return // dimension data can be different in newer versions so check worldName
-    dimension = packet.dimension
-    worldName = packet.worldData
+    if (bot.supportFeature('dimensionIsAnInt')) {
+      if (dimension === packet.dimension) return
+      dimension = packet.dimension
+    } else {
+      if (dimension === packet.dimension) return
+      if (worldName === packet.worldName) return // dimension data can be different in newer versions so check worldName
+      dimension = packet.dimension
+      worldName = packet.worldName
+    }
     switchWorld()
   })
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -89,13 +89,20 @@ function inject (bot, { version }) {
     return best
   }
 
-  bot._client.once('login', (packet) => {
+  // Some servers use different entityIds between worlds
+  let previousBotId
+  bot._client.on('login', (packet) => {
     // login
     bot.entity = fetchEntity(packet.entityId)
+    if (previousBotId && previousBotId !== packet.entityId) {
+      // purge previous entity if packet.entityId !== bot_id
+      bot._client.emit('entity_destroy', { entityIds: [previousBotId] })
+    }
     bot.username = bot._client.username
     bot.entity.username = bot._client.username
     bot.entity.type = 'player'
     bot.entity.name = 'player'
+    previousBotId = packet.entityId
   })
 
   bot._client.on('entity_equipment', (packet) => {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -89,20 +89,17 @@ function inject (bot, { version }) {
     return best
   }
 
-  // Some servers use different entityIds between worlds
-  let previousBotId
+  // Reset list of players and entities on login
   bot._client.on('login', (packet) => {
+    bot.players = {}
+    bot.uuidToUsername = {}
+    bot.entities = {}
     // login
     bot.entity = fetchEntity(packet.entityId)
-    if (previousBotId && previousBotId !== packet.entityId) {
-      // purge previous entity if packet.entityId !== bot_id
-      bot._client.emit('entity_destroy', { entityIds: [previousBotId] })
-    }
     bot.username = bot._client.username
     bot.entity.username = bot._client.username
     bot.entity.type = 'player'
     bot.entity.name = 'player'
-    previousBotId = packet.entityId
   })
 
   bot._client.on('entity_equipment', (packet) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -217,6 +217,41 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
     describe('entities', () => {
+      it('entity id changes on login', (done) => {
+        let loginPacket
+        server.on('login', (client) => {
+          if (bot.supportFeature('usesLoginPacket')) {
+            loginPacket = mcData.loginPacket
+          } else {
+            loginPacket = {
+              entityId: 0,
+              levelType: 'fogetaboutit',
+              gameMode: 0,
+              previousGameMode: 255,
+              worldNames: ['minecraft:overworld'],
+              dimension: 0,
+              worldName: 'minecraft:overworld',
+              hashedSeed: [0, 0],
+              difficulty: 0,
+              maxPlayers: 20,
+              reducedDebugInfo: 1,
+              enableRespawnScreen: true
+            }
+          }
+          loginPacket.entityId = 0 // Default login packet in minecraft-data 1.16.5 is 1, so set it to 0
+          client.write('login', loginPacket)
+          bot.once('login', () => {
+            assert.ok(bot.entity.id === 0)
+            loginPacket.entityId = 42
+            bot.once('login', () => {
+              assert.ok(bot.entity.id === 42)
+              done()
+            })
+            client.write('login', loginPacket)
+          })
+        })
+      })
+
       it('player displayName', (done) => {
         server.on('login', (client) => {
           bot.on('entitySpawn', (entity) => {


### PR DESCRIPTION
1. respawn packet checks worldName instead of dimension int on versions above 1.15.2

2. fix when entity id changes between seperate bungeecord servers with SkinRestorer (or any Bungeecord server)

Resolves https://github.com/PrismarineJS/mineflayer/issues/2269