### PR TITLE
Added method to wait until sleep function is in reality sleeping

### DIFF
--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -147,7 +147,7 @@ function inject (bot) {
       }
 
       await bot.activateBlock(bedBlock)
-      
+
       await timeout(3000)
       if (!bot.isSleeping) {
         throw new Error('bot is not sleeping')

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -148,23 +148,25 @@ function inject (bot) {
 
       await bot.activateBlock(bedBlock)
 
-      await timeout(3000)
-      if (!bot.isSleeping) {
-        throw new Error('bot is not sleeping')
+      const err = await waitUntilSleep()
+      if (err) {
+        throw new Error(err)
       }
     }
   }
 
-  function timeout (ms) {
-    return new Promise(resolve => setTimeout(resolve, ms))
-  }
+  async function waitUntilSleep () {
+    return new Promise((resolve, reject) => {
+      const timeoutForSleep = setTimeout(() => {
+        resolve('bot is not sleeping')
+      }, 3000)
 
-  bot._client.on('game_state_change', (packet) => {
-    if (packet.reason === 0) {
-      // occurs when you can't spawn in your bed and your spawn point gets reset
-      bot.emit('spawnReset')
-    }
-  })
+      bot.once('sleep', () => {
+        clearTimeout(timeoutForSleep)
+        resolve()
+      })
+    })
+  }
 
   bot.on('entitySleep', (entity) => {
     if (entity === bot.entity) {

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -147,6 +147,7 @@ function inject (bot) {
       }
 
       await bot.activateBlock(bedBlock)
+      
       await timeout(3000)
       if (!bot.isSleeping) {
         throw new Error('bot is not sleeping')

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -154,10 +154,9 @@ function inject (bot) {
     }
   }
 
-  function timeout(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  function timeout (ms) {
+    return new Promise(resolve => setTimeout(resolve, ms))
   }
-
 
   bot._client.on('game_state_change', (packet) => {
     if (packet.reason === 0) {

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -168,6 +168,13 @@ function inject (bot) {
     })
   }
 
+  bot._client.on('game_state_change', (packet) => {
+    if (packet.reason === 0) {
+      // occurs when you can't spawn in your bed and your spawn point gets reset
+      bot.emit('spawnReset')
+    }
+  })
+
   bot.on('entitySleep', (entity) => {
     if (entity === bot.entity) {
       bot.isSleeping = true

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -148,7 +148,6 @@ function inject (bot) {
 
       bot.activateBlock(bedBlock)
       await waitUntilSleep()
-
     }
   }
 

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -147,8 +147,17 @@ function inject (bot) {
       }
 
       await bot.activateBlock(bedBlock)
+      await timeout(3000)
+      if (!bot.isSleeping) {
+        throw new Error('bot is not sleeping')
+      }
     }
   }
+
+  function timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
 
   bot._client.on('game_state_change', (packet) => {
     if (packet.reason === 0) {

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -146,19 +146,16 @@ function inject (bot) {
         }
       }
 
-      await bot.activateBlock(bedBlock)
+      bot.activateBlock(bedBlock)
+      await waitUntilSleep()
 
-      const err = await waitUntilSleep()
-      if (err) {
-        throw new Error(err)
-      }
     }
   }
 
   async function waitUntilSleep () {
     return new Promise((resolve, reject) => {
       const timeoutForSleep = setTimeout(() => {
-        resolve('bot is not sleeping')
+        reject(new Error('bot is not sleeping'))
       }, 3000)
 
       bot.once('sleep', () => {

--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -147,6 +147,7 @@ function inject (bot) {
       }
 
       bot.activateBlock(bedBlock)
+
       await waitUntilSleep()
     }
   }

--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -31,7 +31,6 @@ module.exports = () => async (bot) => {
   // Sleep
   assert(!bot.isSleeping)
   await bot.sleep(bot.blockAt(bedPos1))
-  await once(bot, 'sleep')
 
   // Wake
   assert(bot.isSleeping)


### PR DESCRIPTION
- [x] The [FAQ](https://github.com/PrismarineJS/mineflayer/blob/master/docs/FAQ.md) doesn't contain a resolution to my issue 

## Versions
 - mineflayer: 4.3.0
 - server: vanilla 1.18.1
 - node: Dockerized:  node:16.13-bullseye

## Detailed description of a problem
If the bot click on bed at same time when other bot/player click on bed and steal him they don't return any error,
The function no return an error

I attach video you can see a bit better: https://youtu.be/S5PrYqO4KRk

## Expected behavior
Throw an error

