### PR TITLE
Add reason for the end of a mineflayer bot

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -158,7 +158,7 @@
       - ["weatherUpdate"](#weatherupdate)
       - ["time"](#time)
       - ["kicked" (reason, loggedIn)](#kicked-reason-loggedin)
-      - ["end"](#end)
+      - ["end" (reason)](#end-reason)
       - ["error" (err)](#error-err)
       - ["spawnReset"](#spawnreset)
       - ["death"](#death)
@@ -247,7 +247,7 @@
       - [bot.recipesAll(itemType, metadata, craftingTable)](#botrecipesallitemtype-metadata-craftingtable)
       - [bot.nearestEntity(match = (entity) => { return true })](#botnearestentitymatch--entity---return-true-)
     - [Methods](#methods)
-      - [bot.end()](#botend)
+      - [bot.end(reason)](#botendreason)
       - [bot.quit(reason)](#botquitreason)
       - [bot.tabComplete(str, cb, [assumeCommand], [sendBlockInSight])](#bottabcompletestr-cb-assumecommand-sendblockinsight)
       - [bot.chat(message)](#botchatmessage)
@@ -1156,9 +1156,10 @@ is a chat message explaining why you were kicked. `loggedIn`
 is `true` if the client was kicked after successfully logging in,
 or `false` if the kick occurred in the login phase.
 
-#### "end"
+#### "end" (reason)
 
 Emitted when you are no longer connected to the server.
+`reason` is a string explaining why the client was ended. Defaults to SocketClosed.
 
 #### "error" (err)
 
@@ -1511,7 +1512,7 @@ const cow = bot.nearestEntity(entity => entity.name.toLowerCase() === 'cow') // 
 
 ### Methods
 
-#### bot.end()
+#### bot.end(reason)
 
 End the connection with the server.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1515,6 +1515,7 @@ const cow = bot.nearestEntity(entity => entity.name.toLowerCase() === 'cow') // 
 #### bot.end(reason)
 
 End the connection with the server.
+* `reason` - Optional string that states the reason of the end.
 
 #### bot.quit(reason)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ interface BotEvents {
   rain: () => Promise<void> | void
   time: () => Promise<void> | void
   kicked: (reason: string, loggedIn: boolean) => Promise<void> | void
-  end: () => Promise<void> | void
+  end: (reason: string) => Promise<void> | void
   spawnReset: () => Promise<void> | void
   death: () => Promise<void> | void
   health: () => Promise<void> | void
@@ -194,7 +194,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   supportFeature: (feature: string) => boolean
 
-  end: () => void
+  end: (reason?: string) => void
 
   blockAt: (point: Vec3) => Block | null
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -70,7 +70,7 @@ function createBot (options = {}) {
   options.brand = options.brand ?? 'vanilla'
   const bot = new EventEmitter()
   bot._client = options.client
-  bot.end = () => bot._client.end()
+  bot.end = (reason) => bot._client.end(reason)
   if (options.logErrors) {
     bot.on('error', err => {
       if (!options.hideErrors) {
@@ -99,8 +99,8 @@ function createBot (options = {}) {
   bot._client.on('error', (err) => {
     bot.emit('error', err)
   })
-  bot._client.on('end', () => {
-    bot.emit('end')
+  bot._client.on('end', (reason) => {
+    bot.emit('end', reason)
   })
   if (!bot._client.wait_connect) next()
   else bot._client.once('connect_allowed', next)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -31,7 +31,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
     afterEach((done) => {
-      bot.on('end', done)
+      bot.on('end', done())
       server.close()
     })
     it('chat', (done) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -31,7 +31,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
     afterEach((done) => {
-      bot.on('end', done())
+      bot.on('end', () => {
+        done()
+      })
       server.close()
     })
     it('chat', (done) => {


### PR DESCRIPTION
This adds the parameter `reason` to bot.end() and the event `end`.

node-minecraft-protocol emits a default reason of `SocketClosed`.

If we start adding reasons for why the connection closed, then it will make future debugging easier.