### PR TITLE
Added attachEntity and detatchEntity functionality to versions past 1.8 #2819

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -354,6 +354,27 @@ function inject (bot) {
     }
   })
 
+  bot._client.on('set_passengers', (packet) => {
+    //set_passengers for versions past 1.8
+    const entity = fetchEntity(packet.entityId)
+    if (!entity.passengerCount){
+      entity.passengerCount = packet.passengers.length
+      bot.emit('entityAttach', entity)
+    }
+    else if (packet.passengers.length === 1){
+      entity.passengerCount = 1
+      bot.emit('entityDetach', entity)
+    }
+    else if (!packet.passengers.length){
+      delete entity.passengerCount
+      bot.emit('entityDetach', entity)
+    }
+    else {
+      entity.passengerCount = 2
+      bot.emit('entityAttach', entity)
+    }
+  })
+
   bot._client.on('entity_metadata', (packet) => {
     // entity metadata
     const entity = fetchEntity(packet.entityId)

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -359,12 +359,12 @@ function inject (bot) {
     const entity = fetchEntity(packet.entityId) // entity of the vehicle
     if (!entity.passengerCount) { // if passengerCount DNE, create it. entity must be attaching
       entity.passengerCount = packet.passengers.length
-      bot.emit('entityAttach', entity) 
+      bot.emit('entityAttach', entity)
     } else if (packet.passengers.length === 1) { // if pasengerCount exists + passengers array is len 1, must be detaching
       entity.passengerCount = 1
       bot.emit('entityDetach', entity)
     } else if (!packet.passengers.length) { // if passengers array is empty, detaching
-      delete entity.passengerCount  
+      delete entity.passengerCount
       bot.emit('entityDetach', entity)
     } else { // else passengers array must have two members and must be attaching
       entity.passengerCount = 2

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -355,21 +355,18 @@ function inject (bot) {
   })
 
   bot._client.on('set_passengers', (packet) => {
-    //set_passengers for versions past 1.8
+    // set_passengers for versions past 1.8
     const entity = fetchEntity(packet.entityId)
-    if (!entity.passengerCount){
+    if (!entity.passengerCount) {
       entity.passengerCount = packet.passengers.length
       bot.emit('entityAttach', entity)
-    }
-    else if (packet.passengers.length === 1){
+    } else if (packet.passengers.length === 1) {
       entity.passengerCount = 1
       bot.emit('entityDetach', entity)
-    }
-    else if (!packet.passengers.length){
+    } else if (!packet.passengers.length) {
       delete entity.passengerCount
       bot.emit('entityDetach', entity)
-    }
-    else {
+    } else {
       entity.passengerCount = 2
       bot.emit('entityAttach', entity)
     }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -356,17 +356,17 @@ function inject (bot) {
 
   bot._client.on('set_passengers', (packet) => {
     // set_passengers for versions past 1.8
-    const entity = fetchEntity(packet.entityId)
-    if (!entity.passengerCount) {
+    const entity = fetchEntity(packet.entityId) // entity of the vehicle
+    if (!entity.passengerCount) { // if passengerCount DNE, create it. entity must be attaching
       entity.passengerCount = packet.passengers.length
-      bot.emit('entityAttach', entity)
-    } else if (packet.passengers.length === 1) {
+      bot.emit('entityAttach', entity) 
+    } else if (packet.passengers.length === 1) { // if pasengerCount exists + passengers array is len 1, must be detaching
       entity.passengerCount = 1
       bot.emit('entityDetach', entity)
-    } else if (!packet.passengers.length) {
-      delete entity.passengerCount
+    } else if (!packet.passengers.length) { // if passengers array is empty, detaching
+      delete entity.passengerCount  
       bot.emit('entityDetach', entity)
-    } else {
+    } else { // else passengers array must have two members and must be attaching
       entity.passengerCount = 2
       bot.emit('entityAttach', entity)
     }


### PR DESCRIPTION
As mentioned in #2819, just added an event for `set_passengers` in entities.js. Attaching and detaching now works as expected as far as triggering the events; however, the return values only include the vehicle. This is because `set_passengers` itself has no way of tracking the previous passenger state of the vehicle unlike `attach_entity`, and thus there is no way with just that function to be able to tell which entity has been attached/detached in certain cases.