### PR TITLE
Fixed openContainer and added missing functions extended from windows

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -619,6 +619,7 @@ interface ConditionalStorageEvents extends StorageEvents {
 
 export class Chest extends (EventEmitter as new () => TypedEmitter<StorageEvents>) {
   window: object | /* prismarine-windows ChestWindow */ null
+  slots: Array<Item>;
 
   constructor ();
 
@@ -646,6 +647,7 @@ export class Chest extends (EventEmitter as new () => TypedEmitter<StorageEvents
 export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEvents>) {
   fuel: number
   progress: number
+  slots: Array<Item>;
 
   constructor ();
 
@@ -682,6 +684,8 @@ export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEven
 
 export class Dispenser extends (EventEmitter as new () => TypedEmitter<StorageEvents>) {
   constructor ();
+
+  slots: Array<Item>;
 
   close (): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -338,7 +338,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
     pages: string[]
   ) => Promise<void>
 
-  openContainer: (chest: Block | Entity, direction?: Vec3, cursorPos?: Vec3) => Promise<Chest | Furnace | Dispenser>
+  openContainer: (chest: Block | Entity, direction?: Vec3, cursorPos?: Vec3) => Promise<Chest | Dispenser>
 
   openChest: (chest: Block | Entity, direction?: number, cursorPos?: Vec3) => Promise<Chest>
 
@@ -639,6 +639,8 @@ export class Chest extends (EventEmitter as new () => TypedEmitter<StorageEvents
   count (itemType: number, metadata: number | null): number;
 
   items (): Item[];
+
+  containerItems (): Item[];
 }
 
 export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEvents>) {
@@ -672,6 +674,10 @@ export class Furnace extends (EventEmitter as new () => TypedEmitter<FurnaceEven
   fuelItem (): Item;
 
   outputItem (): Item;
+
+  items (): Item[];
+
+  containerItems (): Item[];
 }
 
 export class Dispenser extends (EventEmitter as new () => TypedEmitter<StorageEvents>) {
@@ -694,6 +700,8 @@ export class Dispenser extends (EventEmitter as new () => TypedEmitter<StorageEv
   count (itemType: number, metadata: number | null): number;
 
   items (): Item[];
+
+  containerItems (): Item[];
 }
 
 export class EnchantmentTable extends (EventEmitter as new () => TypedEmitter<ConditionalStorageEvents>) {


### PR DESCRIPTION
The function of containerItems is missing from chest / dispenser / and furnance
This function is extended from windows

Also "openContainer" no works with furnance