### PR TITLE
fix type definition in regards to documentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -565,7 +565,7 @@ export interface FindBlockOptions {
   matching: number | number[] | ((block: Block) => boolean)
   maxDistance?: number
   count?: number
-  useExtraInfo?: boolean
+  useExtraInfo?: boolean | ((block: Block) => boolean)
 }
 
 export type EquipmentDestination = 'hand' | 'head' | 'torso' | 'legs' | 'feet' | 'off-hand'


### PR DESCRIPTION
As written in the API Docs(https://github.com/PrismarineJS/mineflayer/blob/master/docs/api.md#botfindblocksoptions) `useExtraInfo` can be a boolean or a function, the typings do not reflect that.