### PR TITLE
*: update dep and make tweaks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export interface PluginOptions {
 
 export type Plugin = (bot: Bot, options: BotOptions) => void
 
-interface BotEvents {
+type BotEvents = {
   chat: (
     username: string,
     message: string,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prismarine-windows": "^2.5.0",
     "prismarine-world": "^3.6.0",
     "protodef": "^1.14.0",
-    "typed-emitter": "^1.0.0",
+    "typed-emitter": "^2.1.0",
     "vec3": "^0.1.7"
   },
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
       "module": "commonjs",
-      "strictNullChecks": true
+      "strictNullChecks": true,
+      "esModuleInterop": true
     },
     "files": [
       "index.d.ts"


### PR DESCRIPTION
- Update the `typed-emitter` dependency to it's latest version.
- The `BotEvents` interface is supposed to be a type instead of an interface, required by the latest versions of the `typed-emitter` dependency.
- Set the `esModuleInterop` compiler option to `true` required to import type definitions of some of the updated dependencies.