### PR TITLE
Add `spectator` to gameModes array

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -2,7 +2,7 @@ const nbt = require('prismarine-nbt')
 module.exports = inject
 
 const difficultyNames = ['peaceful', 'easy', 'normal', 'hard']
-const gameModes = ['survival', 'creative', 'adventure']
+const gameModes = ['survival', 'creative', 'adventure', 'spectator']
 
 const dimensionNames = {
   '-1': 'minecraft:nether',


### PR DESCRIPTION
This PR is a fix to the following bug: When in spectator mode, `bot.game.gameMode` is `undefined`.

The affected lines were first implemented in https://github.com/PrismarineJS/mineflayer/commit/ad52fcaee0fc0529796f3ed37ea11346b1efdc55.