### PR TITLE
Fixes `TypeError: Cannot read property 'id' of undefined`

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -436,7 +436,7 @@ function inject (bot, { version, hideErrors }) {
     }
     if (windowClickQueue.length > 0 && Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
       if (!hideErrors) {
-        console.log(`WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue`)
+        console.log('WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue')
         windowClickQueue.pop()
       }
       return

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -437,7 +437,7 @@ function inject (bot, { version, hideErrors }) {
     if (Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
       if (!hideErrors) {
         console.log(`WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue`)
-        windowClickQueue.length = 0
+        windowClickQueue.pop()
       }
       return
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -437,7 +437,7 @@ function inject (bot, { version, hideErrors }) {
     if (windowClickQueue.length > 0 && Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
       windowClickQueue.pop()
       if (!hideErrors) {
-        console.log('WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue')
+        console.log('WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping the last click in windowClickQueue')
       }
       return
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -434,6 +434,13 @@ function inject (bot, { version, hideErrors }) {
       }
       return
     }
+    if (Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
+      if (!hideErrors) {
+        console.log(`WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue`)
+        windowClickQueue.length = 0
+      }
+      return
+    }
     assert.ok(click.id <= actionId)
     while (actionId > click.id) {
       onAccepted()

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -434,7 +434,7 @@ function inject (bot, { version, hideErrors }) {
       }
       return
     }
-    if (Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
+    if (windowClickQueue.length > 0 && Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
       if (!hideErrors) {
         console.log(`WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue`)
         windowClickQueue.pop()

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -435,9 +435,9 @@ function inject (bot, { version, hideErrors }) {
       return
     }
     if (windowClickQueue.length > 0 && Math.max(...windowClickQueue.map(x => x.id)) < actionId) {
+      windowClickQueue.pop()
       if (!hideErrors) {
         console.log('WARNING : ignoring transaction where actionId > max action id in windowClickQueue and dropping all of windowClickQueue')
-        windowClickQueue.pop()
       }
       return
     }


### PR DESCRIPTION
Fixes: 
```
C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\mineflayer\lib\plugins\inventory.js:444
    while (actionId > click.id) {
                            ^

TypeError: Cannot read property 'id' of undefined
    at Client.<anonymous> (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\mineflayer\lib\plugins\inventory.js:576:5)
    at Client.emit (node:events:394:28)
    at FullPacketParser.<anonymous> (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\minecraft-protocol\src\client.js:91:12)
    at FullPacketParser.emit (node:events:394:28)
    at addChunk (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\readable-stream\lib\_stream_readable.js:298:12)
    at readableAddChunk (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\readable-stream\lib\_stream_readable.js:280:11)
    at FullPacketParser.Readable.push (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\readable-stream\lib\_stream_readable.js:241:10)
    at FullPacketParser.Transform.push (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\readable-stream\lib\_stream_transform.js:139:32)
    at FullPacketParser._transform (C:\Users\---\Documents\js-projects\cosmic-lore-bot\node_modules\protodef\src\serializer.js:89:10)
```
closes https://github.com/PrismarineJS/mineflayer/issues/1811