### PR TITLE
Fix inventory event emitter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -177,7 +177,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   physicsEnabled: boolean
   time: Time
   quickBarSlot: number
-  inventory: Window
+  inventory: Window<StorageEvents>
   targetDigBlock: Block
   isSleeping: boolean
   scoreboards: { [name: string]: ScoreBoard }
@@ -606,7 +606,7 @@ export class Painting {
 interface StorageEvents {
   open: () => void
   close: () => void
-  updateSlot: (oldItem: Item | null, newItem: Item) => void
+  updateSlot: (oldItem: Item | null, newItem: Item | null) => void
 }
 
 interface FurnaceEvents extends StorageEvents {


### PR DESCRIPTION
Current event emitter types in mineflayer are broken and cause typescript project to not compile. This should fix that. 