### PR TITLE
Fix not updating world height on respawn packet

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -48,6 +48,9 @@ function inject (bot, options) {
         bot.game.height = height
       } else if (packet.dimension) { // respawn
         bot.game.dimension = packet.dimension.replace('minecraft:', '')
+        const { minY, height } = bot.registry.dimensionsByName[bot.game.dimension]
+        bot.game.minY = minY
+        bot.game.height = height
       }
     } else if (bot.supportFeature('dimensionDataIsAvailable')) { // 1.18
       const dimensionData = nbt.simplify(packet.dimension)


### PR DESCRIPTION
Failing to update world height on dimension change causes mineflayer to throw errors when switching to a dimension with less sections per column.

This PR should also fix failing CI in https://github.com/PrismarineJS/mineflayer/pull/2932