### PR TITLE
Send arm_animation before use_entity

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -544,11 +544,11 @@ function inject (bot, { version }) {
   }
 
   function attack (target, swing = true) {
-    useEntity(target, 1)
-
+    // arm animation comes before the use_entity packet
     if (swing) {
       swingArm()
     }
+    useEntity(target, 1)
   }
 
   function mount (target) {


### PR DESCRIPTION
In vanilla, the client sends an `arm_animation` packet before the `use_entity` packet. Sending a `use_entity` packet before `arm_animation` might flag some anticheats for "no swing"