### PR TITLE
Improve look and fix bug slow craft

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -235,6 +235,10 @@ function inject (bot, { physicsEnabled }) {
     const yawChange = Math.round((yaw - bot.entity.yaw) / sensitivity) * sensitivity
     const pitchChange = Math.round((pitch - bot.entity.pitch) / sensitivity) * sensitivity
 
+    if (yawChange === 0 && pitchChange === 0) {
+      return true
+    }
+
     bot.entity.yaw += yawChange
     bot.entity.pitch += pitchChange
 
@@ -243,7 +247,7 @@ function inject (bot, { physicsEnabled }) {
       lastSentPitch = pitch
       return
     }
-
+    
     await lookingTask.promise
   }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -247,7 +247,7 @@ function inject (bot, { physicsEnabled }) {
       lastSentPitch = pitch
       return
     }
-    
+
     await lookingTask.promise
   }
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -236,7 +236,7 @@ function inject (bot, { physicsEnabled }) {
     const pitchChange = Math.round((pitch - bot.entity.pitch) / sensitivity) * sensitivity
 
     if (yawChange === 0 && pitchChange === 0) {
-      return true
+      return
     }
 
     bot.entity.yaw += yawChange


### PR DESCRIPTION
Hi guys i found the issue why crafting are too slow,

The issue comes because is executing a lot of time ```bot.activateBlock```
This command execute bot.look, 

But when are crafting 1 times is fine, but when you craft a alot of items they are executed one time for craft,
The issue comes because this function is added on task, and need to wait to execute task to finish craft, this delays 1 second for craft,

I fixed easly, if the look are already looking to point then no eed to create new task, and return true,

This also improve the speed for other functions when no need to look the point

Issues related:
https://github.com/PrismarineJS/mineflayer/issues/2574
https://github.com/PrismarineJS/mineflayer/issues/257

Note: one of the bug "still" are opening and closing the windows each time to craft, i think i will make another pr to fix them, but is a different issue
