### PR TITLE
Fix player entity being unset when player is updated

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -484,7 +484,7 @@ function inject (bot) {
           Object.assign(player, obj)
         }
 
-        const playerEntity = Object.values(bot.entities).find(e => e.type === 'player' && e.username === obj.username)
+        const playerEntity = Object.values(bot.entities).find(e => e.type === 'player' && e.username === player.username)
         player.entity = playerEntity
 
         if (playerEntity === bot.entity) {


### PR DESCRIPTION
1.19.3 player_info parsing currently expects the username field to always be present. This means the player entity will be undefined when that is not the case.

With this PR the entity is found using the existing player object instead.