### PR TITLE
digging.js timing fix

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -7,12 +7,17 @@ module.exports = inject
 
 function inject (bot) {
   let swingInterval = null
-  let waitTimeout = null
+  let waitInterval = null
 
   let diggingTask = createDoneTask()
 
   bot.targetDigBlock = null
   bot.lastDigTime = null
+
+  bot.digPercentage = 0;
+  bot.on('heldItemChanged', () => {
+    bot.digPercentage = 0;
+  });
 
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
@@ -99,19 +104,28 @@ function inject (bot) {
       face: diggingFace // default face is 1 (top)
     })
     const waitTime = bot.digTime(block)
-    waitTimeout = setTimeout(finishDigging, waitTime)
+    //waitTimeout = setTimeout(finishDigging, waitTime)
+    waitInterval = setInterval(() => {
+        bot.digPercentage += (50 / bot.digTime(block));
+        if (bot.digPercentage >= 1.0) {
+            finishDigging();
+        }
+    }, 50);
+
     bot.targetDigBlock = block
     bot.swingArm()
 
+    //This has a habit of getting stuck often.
     swingInterval = setInterval(() => {
       bot.swingArm()
     }, 350)
 
     function finishDigging () {
+      bot.digPercentage = 0;
       clearInterval(swingInterval)
-      clearTimeout(waitTimeout)
+      clearTimeout(waitInterval)
       swingInterval = null
-      waitTimeout = null
+      waitInterval = null
       if (bot.targetDigBlock) {
         bot._client.write('block_dig', {
           status: 2, // finish digging
@@ -131,9 +145,10 @@ function inject (bot) {
       if (!bot.targetDigBlock) return
       bot.removeListener(eventName, onBlockUpdate)
       clearInterval(swingInterval)
-      clearTimeout(waitTimeout)
+      clearTimeout(waitInterval)
       swingInterval = null
-      waitTimeout = null
+      waitInterval = null
+      bot.digPercentage = 0;
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
@@ -153,9 +168,10 @@ function inject (bot) {
       if (newBlock.type !== 0) return
       bot.removeListener(eventName, onBlockUpdate)
       clearInterval(swingInterval)
-      clearTimeout(waitTimeout)
+      clearTimeout(waitInterval)
       swingInterval = null
-      waitTimeout = null
+      waitInterval = null
+      bot.digPercentage = 0.0;
       bot.targetDigBlock = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingCompleted', newBlock)


### PR DESCRIPTION
This fixes inconsistent timings when compared to vanilla when the mineflayer client performs and action that causes the time it takes to dig a block in the middle of digging a block, such as starting to dig a block in the air, followed by landing and continuing to dig. The old version would not finish digging until the air time finished, while this fix allows for it to be more in line with vanilla. This has not been extensively tested, especially against anticheats.

This fix adds a new variable called "bot.digPercentage" which is on a scale from 0.0(just started) to 1.0(finished). This variable will reset to 0.0 when the bot's held item is switched, just like the vanilla client. Again, not tested extensively. These fixes appear to work to me, but I would test them a little more thoroughly against the older version.

THINGS THAT STILL NEED FIXING:
* swingInterval will not clear sometimes, and as a result the bot will swing its arm indefinitely, which is not only visually unappealing but affects the bot's ability to PvP in 1.9+ due to the cooldown resetting whenever the arm swing animation plays in either hand. My personal fix has been to disable it and make the bot swing its arm on my own terms, but I'm not sure how it would be fixed here. May be easier to replicate on weaker machines, as my laptop is super low end and I get it very quickly.
* Inconsistent timings in certain aspects of mining. I.e. bot's head above water while standing on a dirt block but the dig time is not those of a vanilla client. Easiest to test in a swamp.
* I got a memory leak about waiting for events when testing this new version. I have no clue if it is related with any of the changes I made or if it is just a result of the project I was working on. Either way, I would test this more before implementing.