### PR TITLE
fix_dimension 2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -449,7 +449,7 @@ export type LevelType =
   | 'buffet'
   | 'default_1_1'
 export type GameMode = 'survival' | 'creative' | 'adventure' | 'spectator'
-export type Dimension = 'minecraft:the_nether' | 'minecraft:overworld' | 'minecraft:the_end'
+export type Dimension = 'the_nether' | 'overworld' | 'the_end'
 export type Difficulty = 'peaceful' | 'easy' | 'normal' | 'hard'
 
 export interface Player {


### PR DESCRIPTION
A few months i did pr changing this, https://github.com/PrismarineJS/mineflayer/pull/2732

But from another pr the types has been changed:

https://github.com/PrismarineJS/mineflayer/blame/55d73fb968342518e5b4f05d2991a637753898c3/lib/plugins/game.js#L43-L66

https://github.com/PrismarineJS/mineflayer/pull/2743/files#diff-94e0a8343c4881e61ff94f1f4e3501d51f052e02c9e9366542a133e6a2eb786f

Now game returns withouth minecraft:

![image](https://user-images.githubusercontent.com/20754836/222892791-94daf6ef-e478-4b00-a627-549c241b5003.png)
