### PR TITLE
Fix unhandled promise rejection in onceWithCleanup

### DIFF
--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -67,7 +67,7 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
     })
   }
 
-  task.promise.finally(() => emitter.removeListener(event, onEvent))
+  task.promise.finally(() => emitter.removeListener(event, onEvent)).catch((err) => {})
 
   return task.promise
 }

--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -67,7 +67,7 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
     })
   }
 
-  task.promise.finally(() => emitter.removeListener(event, onEvent)).catch((err) => {})
+  task.promise.catch(() => {}).finally(() => emitter.removeListener(event, onEvent))
 
   return task.promise
 }


### PR DESCRIPTION
From MDN:

> Returns an equivalent Promise with its finally handler set to the specified function. If the handler throws an error or returns a rejected promise, the promise returned by finally() will be rejected with that value instead

So finally will throw an unhandled promise rejection if the task promise rejects. Causing a un-catchable promise rejection on the onceWithCleanup function