### PR TITLE
Don't log `WARNING : unknown transaction confirmation for window`

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -438,9 +438,6 @@ function inject (bot, { hideErrors }) {
         accepted: true
         // bot.emit(`confirmTransaction${click.id}`, false)
       })
-      if (!hideErrors) {
-        console.log(`WARNING : unknown transaction confirmation for window ${windowId}, action ${actionId} and accepted ${accepted}`)
-      }
       return
     }
     // shift it later if packets are sent out of order


### PR DESCRIPTION
There's no reason to print this out, since the vanilla client does this