### PR TITLE
Emit window close event AFTER updating the inventory

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -303,8 +303,8 @@ function inject (bot, { version, hideErrors }) {
 
   function extendWindow (window) {
     window.close = () => {
-      window.emit('close')
       closeWindow(window)
+      window.emit('close')
     }
 
     window.withdraw = async (itemType, metadata, count, nbt) => {
@@ -382,7 +382,7 @@ function inject (bot, { version, hideErrors }) {
       if (item) {
         item.slot = slot
       }
-      bot.inventory.slots[slot] = item
+      if (!Item.equal(bot.inventory.slots[slot], item, true)) bot.inventory.updateSlot(slot, item)
     }
   }
 


### PR DESCRIPTION
Also emit update slot events when copying the inventory

This way if you read the inventory right after receiving the event you will get an updated one instead of an outdated one (see https://github.com/imharvol/mineflayer-web-inventory/pull/26 for an example, this is the reason tests are failing there)