### PR TITLE
Fix type error on chest open

### DIFF
--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -44,7 +44,7 @@ function inject (bot) {
       const perpendicularCardinals = Object.keys(FACING_MAP[facing])
       for (const cardinal of perpendicularCardinals) {
         const cardinalOffset = CARDINALS[cardinal]
-        if (bot.blockAt(chestBlock.position.plus(cardinalOffset)).type === chestBlock.type) {
+        if (bot.blockAt(chestBlock.position.plus(cardinalOffset))?.type === chestBlock.type) {
           return FACING_MAP[cardinal][facing]
         }
       }


### PR DESCRIPTION
There is a missing null check when trying to access a block. If that block is outside the render distance blockAt can return null causing a type error. See PrismarineJS discord message for an example https://discord.com/channels/413438066984747026/413438150594265099/993210395990949988