### PR TITLE
Extend every window that is opened

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -588,6 +588,7 @@ function inject (bot, { hideErrors }) {
     if (!windowItems || window.id !== windowItems.windowId) {
       // don't emit windowOpen until we have the slot data
       bot.once(`setWindowItems:${window.id}`, () => {
+        extendWindow(window)
         bot.emit('windowOpen', window)
       })
     } else {
@@ -596,6 +597,7 @@ function inject (bot, { hideErrors }) {
         window.updateSlot(i, item)
       }
       updateHeldItem()
+      extendWindow(window)
       bot.emit('windowOpen', window)
     }
   }


### PR DESCRIPTION
Not all windows that are emitted with windowOpen include withdraw, deposit and close. 
Especially close is really important when having windows open. I am not 100% sure if withdraw and deposit work with all types off windows that can be opened. Maybe someone can test it?