### PR TITLE
compute scoreboard displayName dynamically

### DIFF
--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -1,9 +1,7 @@
-const ScoreBoard = require('../scoreboard')
-
 module.exports = inject
 
 function inject (bot) {
-  const ChatMessage = require('prismarine-chat')(bot.version)
+  const ScoreBoard = require('../scoreboard')(bot)
   const scoreboards = {}
 
   bot._client.on('scoreboard_objective', (packet) => {
@@ -29,12 +27,7 @@ function inject (bot) {
   bot._client.on('scoreboard_score', (packet) => {
     const scoreboard = scoreboards[packet.scoreName]
     if (scoreboard !== undefined && packet.action === 0) {
-      const { itemName, value } = packet
-      let displayName = new ChatMessage(itemName)
-      if (itemName in bot.teamMap) {
-        displayName = bot.teamMap[itemName].displayName(itemName)
-      }
-      const updated = scoreboard.add(itemName, value, displayName)
+      const updated = scoreboard.add(packet.itemName, packet.value)
       bot.emit('scoreUpdated', scoreboard, updated)
     }
 

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -4,49 +4,56 @@ const sortItems = (a, b) => {
   return 1
 }
 
-class ScoreBoard {
-  constructor (packet) {
-    this.name = packet.name
-    this.setTitle(packet.displayText)
-    this.itemsMap = {}
-  }
-
-  setTitle (title) {
-    try {
-      this.title = JSON.parse(title).text // version>1.13
-    } catch {
-      this.title = title
+module.exports = (bot) => {
+  class ScoreBoard {
+    constructor (packet) {
+      this.name = packet.name
+      this.setTitle(packet.displayText)
+      this.itemsMap = {}
+    }
+  
+    setTitle (title) {
+      try {
+        this.title = JSON.parse(title).text // version>1.13
+      } catch {
+        this.title = title
+      }
+    }
+  
+    add (name, value) {
+      this.itemsMap[name] = { name, value }
+      this.itemsMap[name] = { name, value, get displayName () {
+        if (name in bot.teamMap) {
+          return bot.teamMap[name].displayName(name)
+        }
+        return new ChatMessage(itemName)
+      }}
+      return this.itemsMap[name]
+    }
+  
+    remove (name) {
+      const removed = this.itemsMap[name]
+      delete this.itemsMap[name]
+      return removed
+    }
+  
+    get items () {
+      return Object.values(this.itemsMap).sort(sortItems)
     }
   }
-
-  add (name, value, displayName) {
-    this.itemsMap[name] = { name, value, displayName }
-    return this.itemsMap[name]
+  
+  ScoreBoard.positions = {
+    get list () {
+      return this[0]
+    },
+  
+    get sidebar () {
+      return this[1]
+    },
+  
+    get belowName () {
+      return this[2]
+    }
   }
-
-  remove (name) {
-    const removed = this.itemsMap[name]
-    delete this.itemsMap[name]
-    return removed
-  }
-
-  get items () {
-    return Object.values(this.itemsMap).sort(sortItems)
-  }
+  return ScoreBoard
 }
-
-ScoreBoard.positions = {
-  get list () {
-    return this[0]
-  },
-
-  get sidebar () {
-    return this[1]
-  },
-
-  get belowName () {
-    return this[2]
-  }
-}
-
-module.exports = ScoreBoard

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -5,13 +5,15 @@ const sortItems = (a, b) => {
 }
 
 module.exports = (bot) => {
+  const ChatMessage = require('prismarine-chat')(bot.version)
+
   class ScoreBoard {
     constructor (packet) {
       this.name = packet.name
       this.setTitle(packet.displayText)
       this.itemsMap = {}
     }
-  
+
     setTitle (title) {
       try {
         this.title = JSON.parse(title).text // version>1.13
@@ -19,38 +21,42 @@ module.exports = (bot) => {
         this.title = title
       }
     }
-  
+
     add (name, value) {
       this.itemsMap[name] = { name, value }
-      this.itemsMap[name] = { name, value, get displayName () {
-        if (name in bot.teamMap) {
-          return bot.teamMap[name].displayName(name)
+      this.itemsMap[name] = {
+        name,
+        value,
+        get displayName () {
+          if (name in bot.teamMap) {
+            return bot.teamMap[name].displayName(name)
+          }
+          return new ChatMessage(name)
         }
-        return new ChatMessage(itemName)
-      }}
+      }
       return this.itemsMap[name]
     }
-  
+
     remove (name) {
       const removed = this.itemsMap[name]
       delete this.itemsMap[name]
       return removed
     }
-  
+
     get items () {
       return Object.values(this.itemsMap).sort(sortItems)
     }
   }
-  
+
   ScoreBoard.positions = {
     get list () {
       return this[0]
     },
-  
+
     get sidebar () {
       return this[1]
     },
-  
+
     get belowName () {
       return this[2]
     }


### PR DESCRIPTION
This is a problem because the server can send a teams packet with an updated prefix/suffix and `bot.scoreboard.sidebar.items` won't update it's `displayName`, as that was only updated when a new `scoreboard_display_objective` packet with action 1 was sent, however the vanilla client doesn't require this, so we shouldn't either.