### PR TITLE
Emit inject_allowed after a timeout of 0

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -123,7 +123,7 @@ function createBot (options = {}) {
     bot.version = version.minecraftVersion
     options.version = version.minecraftVersion
     bot.supportFeature = bot.registry.supportFeature
-    bot.emit('inject_allowed')
+    setTimeout(() => bot.emit('inject_allowed'), 0)
   }
   return bot
 }


### PR DESCRIPTION
The current implementation can in some cases emit the inject_allowed event synchronously within createBot. This makes it impossible to listen to that event on the bot object after createBot. Using setTimeout will schedule the event emitting in the next cycle giving other code outside of createBot enough time to register event listeners for inject_allowed.