### PR TITLE
Added type on move event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ interface BotEvents {
   blockBreakProgressEnd: (block: Block) => Promise<void> | void
   diggingCompleted: (block: Block) => Promise<void> | void
   diggingAborted: (block: Block) => Promise<void> | void
-  move: () => Promise<void> | void
+  move: (position: Vec3) => Promise<void> | void
   forcedMove: () => Promise<void> | void
   mount: () => Promise<void> | void
   dismount: (vehicle: Entity) => Promise<void> | void


### PR DESCRIPTION
The position of event move is missing in type

The event of move all time is emited with Vec3 type:

https://github.com/PrismarineJS/mineflayer/blob/90f6d51a6a7409226ce4c9cf6bfa053fe3f67765/lib/plugins/physics.js#L96
https://github.com/PrismarineJS/mineflayer/blob/90f6d51a6a7409226ce4c9cf6bfa053fe3f67765/lib/plugins/physics.js#L86
https://github.com/PrismarineJS/mineflayer/blob/90f6d51a6a7409226ce4c9cf6bfa053fe3f67765/lib/plugins/physics.js#L101-L109