### PR TITLE
(feat): add option to `FindBlockOptions` to *not* sort all blocks

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1472,6 +1472,7 @@ Finds the closest blocks from the given point.
       - **function** - Creates two stage maching, if block passes `matching` function it is passed further to `useExtraInfo` with additional info
    - `maxDistance` - The furthest distance for the search, defaults to 16.
    - `count` - Number of blocks to find before returning the search. Default to 1. Can return less if not enough blocks are found exploring the whole area.
+   - `sort` - Whether to sort the resulting blocks by their distance to the bot. Default is `true`
 
 Returns an array (possibly empty) with the found block coordinates (not the blocks). The array is sorted (closest first)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -556,6 +556,7 @@ export interface FindBlockOptions {
   maxDistance?: number
   count?: number
   useExtraInfo?: boolean
+	sort?: boolean
 }
 
 export type EquipmentDestination = 'hand' | 'head' | 'torso' | 'legs' | 'feet' | 'off-hand'

--- a/index.d.ts
+++ b/index.d.ts
@@ -556,7 +556,7 @@ export interface FindBlockOptions {
   maxDistance?: number
   count?: number
   useExtraInfo?: boolean
-	sort?: boolean
+  sort?: boolean
 }
 
 export type EquipmentDestination = 'hand' | 'head' | 'torso' | 'legs' | 'feet' | 'off-hand'

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -228,9 +228,9 @@ function inject (bot, { version, storageBuilder }) {
       next = it.next()
     }
     if (options.sort) {
-        blocks.sort((a, b) => {
-            return a.distanceTo(point) - b.distanceTo(point)
-        })
+      blocks.sort((a, b) => {
+        return a.distanceTo(point) - b.distanceTo(point)
+      })
     }
     // We found more blocks than needed, shorten the array to not confuse people
     if (blocks.length > count) {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -227,11 +227,11 @@ function inject (bot, { version, storageBuilder }) {
       startedLayer = it.apothem
       next = it.next()
     }
-		if (options.sort) {
-			blocks.sort((a, b) => {
-				return a.distanceTo(point) - b.distanceTo(point)
-			})
-		}
+    if (options.sort) {
+        blocks.sort((a, b) => {
+            return a.distanceTo(point) - b.distanceTo(point)
+        })
+    }
     // We found more blocks than needed, shorten the array to not confuse people
     if (blocks.length > count) {
       blocks = blocks.slice(0, count)

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -227,9 +227,11 @@ function inject (bot, { version, storageBuilder }) {
       startedLayer = it.apothem
       next = it.next()
     }
-    blocks.sort((a, b) => {
-      return a.distanceTo(point) - b.distanceTo(point)
-    })
+		if (options.sort) {
+			blocks.sort((a, b) => {
+				return a.distanceTo(point) - b.distanceTo(point)
+			})
+		}
     // We found more blocks than needed, shorten the array to not confuse people
     if (blocks.length > count) {
       blocks = blocks.slice(0, count)


### PR DESCRIPTION
Title says it all. The default `Array.prototype.sort` function is not very fast, and using it by default with no option to disable it is not ideal.

For example,
```javascript
const small = Array.from({ length: 1000 }, Math.random);
const medium = Array.from({ length: 100000 }, Math.random);
const large = Array.from({ length: 10000000 }, Math.random);

function sortAndTime(array, name) {
	console.time(name);
	array.sort((a, b) => b - a);
	console.timeEnd(name);
}

sortAndTime(small, 'small');
sortAndTime(medium, 'medium');
sortAndTime(large, 'large');
```

```console
small: 0.37ms
medium: 45.348ms
large: 8.632s
```

When searching for millions of blocks (e.g. digging only stone out of multiple chunks), the `findBlocks` function is very slow