### PR TITLE
Add window transaction timeout

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -547,6 +547,9 @@ function inject (bot, { hideErrors }) {
         confirmTransaction(window.id, actionId, true)
       }
       const [success] = await withTimeout(response, WINDOW_TIMEOUT)
+      .catch(() => {
+        throw new Error(`Server didn't respond to transaction for clicking on slot ${slot} on window with id ${window?.id}.`)
+      })
       if (!success) {
         throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window with id ${window?.id}.`)
       }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -547,9 +547,9 @@ function inject (bot, { hideErrors }) {
         confirmTransaction(window.id, actionId, true)
       }
       const [success] = await withTimeout(response, WINDOW_TIMEOUT)
-      .catch(() => {
-        throw new Error(`Server didn't respond to transaction for clicking on slot ${slot} on window with id ${window?.id}.`)
-      })
+        .catch(() => {
+          throw new Error(`Server didn't respond to transaction for clicking on slot ${slot} on window with id ${window?.id}.`)
+        })
       if (!success) {
         throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window with id ${window?.id}.`)
       }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -12,6 +12,8 @@ const DIG_CLICK_TIMEOUT = 500
 // This number is larger than the eat time of 1.61 seconds to account for latency and low tps.
 // The eat time comes from https://minecraft.fandom.com/wiki/Food#Usage
 const CONSUME_TIMEOUT = 2500
+// milliseconds to wait for the server to respond to a window click transaction
+const WINDOW_TIMEOUT = 5000
 
 const ALWAYS_CONSUMABLES = [
   'potion',
@@ -544,7 +546,7 @@ function inject (bot, { hideErrors }) {
       if (!window.transactionRequiresConfirmation(click)) {
         confirmTransaction(window.id, actionId, true)
       }
-      const [success] = await response
+      const [success] = await withTimeout(response, WINDOW_TIMEOUT)
       if (!success) {
         throw new Error(`Server rejected transaction for clicking on slot ${slot}, on window with id ${window?.id}.`)
       }


### PR DESCRIPTION
Fixes a memory leak if the server doesn't respond to a window transaction, causing multiple listeners to be created without the promise resolving (if `bot.clickWindow` is called multiple times)