### PR TITLE
fix typo harming type safety

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -201,7 +201,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   blockInSight: (maxSteps: number, vectorLength: number) => Block | null
 
   blockAtCursor: (maxDistance?: number, matcher?: Function) => Block | null
-  blockAtEntityCursor: (entity?: entity, maxDistance?: number, matcher?: Function) => Block | null
+  blockAtEntityCursor: (entity?: Entity, maxDistance?: number, matcher?: Function) => Block | null
 
   canSeeBlock: (block: Block) => boolean
 


### PR DESCRIPTION
for blockAtEntityCursor, use `Entity` imported from prismarine-entity instead of `entity` which is unresolvable and degenerates to `any`