### PR TITLE
Add options to control block validation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1988,10 +1988,11 @@ Example `options` argument:
   trackOutput: true,
   conditional: false,
   alwaysActive: true
+  checkblock: true
 }
 ```
 options.mode can have 3 values: 0 (SEQUENCE), 1 (AUTO), 2 (REDSTONE)
-All options attributes are false by default, except mode which is 2 (as to replicate the default command block in Minecraft).
+All options attributes are false by default, except mode which is 2 (as to replicate the default command block in Minecraft) and checkblock which is true (to verify that there is a command block at those coordinates).
 
 #### bot.supportFeature(name)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1987,7 +1987,7 @@ Example `options` argument:
   mode: 2,
   trackOutput: true,
   conditional: false,
-  alwaysActive: true
+  alwaysActive: true,
   checkblock: true
 }
 ```

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -9,7 +9,7 @@ function inject (bot) {
     assert.notStrictEqual(pos, null)
     assert.notStrictEqual(command, null)
     if (options.checkblock !== false) {
-     assert.strictEqual(bot.blockAt(pos).name.includes('command_block'), true, new Error("The block isn't a command block"))
+      assert.strictEqual(bot.blockAt(pos).name.includes('command_block'), true, new Error("The block isn't a command block"))
     }
     // Default values when a command block is placed in vanilla minecraft
     options.checkblock = options.checkblock ?? true // Check if the block is a command block

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -8,9 +8,11 @@ function inject (bot) {
     assert.strictEqual(bot.player.gamemode, 1, new Error('The bot has to be in creative mode to open the command block window'))
     assert.notStrictEqual(pos, null)
     assert.notStrictEqual(command, null)
-    assert.strictEqual(bot.blockAt(pos).name.includes('command_block'), true, new Error("The block isn't a command block"))
-
+    if (options.checkblock != false) {
+     assert.strictEqual(bot.blockAt(pos).name.includes('command_block'), true, new Error("The block isn't a command block"))
+    }
     // Default values when a command block is placed in vanilla minecraft
+    options.checkblock = options.checkblock ?? true // Check if the block is a command block
     options.trackOutput = options.trackOutput ?? false
     options.conditional = options.conditional ?? false
     options.alwaysActive = options.alwaysActive ?? false

--- a/lib/plugins/command_block.js
+++ b/lib/plugins/command_block.js
@@ -8,7 +8,7 @@ function inject (bot) {
     assert.strictEqual(bot.player.gamemode, 1, new Error('The bot has to be in creative mode to open the command block window'))
     assert.notStrictEqual(pos, null)
     assert.notStrictEqual(command, null)
-    if (options.checkblock != false) {
+    if (options.checkblock !== false) {
      assert.strictEqual(bot.blockAt(pos).name.includes('command_block'), true, new Error("The block isn't a command block"))
     }
     // Default values when a command block is placed in vanilla minecraft


### PR DESCRIPTION
setting for a problem I've had and think others may have as well.
The problem is that the bot teleports to a certain place and placing a command block there by commands (like /setblock) but it cannot detect it and cannot write anything in it but it can write something if we add this options.
