### PR TITLE
Update missing/outdated typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -197,7 +197,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   end: (reason?: string) => void
 
-  blockAt: (point: Vec3) => Block | null
+  blockAt: (point: Vec3, extraInfos?: boolean) => Block | null
 
   blockInSight: (maxSteps: number, vectorLength: number) => Block | null
 


### PR DESCRIPTION
There is a lot of outdated typescript definitions that no longer match what's in the real code. I will try to add as much as I notice while working with mineflayer in TS.

PS: dont't merge this right away as there is a good chance I will find a lot more in the next few days