### PR TITLE
Resolving #2593. Change mineflayer.container docs to reference openContainer not openChest and updated examples.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -453,7 +453,7 @@ See [prismarine-recipe](https://github.com/PrismarineJS/prismarine-recipe)
 ### mineflayer.Container
 
 Extends windows.Window for chests, dispensers, etc...
-See `bot.openChest(chestBlock or minecartchestEntity)`.
+See `bot.openContainer(chestBlock or minecartchestEntity)`.
 
 ### mineflayer.Furnace
 

--- a/docs/es/api_es.md
+++ b/docs/es/api_es.md
@@ -423,7 +423,7 @@ Mira [prismarine-recipe](https://github.com/PrismarineJS/prismarine-recipe)
 ### mineflayer.Container
 
 Extiende windows.Window para cofres, dispensadores, etc...
-Mira `bot.openChest(chestBlock o minecartchestEntity)`.
+Mira `bot.openContainer(chestBlock o minecartchestEntity)`.
 
 ### mineflayer.Furnace
 

--- a/docs/ru/api_ru.md
+++ b/docs/ru/api_ru.md
@@ -368,7 +368,7 @@
 ### mineflayer.Chest
 
 Предоставляет сеанс взаимодействия с сундуками ( Открытие и закрытие )
-Смотрите `bot.openChest(chestBlock or minecartchestEntity)`.
+Смотрите `bot.openContainer(chestBlock or minecartchestEntity)`.
 
 #### chest.window
 
@@ -1490,7 +1490,7 @@ bot.once('login', () => {
 
 #### bot.openChest(chestBlock or minecartchestEntity)
 
-Открывает сундук
+Устарело.Открывает сундук. Такой же как "openContainer"
 
 #### bot.openFurnace(furnaceBlock)
 

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -446,7 +446,7 @@ See [prismarine-recipe](https://github.com/PrismarineJS/prismarine-recipe)
 ### mineflayer.Container
 
 Extends windows.Window for chests, dispensers, etc...
-See `bot.openChest(chestBlock or minecartchestEntity)`.
+See `bot.openContainer(chestBlock or minecartchestEntity)`.
 
 ### mineflayer.Furnace
 

--- a/examples/chest.js
+++ b/examples/chest.js
@@ -103,7 +103,7 @@ async function watchChest (minecart, blocks = []) {
       return
     }
   }
-  const chest = await bot.openChest(chestToOpen)
+  const chest = await bot.openContainer(chestToOpen)
   sayItems(chest.containerItems())
   chest.on('updateSlot', (slot, oldItem, newItem) => {
     bot.chat(`chest update: ${itemToString(oldItem)} -> ${itemToString(newItem)} (slot: ${slot})`)

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -38,7 +38,7 @@ module.exports = () => async (bot) => {
   }
 
   async function depositBones (chestLocation, count) {
-    const chest = await bot.openChest(bot.blockAt(chestLocation))
+    const chest = await bot.openContainer(bot.blockAt(chestLocation))
     assert(chest.containerItems().length === 0)
     assert(chest.items().length > 0)
     const name = 'bone'
@@ -52,7 +52,7 @@ module.exports = () => async (bot) => {
   }
 
   async function withdrawBones (chestLocation, count) {
-    const chest = await bot.openChest(bot.blockAt(chestLocation))
+    const chest = await bot.openContainer(bot.blockAt(chestLocation))
     const name = 'bone'
     const item = itemByName(chest.containerItems(), name)
     if (!item) {
@@ -109,7 +109,7 @@ module.exports = () => async (bot) => {
       chest.close()
     }
   }
-  const chest = await bot.openChest(bot.blockAt(largeChestLocations[0]))
+  const chest = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
   await once(chest, 'close')
 
   await depositBones(smallChestLocation, 1)


### PR DESCRIPTION
To preface, this is my first-issue.

I was trying to add on to "Documentation for mineflayer.Container refers to bot.openChest(), which is deprecated #2593."

- [x] have updated docs
- [x] have updated examples
- [x] passed automatic checks

If someone knows how to instead add this PR to #2593 please tell me / do. 