### PR TITLE
Make resetState much faster for newer versions

### DIFF
--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -1,6 +1,6 @@
 const assert = require('assert')
 const { Vec3 } = require('vec3')
-const { sleep } = require('../promise_utils')
+const { sleep, onceWithCleanup } = require('../promise_utils')
 const { once } = require('events')
 
 module.exports = inject
@@ -17,11 +17,6 @@ function inject (bot, { version }) {
   }
 
   const creativeSlotsUpdates = []
-  bot._client.on('set_slot', ({ windowId, slot, item }) => {
-    if (windowId === 0 && creativeSlotsUpdates[slot]) {
-      bot.emit(`set_creative_slot_${slot}`)
-    }
-  })
 
   // WARN: This method should not be called twice on the same slot before first promise succeeds
   async function setInventorySlot (slot, item) {
@@ -37,7 +32,7 @@ function inject (bot, { version }) {
       item: Item.toNotch(item)
     })
 
-    await once(bot, `set_creative_slot_${slot}`)
+    await onceWithCleanup(bot.inventory, `updateSlot:${slot}`, { checkCondition: (oldItem, newItem) => newItem?.name === item.name && newItem?.count === item.count && newItem?.metadata === item.metadata })
     creativeSlotsUpdates[slot] = false
   }
 

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -12,7 +12,6 @@ const { getPort } = require('./common/util')
 // set this to false if you want to test without starting a server automatically
 const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
-const WAIT_TIME_BEFORE_STARTING = 5000
 const TEST_TIMEOUT_MS = 90000
 
 const excludedTests = ['digEverything', 'book', 'anvil', 'placeEntity']
@@ -65,12 +64,13 @@ for (const supportedVersion of mineflayer.testedVersions) {
         bot.test.port = PORT
 
         console.log('starting bot')
-        bot.once('login', () => {
+        bot.once('spawn', () => {
           wrap.writeServer('op flatbot\n')
-          console.log('waiting a second...')
-          // this wait is to get all the window updates out of the way before we start expecting exactly what we cause.
-          // there are probably other updates coming in that we want to get out of the way too, like health updates.
-          setTimeout(done, WAIT_TIME_BEFORE_STARTING)
+          bot.once('messagestr', msg => {
+            if (msg === '[Server: Made flatbot a server operator]' || msg === '[Server: Opped flatbot]') {
+              done()
+            }
+          })
         })
       }
 

--- a/test/externalTests/consume.js
+++ b/test/externalTests/consume.js
@@ -8,6 +8,10 @@ module.exports = () => async (bot) => {
   await bot.test.becomeSurvival()
   // Cannot consume if bot.food === 20
   await assert.rejects(bot.consume, (err) => {
+    if (!err) {
+      // log the conditions that made this not throw
+      console.log({ a: bot.game.gameMode !== 'creative', b: !['potion', 'milk_bucket', 'enchanted_golden_apple', 'golden_apple'].includes(bot.heldItem.name), c: bot.food === 20 })
+    }
     assert.notStrictEqual(err, undefined)
     return true
   })

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -10,7 +10,6 @@ module.exports = inject
 
 function inject (bot) {
   console.log(bot.version)
-  const Item = require('prismarine-item')(bot.version)
 
   bot.test = {}
   bot.test.groundY = bot.supportFeature('tallWorld') ? -60 : 4
@@ -133,14 +132,6 @@ function inject (bot) {
   // you need to be in creative mode for this to work
   async function setInventorySlot (targetSlot, item) {
     assert(item === null || item.name !== 'unknown', `item should not be unknown ${JSON.stringify(item)}`)
-    // TODO FIX
-    if (Item.equal(bot.inventory.slots[targetSlot], item)) {
-      // console.log('placing')
-      // console.log(bot.inventory.slots[targetSlot])
-      // already good to go
-      return
-    }
-
     return bot.creative.setInventorySlot(targetSlot, item)
   }
 


### PR DESCRIPTION
Later versions don't want to say anything in chat for gamemode changes unless we actually changes gamemode, not just creative->creative.