### PR TITLE
Fix arm_animation and use_entity

### DIFF
--- a/lib/features.json
+++ b/lib/features.json
@@ -318,5 +318,10 @@
     "name": "setSlotAsTransaction",
     "description": "use setslot as transaction instead of just hoping it'll work",
     "versions": ["1.17", "1.17.1"]
+  },
+  {
+    "name": "armAnimationBefore",
+    "description": "arm animation packet sent before use entity packet",
+    "versions": ["1.8", "1.8.9"]
   }
 ]

--- a/lib/features.json
+++ b/lib/features.json
@@ -320,7 +320,7 @@
     "versions": ["1.17", "1.17.1"]
   },
   {
-    "name": "armAnimationBefore",
+    "name": "armAnimationBeforeUse",
     "description": "arm animation packet sent before use entity packet",
     "versions": ["1.8", "1.8.9"]
   }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -549,7 +549,7 @@ function inject (bot, { version }) {
 
   function attack (target, swing = true) {
     // arm animation comes before the use_entity packet on 1.8
-    if (bot.supportFeature('armAnimationBefore')) {
+    if (bot.supportFeature('armAnimationBeforeUse')) {
       if (swing) {
         swingArm()
       }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -548,11 +548,18 @@ function inject (bot, { version }) {
   }
 
   function attack (target, swing = true) {
-    // arm animation comes before the use_entity packet
-    if (swing) {
-      swingArm()
+    // arm animation comes before the use_entity packet on 1.8
+    if (bot.supportFeature('armAnimationBefore')) {
+      if (swing) {
+        swingArm()
+      }
+      useEntity(target, 1)
+    } else {
+      useEntity(target, 1)
+      if (swing) {
+        swingArm()
+      }
     }
-    useEntity(target, 1)
   }
 
   function mount (target) {


### PR DESCRIPTION
This should fix the "Sword doesn't wait for cooldown" error

From 1.8 to 1.8.9, Minecraft sends the arm_animation packet before the use_entity packet, but on 1.9+, Minecraft sends the use_entity packet before the arm_animation packet