### PR TITLE
Fix reference error with block updates

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -813,16 +813,14 @@ A sync representation of the world. Check the doc at http://github.com/Prismarin
 ##### world "blockUpdate" (oldBlock, newBlock)
 
 Fires when a block updates. Both `oldBlock` and `newBlock` provided for
-comparison.
-
-Note that `oldBlock` may be `null`.
+comparison. All listeners receive null for `oldBlock` and `newBlock` when the world is unloaded. 
+`oldBlock` may be `null` with normal block updates.
 
 ##### world "blockUpdate:(x, y, z)" (oldBlock, newBlock)
 
 Fires for a specific point. Both `oldBlock` and `newBlock` provided for
-comparison.
-
-Note that `oldBlock` may be `null`.
+comparison. All listeners receive null for `oldBlock` and `newBlock` when the world is unloaded.
+`oldBlock` may be `null` with normal block updates.
 
 
 #### bot.entity

--- a/docs/api.md
+++ b/docs/api.md
@@ -813,13 +813,13 @@ A sync representation of the world. Check the doc at http://github.com/Prismarin
 ##### world "blockUpdate" (oldBlock, newBlock)
 
 Fires when a block updates. Both `oldBlock` and `newBlock` provided for
-comparison. All listeners receive null for `oldBlock` and `newBlock` when the world is unloaded. 
+comparison.
 `oldBlock` may be `null` with normal block updates.
 
 ##### world "blockUpdate:(x, y, z)" (oldBlock, newBlock)
 
 Fires for a specific point. Both `oldBlock` and `newBlock` provided for
-comparison. All listeners receive null for `oldBlock` and `newBlock` when the world is unloaded.
+comparison. All listeners receive null for `oldBlock` and `newBlock` and get automatically removed when the world is unloaded.
 `oldBlock` may be `null` with normal block updates.
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,8 +103,8 @@ interface BotEvents {
   playerJoined: (player: Player) => Promise<void> | void
   playerUpdated: (player: Player) => Promise<void> | void
   playerLeft: (entity: Player) => Promise<void> | void
-  blockUpdate: (oldBlock: Block | null, newBlock: Block) => Promise<void> | void
-  'blockUpdate:(x, y, z)': (oldBlock: Block | null, newBlock: Block) => Promise<void> | void
+  blockUpdate: (oldBlock: Block | null, newBlock: Block | null) => Promise<void> | void
+  'blockUpdate:(x, y, z)': (oldBlock: Block | null, newBlock: Block | null) => Promise<void> | void
   chunkColumnLoad: (entity: Vec3) => Promise<void> | void
   chunkColumnUnload: (entity: Vec3) => Promise<void> | void
   soundEffectHeard: (

--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,7 @@ interface BotEvents {
   playerJoined: (player: Player) => Promise<void> | void
   playerUpdated: (player: Player) => Promise<void> | void
   playerLeft: (entity: Player) => Promise<void> | void
-  blockUpdate: (oldBlock: Block | null, newBlock: Block | null) => Promise<void> | void
+  blockUpdate: (oldBlock: Block | null, newBlock: Block) => Promise<void> | void
   'blockUpdate:(x, y, z)': (oldBlock: Block | null, newBlock: Block | null) => Promise<void> | void
   chunkColumnLoad: (entity: Vec3) => Promise<void> | void
   chunkColumnUnload: (entity: Vec3) => Promise<void> | void

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -162,7 +162,8 @@ function inject (bot) {
     function onBlockUpdate (oldBlock, newBlock) {
       // vanilla server never actually interrupt digging, but some server send block update when you start digging
       // so ignore block update if not air
-      if (newBlock.type !== 0) return
+      // All block update listeners receive (null, null) when the world is unloaded. So newBlock can be null.
+      if (newBlock?.type !== 0) return
       bot.removeListener(eventName, onBlockUpdate)
       clearInterval(swingInterval)
       clearTimeout(waitTimeout)

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -17,7 +17,7 @@ function inject (bot) {
     if (!oldBlock && !newBlock) {
       return
     }
-    if (oldBlock?.type === newBlock?.type) {
+    if (oldBlock?.type === newBlock.type) {
       throw new Error(`No block has been placed : the block is still ${oldBlock?.name}`)
     } else {
       bot.emit('blockPlaced', oldBlock, newBlock)

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -13,8 +13,12 @@ function inject (bot) {
       [oldBlock, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, { timeout: 5000 })
     }
 
-    if (oldBlock.type === newBlock.type) {
-      throw new Error(`No block has been placed : the block is still ${oldBlock.name}`)
+    // blockUpdate emits (null, null) when the world unloads
+    if (!oldBlock && !newBlock) {
+      return
+    }
+    if (oldBlock?.type === newBlock?.type) {
+      throw new Error(`No block has been placed : the block is still ${oldBlock?.name}`)
     } else {
       bot.emit('blockPlaced', oldBlock, newBlock)
     }


### PR DESCRIPTION
Both oldBlock and newBlock in block updates can be null. This was causing some reference errors in mineflayer.