### PR TITLE
meta: update GitHub workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js 14.x
-      uses: actions/setup-node@v1.4.4
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 14
+        check-latest: true
     - run: npm i && npm run lint
 
   MinecraftServer:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        javaVersion: [1.8]
+        javaVersion: [8]
         mcVersion: ['1.8.8', '1.9.4', '1.10.2', '1.11.2', '1.12.2', '1.13.2', '1.14.4', '1.15.2', '1.16.5']
         include:
-         - javaVersion: 16
+         - javaVersion: 17
            mcVersion: '1.17.1'
          - javaVersion: 17
            mcVersion: '1.18.2'
@@ -38,16 +39,19 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1.4.4
+      - uses: actions/checkout@v3
+      - name: Use Node.js 14
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 14
+          check-latest: true
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.javaVersion }}
           java-package: jre
+          check-latest: true
       - name: Install Dependencies
         run: npm install
       - name: Start Tests

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
     - name: Set up Node.js
-      uses: actions/setup-node@master
+      uses: actions/setup-node@v3
       with:
-        node-version: 14.0.0
+        node-version: 14
+        check-latest: true
     - id: publish
       uses: JS-DevTools/npm-publish@v1
       with:
@@ -21,12 +22,12 @@ jobs:
     - name: Create Release
       if: steps.publish.outputs.type != 'none'
       id: create_release
-      uses: actions/create-release@v1
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         tag_name: ${{ steps.publish.outputs.version }}
-        release_name: Release ${{ steps.publish.outputs.version }}
+        name: Release ${{ steps.publish.outputs.version }}
         body: ${{ steps.publish.outputs.version }}
         draft: false
         prerelease: false


### PR DESCRIPTION
- Update the GitHub workflow actions to their latest versions.
- Switch to the `softprops/action-gh-release` action as the `actions/create-release` action is no longer maintained.