### PR TITLE
settings.js imporvements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -745,6 +745,8 @@ Create and return an instance of the class bot.
  * [viewDistance](#bot.settings.viewDistance)
  * [difficulty](#bot.settings.difficulty)
  * [skinParts](#bot.settings.skinParts)
+ * [enableTextFiltering](#bot.settings.enableTextFiltering)
+ * [enableServerListing](#bot.settings.enableServerListing)
  * chatLengthLimit : the maximum amount of characters that can be sent in a single message. If this is not set, it will be 100 in < 1.11 and 256 in >= 1.11.
  * defaultChatPatterns: defaults to true, set to false to not add the patterns such as chat and whisper
 
@@ -881,6 +883,7 @@ Default true, whether or not you receive color codes in chats from the server.
 
 #### bot.settings.viewDistance
 
+Can be a string listed below or a postive number.
 Choices:
  * `far` (default)
  * `normal`
@@ -911,7 +914,10 @@ If you have a cape you can turn it off by setting this to false.
 
 ##### bot.settings.skinParts.showHat - boolean
 
-
+#### bot.settings.enableTextFiltering - boolean
+Unused, defaults to false in Notchian (Vanilla) client.
+#### bot.settings.enableServerListing - boolean
+This setting is sent to the server to determine whether the player should show up in server listings
 #### bot.experience.level
 
 #### bot.experience.points

--- a/lib/plugins/settings.js
+++ b/lib/plugins/settings.js
@@ -23,13 +23,27 @@ const viewDistanceToBits = {
 function inject (bot, options) {
   function setSettings (settings) {
     extend(bot.settings, settings)
+
+    // chat
     const chatBits = chatToBits[bot.settings.chat]
     assert.ok(chatBits != null, `invalid chat setting: ${bot.settings.chat}`)
-    const viewDistanceBits = viewDistanceToBits[bot.settings.viewDistance]
+
+    // view distance
+    let viewDistanceBits = null
+    if (typeof bot.settings.viewDistance === 'string') {
+      viewDistanceBits = viewDistanceToBits[bot.settings.viewDistance]
+    } else if (typeof bot.settings.viewDistance === 'number' && bot.settings.viewDistance > 0) { // Make sure view distance is a valid # || should be 2 or more
+      viewDistanceBits = bot.settings.viewDistance
+    }
     assert.ok(viewDistanceBits != null, `invalid view distance setting: ${bot.settings.viewDistance}`)
+
+    // hand
     const handBits = handToBits[bot.settings.mainHand]
     assert.ok(handBits != null, `invalid main hand: ${bot.settings.mainHand}`)
-    bot.settings.showCape = !!bot.settings.showCape
+
+    // skin
+    // cape is inverted, not used at all (legacy?)
+    // bot.settings.showCape = !!bot.settings.showCape
     const skinParts = bot.settings.skinParts.showCape << 0 |
           bot.settings.skinParts.showJacket << 1 |
           bot.settings.skinParts.showLeftSleeve << 2 |
@@ -37,13 +51,17 @@ function inject (bot, options) {
           bot.settings.skinParts.showLeftPants << 4 |
           bot.settings.skinParts.showRightPants << 5 |
           bot.settings.skinParts.showHat << 6
+    
+    // write the packet
     bot._client.write('settings', {
       locale: bot.settings.locale || 'en_US',
       viewDistance: viewDistanceBits,
       chatFlags: chatBits,
       chatColors: bot.settings.colorsEnabled,
       skinParts: skinParts,
-      mainHand: handBits
+      mainHand: handBits,
+      enableTextFiltering: bot.settings.enableTextFiltering,
+      enableServerListing: bot.settings.enableServerListing,
     })
   }
 
@@ -67,7 +85,9 @@ function inject (bot, options) {
           showHat: true
         }
       : options.skinParts,
-    mainHand: options.mainHand || 'right'
+    mainHand: options.mainHand || 'right',
+    enableTextFiltering: options.enableTextFiltering || false,
+    enableServerListing: options.enableServerListing || true
   }
 
   bot._client.once('login', () => {

--- a/lib/plugins/settings.js
+++ b/lib/plugins/settings.js
@@ -51,7 +51,7 @@ function inject (bot, options) {
           bot.settings.skinParts.showLeftPants << 4 |
           bot.settings.skinParts.showRightPants << 5 |
           bot.settings.skinParts.showHat << 6
-    
+
     // write the packet
     bot._client.write('settings', {
       locale: bot.settings.locale || 'en_US',
@@ -61,7 +61,7 @@ function inject (bot, options) {
       skinParts: skinParts,
       mainHand: handBits,
       enableTextFiltering: bot.settings.enableTextFiltering,
-      enableServerListing: bot.settings.enableServerListing,
+      enableServerListing: bot.settings.enableServerListing
     })
   }
 


### PR DESCRIPTION
add support for the two new options
`enableTextFiltering` boolean added in 1.17: Unused, but is set to false by default in vanilla
`enableServerListing` boolean added in 1.18: Added because of some griefing incidents, allows you to stop showing yourself in the ping for server lists.

Fixes https://github.com/PrismarineJS/mineflayer/issues/2481