### PR TITLE
Adds new title events that work for later versions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -160,6 +160,8 @@
       - ["game"](#game)
       - ["resourcePack" (url, hash)](#resourcepack-url-hash)
       - ["title"](#title)
+      - ["titlemsg" (msg)](#titlemsg-msg)
+      - ["subtitlemsg" (msg)](#subtitlemsg-msg)
       - ["rain"](#rain)
       - ["weatherUpdate"](#weatherupdate)
       - ["time"](#time)
@@ -1159,9 +1161,23 @@ Emitted when the server sends a resource pack.
 
 #### "title"
 
+**Deprecated**, prefer see "titlemsg" event.
+
 Emitted when the server sends a title
 
  * `text` - title's text
+
+#### "titlemsg" (msg)
+
+Emitted when the server sends a title
+
+ * `msg` - title's msg
+
+#### "subtitlemsg" (msg)
+
+Emitted when the server sends a title
+
+ * `msg` - subtitle's msg
 
 #### "rain"
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,10 @@ interface BotEvents {
   spawn: () => Promise<void> | void
   respawn: () => Promise<void> | void
   game: () => Promise<void> | void
+  /** @deprecated */
   title: (text: string) => Promise<void> | void
+  titlemsg: (msg: ChatMessage) => Promise<void> | void
+  subtitlemsg: (msg: ChatMessage) => Promise<void> | void
   rain: () => Promise<void> | void
   time: () => Promise<void> | void
   kicked: (reason: string, loggedIn: boolean) => Promise<void> | void

--- a/lib/plugins/title.js
+++ b/lib/plugins/title.js
@@ -1,9 +1,18 @@
+const ChatMessage = require('prismarine-chat')
 module.exports = inject
 
-function inject (bot) {
+function inject (bot, { version }) {
+  const ChatMsg = ChatMessage(version)
   bot._client.on('title', (packet) => {
     if (packet.action === 0 || packet.action === 1) {
       bot.emit('title', packet.text)
+      bot.emit('titlemsg', ChatMsg.fromNotch(packet.text))
     }
+  })
+  bot._client.on('set_title_text', packet => {
+    bot.emit('titlemsg', ChatMsg.fromNotch(packet.text))
+  })
+  bot._client.on('set_title_subtitle', packet => {
+    bot.emit('subtitlemsg', ChatMsg.fromNotch(packet.text))
   })
 }


### PR DESCRIPTION
The "title" event doesn't work on later versions at all, plus it now sends chat messages, so the msg suffixed events are better overall. I'm considering setting a timer on deprecating the existing title event seeing as it doesn't work on later versions anyway