### PR TITLE
Cache 'positionUpdateSentEveryTick' feature lookup

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -18,6 +18,8 @@ function inject (bot, { physicsEnabled }) {
   const world = { getBlock: (pos) => { return bot.blockAt(pos, false) } }
   const physics = Physics(bot.registry, world)
 
+  const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
+
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown
 
@@ -148,7 +150,7 @@ function inject (bot, { physicsEnabled }) {
       // Send a position packet every second, even if no update was made
       sendPacketPosition(position, onGround)
       lastSent.time = performance.now()
-    } else if (bot.supportFeature('positionUpdateSentEveryTick') && bot.isAlive) {
+    } else if (positionUpdateSentEveryTick && bot.isAlive) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
       bot._client.write('flying', { onGround: bot.entity.onGround })


### PR DESCRIPTION
This peace off code is called 20 times a second. Running `bot.supportFeature('positionUpdateSentEveryTick')` on a raspberrypi 4 takes up to 9ms. Not good.

We should look into caching supportFeature in more places that are called frequently or look into improving the performance off the implementation. Having to call this function multiple times on something like `physicsTick` can slow down the entire process significantly.