### PR TITLE
Update chat parsing

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -113,30 +113,18 @@ function inject (bot, options) {
     const verified = data.verified
     let msg
     if (bot.supportFeature('clientsideChatFormatting')) {
-      let sender
-
-      try {
-        sender = JSON.parse(data.senderName)
-      } catch {
-        sender = {
-          insertion: data.senderName,
-          clickEvent: { action: 'suggest_command', value: `/tell ${data.senderName} ` },
-          hoverEvent: { action: 'show_entity', contents: { id: bot.findPlayer(data.senderName).id, name: data.senderName } },
-          text: data.senderName
-        }
-      }
-
       const parameters = {
-        sender,
+        sender: data.senderName ? JSON.parse(data.senderName) : undefined,
+        target: data.targetName ? JSON.parse(data.targetName) : undefined,
         content: message ? JSON.parse(message) : { text: data.plainMessage }
       }
       msg = ChatMessage.fromNetwork(data.type, parameters)
 
       if (data.unsignedContent) {
-        msg.unsigned = ChatMessage.fromNetwork(data.type, { sender, content: JSON.parse(data.unsignedContent) })
+        msg.unsigned = ChatMessage.fromNetwork(data.type, { sender: parameters.sender, target: parameters.target, content: JSON.parse(data.unsignedContent) })
       }
     } else {
-      msg = ChatMessage.fromNotch(data.formattedMessage)
+      msg = ChatMessage.fromNotch(message)
     }
     bot.emit('message', msg, 'chat', data.sender, verified)
     bot.emit('messagestr', msg.toString(), 'chat', msg, data.sender, verified)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "minecraft-data": "^3.15.2",
-    "minecraft-protocol": "^1.40.1",
+    "minecraft-protocol": "^1.40.2",
     "prismarine-biome": "^1.1.1",
     "prismarine-block": "^1.13.1",
     "prismarine-chat": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "minecraft-data": "^3.15.2",
-    "minecraft-protocol": "^1.40.0",
+    "minecraft-protocol": "^1.40.1",
     "prismarine-biome": "^1.1.1",
     "prismarine-block": "^1.13.1",
     "prismarine-chat": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "minecraft-data": "^3.15.2",
-    "minecraft-protocol": "^1.38.1",
+    "minecraft-protocol": "^1.40.0",
     "prismarine-biome": "^1.1.1",
     "prismarine-block": "^1.13.1",
     "prismarine-chat": "^1.7.1",

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -148,7 +148,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
               plainMessage: 'hello',
               filterType: 0,
               type: 0,
-              networkName: '',
+              networkName: JSON.stringify({ text: 'gary' }),
               previousMessages: [],
               senderUuid: uuid,
               timestamp: Date.now(),


### PR DESCRIPTION
Depends on https://github.com/PrismarineJS/node-minecraft-protocol/pull/1068


- Adds targetName to ChatMessage parameters for parsing chat types `minecraft:msg_command_outgoing`, `minecraft:team_msg_command_incoming` and `minecraft:team_msg_command_outgoing`