### PR TITLE
Add warnings for calling properties on bot too early

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -128,7 +128,21 @@ Note that the order in which plugins are loaded is dynamic, so you should never 
 
 In the options object for `mineflayer.createBot(options)`, remove your `host` option from the options object, have the following variables declared `PROXY_IP, PROXY_PORT, PROXY_USERNAME, PROXY_PASSWORD, MC_SERVER_ADDRESS, MC_SERVER_PORT` and add this to your options object:
 ```js
-connect: (client) => {
+const mineflayer = require('mineflayer')
+
+const PROXY_IP = 'MY_PROXY.com'
+const PROXY_PORT = 9999
+const PROXY_USERNAME = 'MY_USERNAME'
+const PROXY_PASSWORD = 'MY_PASSWORD'
+const MC_SERVER_ADDRESS = 'MC_SERVER.com'
+const MC_SERVER_PORT = 25565
+
+const bot = mineflayer.createBot({
+  host: MC_SERVER_ADDRESS,
+  port: MC_SERVER_PORT,
+  fakeHost: MC_SERVER_ADDRESS,
+  username: 'bot',
+  connect: (client) => {
     socks.createConnection({
       proxy: {
         host: PROXY_IP,
@@ -151,9 +165,9 @@ connect: (client) => {
       client.emit('connect')
     })
   }
-  ```
-  `socks` is declared with `const socks = require('socks').SocksClient` and uses [this](https://www.npmjs.com/package/socks) package.
-  Some servers might reject the connection. If that happens try adding `fakeHost: MC_SERVER_ADDRESS` to your createBot options.
+})
+``` 
+`socks` is declared with `const socks = require('socks').SocksClient` and uses [this](https://www.npmjs.com/package/socks) package.
   
 # Common Errors
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -173,3 +173,21 @@ Update your node version.
 
 Check that spawn protection isn't stopping the bot from it's action
 
+### `[WARNING] You are looking for {bot}.? too early, bot hasn't spawned yet.`
+
+You probably have code like this now:
+
+```js
+const bot = mineflayer.createBot()
+console.log(bot.entities)
+```
+
+The problem is that bot.entities is not loaded yet. To fix this problem, put your code in an event handler. Look [here](https://github.com/PrismarineJS/mineflayer/blob/master/docs/api.md#events), If you want your code to run when the bot logs in, use the `spawn` event like so:
+
+```js
+const bot = mineflayer.createBot()
+bot.once('spawn', () => {
+  console.log(bot.entities)
+})
+```
+

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,6 +2,8 @@ const mc = require('minecraft-protocol')
 const { EventEmitter } = require('events')
 const pluginLoader = require('./plugin_loader')
 const supportFeature = require('./supportFeature')
+const { botSpawned } = require('./util')
+
 const plugins = {
   bed: require('./plugins/bed'),
   title: require('./plugins/title'),
@@ -69,6 +71,7 @@ function createBot (options = {}) {
   options.client = options.client ?? null
   options.brand = options.brand ?? 'vanilla'
   const bot = new EventEmitter()
+  bot.once('spawn', botSpawned)
   bot._client = options.client
   bot.end = (reason) => bot._client.end(reason)
   if (options.logErrors) {

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -1,4 +1,5 @@
 const { once } = require('events')
+const { makeProxyFrom } = require('../util')
 
 module.exports = inject
 
@@ -165,9 +166,9 @@ function inject (bot, options) {
   bot.whisper = (username, message) => {
     chatWithHeader(`/tell ${username} `, message)
   }
-  bot.chat = (message) => {
+  makeProxyFrom(bot, (message) => {
     chatWithHeader('', message)
-  }
+  }, 'chat')
 
   bot.tabComplete = tabComplete
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -1,5 +1,6 @@
 const { Vec3 } = require('vec3')
 const conv = require('../conversions')
+const { makeProxyFrom } = require('../util')
 const NAMED_ENTITY_HEIGHT = 1.62
 const NAMED_ENTITY_WIDTH = 0.6
 const CROUCH_HEIGHT = NAMED_ENTITY_HEIGHT - 0.08
@@ -66,9 +67,9 @@ function inject (bot, { version }) {
     return resultSet
   }
 
-  bot.players = {}
+  makeProxyFrom(bot, {}, 'players')
   bot.uuidToUsername = {}
-  bot.entities = {}
+  makeProxyFrom(bot, {}, 'entities')
 
   bot.nearestEntity = (match = (entity) => { return true }) => {
     let best = null

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,28 @@
+const red = '\x1b[31m'
+const startUnderline = '\x1b[4m'
+const white = '\x1b[37m'
+const endUnderline = '\x1b[0m'
+
+let spawned = false
+
+function sendCalledTooEarly (bot, obj, propertyName) {
+  if (spawned) {
+    bot[propertyName] = obj
+    return
+  }
+  console.error(`${red}[${white}${startUnderline}WARNING${endUnderline}${red}] ${white}You are looking for {bot}.${propertyName} too early, bot hasn't spawned yet.\nSee: https://github.com/PrismarineJS/mineflayer/blob/add-warnings/docs/FAQ.md#warning-you-are-looking-for-bot-too-early-bot-hasnt-spawned-yet`)
+}
+
+function makeProxyFrom (bot, obj, propertyName) {
+  bot[propertyName] = new Proxy(obj, {
+    get (target, prop, receiver) {
+      sendCalledTooEarly(bot, obj, propertyName)
+      return target[prop]
+    }
+  })
+}
+
+module.exports = {
+  makeProxyFrom,
+  botSpawned: () => { spawned = true }
+}


### PR DESCRIPTION
Example code:
```js
const mineflayer = require('mineflayer')

const bot = mineflayer.createBot({
  host: '95.111.249.143',
  port: 10000,
  username: 'we_win_these'
})

console.log(bot.entities)
```
Output: 
![image](https://i.imgur.com/9qGgaB4.png)