### PR TITLE
fix bug with force lastSentPitch in bot.look

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -240,6 +240,7 @@ function inject (bot, { physicsEnabled }) {
 
     if (force) {
       lastSentYaw = yaw
+      lastSentPitch = pitch
       return
     }
 


### PR DESCRIPTION
When doing:
```js
await bot.lookAt(chest, true)
await bot.openChest(chest)
```
it does not open the chest, it only looks at it.
it seems to have been some desync because in the if check it only sets 'lastSentYaw' but not 'lastSentPitch', my change fixes this.