### PR TITLE
Added missing type value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -567,6 +567,7 @@ export interface TransferOptions {
   window: Window
   itemType: number
   metadata: number | null
+  count?: number,
   sourceStart: number
   sourceEnd: number
   destStart: number


### PR DESCRIPTION
Adding missing type value,

Is used on transfer but not are in types, this value is optinal:

https://github.com/PrismarineJS/mineflayer/blob/4734f0e808b52c762bc22380ecd78aa9135a6e37/lib/plugins/inventory.js#L228-L243