### PR TITLE
added bot.canSeeEntity(entity)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -206,6 +206,8 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   canSeeBlock: (block: Block) => boolean
 
+  canSeeEntity: (entity: Entity, vectorLength?: number) => boolean
+
   findBlock: (options: FindBlockOptions) => Block | null
 
   findBlocks: (options: FindBlockOptions) => Vec3[]

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -9,6 +9,9 @@ module.exports = (bot) => {
     return new Vec3(-snYaw * csPitch, snPitch, -csYaw * csPitch)
   }
 
+  const mcData = require('minecraft-data')(bot.version)
+  const transparentBlocks = mcData.blocksArray.filter(e => e.transparent).map(e => e.id)
+
   bot.blockInSight = (maxSteps = 256, vectorLength = 5 / 16) => {
     console.warn('[deprecated] use bot.blockAtCursor instead')
     const block = bot.blockAtCursor(maxSteps * vectorLength)
@@ -32,5 +35,48 @@ module.exports = (bot) => {
     const viewDirection = getViewDirection(pitch, yaw)
 
     return bot.world.raycast(eyePosition, viewDirection, maxDistance, matcher)
+  }
+
+  bot.canSeeEntity = (entity, vectorLength = 5 / 16) => {
+    const { height, position } = bot.entity
+    const entityPos = entity.position.offset(-entity.width / 2, 0, -entity.width / 2)
+
+    // bounding box verticies (8 verticies)
+    const targetBoundingBoxVertices = [
+      entityPos.offset(0,            0,             0),
+      entityPos.offset(entity.width, 0,             0),
+      entityPos.offset(0,            0,             entity.width),
+      entityPos.offset(entity.width, 0,             entity.width),
+      entityPos.offset(0,            entity.height, 0),
+      entityPos.offset(entity.width, entity.height, 0),
+      entityPos.offset(0,            entity.height, entity.width),
+      entityPos.offset(entity.width, entity.height, entity.width),
+    ]
+
+    // Check the line of sight for every vertex
+    const lineOfSight = targetBoundingBoxVertices.map(bbVertex => {
+      // cursor starts at bot's eyes
+      const cursor = position.offset(0, height, 0)
+      // a vector from a to b = b - a
+      const step = bbVertex.minus(cursor).unit().scaled(vectorLength)
+      // we shouldn't step farther than the distance to the entity, plus the longest line inside the bounding box
+      const maxSteps = bbVertex.distanceTo(position) / vectorLength
+
+      // check for obstacles
+      for (let i = 0; i < maxSteps; ++i) {
+        cursor.add(step)
+        const block = bot.blockAt(cursor)
+
+        // block must be air/null or a transparent block
+        if (block !== null && !transparentBlocks.includes(block.type)) {
+          return false
+        }
+      }
+
+      return true
+    })
+
+    // must have at least 1 vertex in line-of-sight
+    return lineOfSight.some(e => e)
   }
 }

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -10,7 +10,7 @@ module.exports = (bot) => {
   }
 
   const mcData = require('minecraft-data')(bot.version)
-  const transparentBlocks = mcData.blocksArray.filter(e => e.transparent).map(e => e.id)
+  const transparentBlocks = mcData.blocksArray.filter(e => e.transparent || e.boundingBox === 'empty').map(e => e.id)
 
   bot.blockInSight = (maxSteps = 256, vectorLength = 5 / 16) => {
     console.warn('[deprecated] use bot.blockAtCursor instead')

--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -43,14 +43,14 @@ module.exports = (bot) => {
 
     // bounding box verticies (8 verticies)
     const targetBoundingBoxVertices = [
-      entityPos.offset(0,            0,             0),
-      entityPos.offset(entity.width, 0,             0),
-      entityPos.offset(0,            0,             entity.width),
-      entityPos.offset(entity.width, 0,             entity.width),
-      entityPos.offset(0,            entity.height, 0),
+      entityPos.offset(0, 0, 0),
+      entityPos.offset(entity.width, 0, 0),
+      entityPos.offset(0, 0, entity.width),
+      entityPos.offset(entity.width, 0, entity.width),
+      entityPos.offset(0, entity.height, 0),
       entityPos.offset(entity.width, entity.height, 0),
-      entityPos.offset(0,            entity.height, entity.width),
-      entityPos.offset(entity.width, entity.height, entity.width),
+      entityPos.offset(0, entity.height, entity.width),
+      entityPos.offset(entity.width, entity.height, entity.width)
     ]
 
     // Check the line of sight for every vertex


### PR DESCRIPTION
This pull request adds the function `bot.canSeeEntity: (entity: Entity, vectorLength?: number) => boolean`.

Basically, all 8 vertices of an entity's bounding box are computed and a ray trace is done from the bot's eyes to each vertex. For each trace, if non-transparent blocks are found along the way, that trace returns false. If any of the traces return true, the bounding box of the entity is partially visible from the bot.