### PR TITLE
Add bot.clickWindow mode disclaimer

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1995,6 +1995,8 @@ These are lower level methods for the inventory, they can be useful sometimes bu
 #### bot.clickWindow(slot, mouseButton, mode)
 
 This function returns a `Promise`, with `void` as its argument upon completion.
+  
+The only valid mode option at the moment is 0. Shift clicking or mouse draging is not implemented.
 
 Click on the current window. See details at https://wiki.vg/Protocol#Click_Window
 


### PR DESCRIPTION
If we are throwing with mode values other then 0 inside the clickWindow function we should also say that in the documentation.