### PR TITLE
Add ender chests as a chest type

### DIFF
--- a/lib/plugins/chest.js
+++ b/lib/plugins/chest.js
@@ -2,7 +2,7 @@
 module.exports = inject
 
 function inject (bot) {
-  const allowedWindowTypes = ['minecraft:generic', 'minecraft:chest', 'minecraft:dispenser', 'minecraft:shulker_box', 'minecraft:hopper', 'minecraft:container', 'minecraft:dropper', 'minecraft:trapped_chest']
+  const allowedWindowTypes = ['minecraft:generic', 'minecraft:chest', 'minecraft:dispenser', 'minecraft:ender_chest', 'minecraft:shulker_box', 'minecraft:hopper', 'minecraft:container', 'minecraft:dropper', 'minecraft:trapped_chest']
 
   function matchWindowType (window) {
     for (const type of allowedWindowTypes) {


### PR DESCRIPTION
Not really much to explain here, just adds ender chests so that a bot can open one without throwing an error.