### PR TITLE
Fix return type for openBlock and openEntity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -381,9 +381,9 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   transfer: (options: TransferOptions) => Promise<void>
 
-  openBlock: (block: Block, direction?: Vec3, cursorPos?: Vec3) => Promise<void>
+  openBlock: (block: Block, direction?: Vec3, cursorPos?: Vec3) => Promise<Window>
 
-  openEntity: (block: Entity, Class: new () => EventEmitter) => Promise<void>
+  openEntity: (block: Entity, Class: new () => EventEmitter) => Promise<Window>
 
   moveSlotItem: (
     sourceSlot: number,


### PR DESCRIPTION
Is returing a void instead of a "Window" element

![image](https://user-images.githubusercontent.com/20754836/184554374-c8601d0a-ed12-4cd8-977e-94a2ac98f006.png)
