### PR TITLE
Emit heldItemChanged when held item slot is changed

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -587,6 +587,8 @@ function inject (bot, { hideErrors }) {
   bot._client.on('held_item_slot', (packet) => {
     // held item change
     bot.setQuickBarSlot(packet.slot)
+    // if slot is updated, held item is also updated
+    updateHeldItem()
   })
 
   function prepareWindow (window) {


### PR DESCRIPTION
As opposed to only emitting when the hotbar slot item contents has changed, the held item also changes when using scroll wheel