### PR TITLE
Persist properties received in player_info packet

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
     - [vec3](#vec3)
     - [mineflayer.Location](#mineflayerlocation)
     - [Entity](#entity)
+      - [Player Skin Data](#player-skin-data)
     - [Block](#block)
     - [Biome](#biome)
     - [Item](#item)
@@ -404,6 +405,18 @@ properties.
 Entities represent players, mobs, and objects. They are emitted
 in many events, and you can access your own entity with `bot.entity`.
 See [prismarine-entity](https://github.com/PrismarineJS/prismarine-entity)
+
+#### Player Skin Data
+
+The skin data is stored in the `skinData` property of the player object, if present.
+
+```js
+// player.skinData
+{
+  url: 'http://textures.minecraft.net/texture/...',
+  model: 'slim' // or 'classic'
+}
+```
 
 ### Block
 

--- a/examples/skin_data.js
+++ b/examples/skin_data.js
@@ -1,0 +1,26 @@
+/*
+ * This script will automatically set if a totem is in the inventory or the off-hand.
+ * It checks for a totem every tick.
+ */
+const mineflayer = require('mineflayer')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node skin_data.js <host> <port> [<name>] [<password>]')
+  process.exit(1)
+}
+
+const bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4] ? process.argv[4] : 'skin_data',
+  password: process.argv[5]
+})
+
+setTimeout(() => {
+  bot.quit()
+  console.log('Skin data:')
+  console.log(Object.entries(bot.players).map(([name, player]) => ({
+    name,
+    skinData: player.skinData
+  })))
+}, 10000)

--- a/index.d.ts
+++ b/index.d.ts
@@ -459,10 +459,16 @@ export interface Player {
   gamemode: number
   ping: number
   entity: Entity
+  skinData: SkinData | undefined
   profileKeys?: {
     publicKey: Buffer
     signature: Buffer
   }
+}
+
+export interface SkinData {
+  url: string
+  model: string | null
 }
 
 export interface ChatPattern {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -462,6 +462,7 @@ function inject (bot) {
         if (packet.action & 1) {
           obj.username = item.player.name
           obj.displayName = player.displayName || new ChatMessage({ text: '', extra: [{ text: item.player.name }] })
+          obj.skinData = extractSkinInformation(item.player.properties)
         }
 
         if (packet.action & 4) {
@@ -510,6 +511,7 @@ function inject (bot) {
               ping: item.ping,
               uuid: item.UUID,
               displayName: new ChatMessage({ text: '', extra: [{ text: item.name }] }),
+              skinData: extractSkinInformation(item.properties),
               profileKeys: item.crypto
                 ? {
                     publicKey: item.crypto.publicKey, // DER-encoded public key
@@ -525,6 +527,7 @@ function inject (bot) {
             // Just an Update
             player.gamemode = item.gamemode
             player.ping = item.ping
+            player.skinData = extractSkinInformation(item.properties)
             if (item.crypto) {
               player.profileKeys = {
                 publicKey: item.crypto.publicKey,
@@ -705,4 +708,26 @@ function parseMetadata (metadata, entityMetadata = {}) {
   }
 
   return entityMetadata
+}
+
+function extractSkinInformation (properties) {
+  if (!properties) {
+    return undefined
+  }
+
+  const props = Object.fromEntries(properties.map((e) => [e.name, e]))
+  if (!props.textures || !props.textures.value) {
+    return undefined
+  }
+
+  const skinTexture = JSON.parse(Buffer.from(props.textures.value, 'base64').toString('utf8'))
+
+  const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? null
+  const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? null
+
+  if (!skinTextureUrl) {
+    return undefined
+  }
+
+  return { url: skinTextureUrl, model: skinTextureModel }
 }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -722,8 +722,8 @@ function extractSkinInformation (properties) {
 
   const skinTexture = JSON.parse(Buffer.from(props.textures.value, 'base64').toString('utf8'))
 
-  const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? null
-  const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? null
+  const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? undefined
+  const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? undefined
 
   if (!skinTextureUrl) {
     return undefined


### PR DESCRIPTION
This changes persists the 'properties' property in the player object when received
via the player_info packet. Now its possible to access properties on the player object
like the textures property which contains skin information about the player.
