### PR TITLE
Add manual crafting test

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prismarine-physics": "^1.3.1",
     "prismarine-recipe": "^1.1.0",
     "prismarine-registry": "^1.0.0",
-    "prismarine-windows": "^2.4.2",
+    "prismarine-windows": "github:IceTank/prismarine-windows#wrong-assertion-workaround",
     "prismarine-world": "^3.6.0",
     "protodef": "^1.14.0",
     "typed-emitter": "^1.0.0",

--- a/test/externalTests/crafting.js
+++ b/test/externalTests/crafting.js
@@ -55,4 +55,18 @@ module.exports = () => async (bot) => {
   await once(bot.inventory, 'updateSlot')
   const craftingTable = bot.findBlock({ matching: blocksByName.crafting_table.id })
   await bot.craft(bot.recipesFor(itemsByName.ladder.id, null, null, true)[0], 1, craftingTable)
+
+  // Manually crafting by clicking on the crafting result slot
+  await bot.test.becomeCreative()
+  await bot.test.setInventorySlot(36, new Item(populateBlockInventory.id, 1, 0))
+  await bot.test.becomeSurvival()
+  await bot.transfer({
+    itemType: populateBlockInventory.id,
+    count: 1,
+    sourceStart: bot.inventory.inventoryStart,
+    sourceEnd: bot.inventory.inventoryEnd,
+    destStart: 1, // crafting slot
+    destEnd: 2
+  })
+  await bot.clickWindow(0, 0, 0) // Click the resulting item (should be planks)
 }


### PR DESCRIPTION
This test only works for 1.12.2+ using this change: https://github.com/PrismarineJS/prismarine-windows/pull/60
I am not sure what is causing the test to fails for older versions tho. 