### PR TITLE
Added thunderState type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,6 +165,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   player: Player
   players: { [username: string]: Player }
   isRaining: boolean
+  thunderState: number
   chatPatterns: ChatPattern[]
   settings: GameSettings
   experience: Experience


### PR DESCRIPTION
The type of Thunder State is missing, i checked and seems is a number:

![image](https://user-images.githubusercontent.com/20754836/181070437-0cbefa43-2425-488b-a836-cfd1a16e3391.png)

They comes from:
https://github.com/PrismarineJS/mineflayer/blob/a0befeb042fe3851ac35887da116c2910f505791/lib/plugins/rain.js#L17-L19

