### PR TITLE
Standardize dimensions for all versions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -866,7 +866,7 @@ Whether the bot is using the item that it's holding, for example eating food or 
 
 #### bot.game.dimension
 
-The bot's current dimension, such as `overworld, `the_end` or `the_nether`.
+The bot's current dimension, such as `overworld`, `the_end` or `the_nether`.
 
 #### bot.game.difficulty
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -866,6 +866,8 @@ Whether the bot is using the item that it's holding, for example eating food or 
 
 #### bot.game.dimension
 
+The bot's current dimension, such as `overworld, `the_end` or `the_nether`.
+
 #### bot.game.difficulty
 
 #### bot.game.gameMode

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -275,7 +275,7 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       bitMap: packet.bitMap,
       heightmaps: packet.heightmaps,
       biomes: packet.biomes,
-      skyLightSent: bot.game.dimension === 'minecraft:overworld',
+      skyLightSent: bot.game.dimension === 'overworld',
       groundUp: packet.groundUp,
       data: packet.chunkData,
       trustEdges: packet.trustEdges,

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -42,12 +42,12 @@ function inject (bot, options) {
 
     if (bot.supportFeature('dimensionDataInCodec')) { // 1.19+
       if (packet.worldType) { // login
-        bot.game.dimension = packet.worldType.replace('minecraft:', '')
+        bot.game.dimension = packet.worldType
         const { minY, height } = bot.registry.dimensionsByName[bot.game.dimension]
         bot.game.minY = minY
         bot.game.height = height
       } else if (packet.dimension) { // respawn
-        bot.game.dimension = packet.dimension.replace('minecraft:', '')
+        bot.game.dimension = packet.dimension
         const { minY, height } = bot.registry.dimensionsByName[bot.game.dimension]
         bot.game.minY = minY
         bot.game.height = height
@@ -60,6 +60,7 @@ function inject (bot, options) {
       bot.game.minY = 0
       bot.game.height = 256
     }
+    bot.game.dimension = bot.game.dimension.replace('minecraft:', '')
     if (packet.difficulty) {
       bot.game.difficulty = difficultyNames[packet.difficulty]
     }

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -5,9 +5,9 @@ const difficultyNames = ['peaceful', 'easy', 'normal', 'hard']
 const gameModes = ['survival', 'creative', 'adventure']
 
 const dimensionNames = {
-  '-1': 'minecraft:nether',
-  0: 'minecraft:overworld',
-  1: 'minecraft:end'
+  '-1': 'the_nether',
+  0: 'overworld',
+  1: 'the_end'
 }
 
 const parseGameMode = gameModeBits => gameModes[(gameModeBits & 0b11)] // lower two bits
@@ -29,9 +29,9 @@ function inject (bot, options) {
     if (bot.supportFeature('dimensionIsAnInt')) {
       bot.game.dimension = dimensionNames[packet.dimension]
     } else if (bot.supportFeature('dimensionIsAString')) {
-      bot.game.dimension = packet.dimension
+      bot.game.dimension = packet.dimension.replace('minecraft:', '')
     } else if (bot.supportFeature('dimensionIsAWorld')) {
-      bot.game.dimension = packet.worldName
+      bot.game.dimension = packet.worldName.replace('minecraft:', '')
     } else {
       throw new Error('Unsupported dimension type in login packet')
     }
@@ -42,12 +42,12 @@ function inject (bot, options) {
 
     if (bot.supportFeature('dimensionDataInCodec')) { // 1.19+
       if (packet.worldType) { // login
-        bot.game.dimension = packet.worldType
+        bot.game.dimension = packet.worldType.replace('minecraft:', '')
         const { minY, height } = bot.registry.dimensionsByName[bot.game.dimension]
         bot.game.minY = minY
         bot.game.height = height
       } else if (packet.dimension) { // respawn
-        bot.game.dimension = packet.dimension
+        bot.game.dimension = packet.dimension.replace('minecraft:', '')
         const { minY, height } = bot.registry.dimensionsByName[bot.game.dimension]
         bot.game.minY = minY
         bot.game.height = height
@@ -60,7 +60,7 @@ function inject (bot, options) {
       bot.game.minY = 0
       bot.game.height = 256
     }
-    bot.game.dimension = bot.game.dimension.replace('minecraft:', '')
+
     if (packet.difficulty) {
       bot.game.difficulty = difficultyNames[packet.difficulty]
     }


### PR DESCRIPTION
Hello guys, i checked when game is lower than 1.19- the game.dimension is returning minecraft:XXX but in 1.19+ is the dimension directly,

I made changes to unify them