### PR TITLE
Fix attempting to access unloaded chunks when updating block entity data

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -413,11 +413,13 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
   bot._client.on('tile_entity_data', (packet) => {
     if (packet.location !== undefined) {
       const column = bot.world.getColumn(packet.location.x >> 4, packet.location.z >> 4)
+      if (!column) return
       const pos = new Vec3(packet.location.x & 0xf, packet.location.y, packet.location.z & 0xf)
       column.setBlockEntity(pos, packet.nbtData)
     } else {
       const tag = packet.nbtData
       const column = bot.world.getColumn(tag.value.x.value >> 4, tag.value.z.value >> 4)
+      if (!column) return
       const pos = new Vec3(tag.value.x.value & 0xf, tag.value.y.value, tag.value.z.value & 0xf)
       column.setBlockEntity(pos, tag)
     }


### PR DESCRIPTION
Some servers may send block entity data before sending chunk data (no clue why). This causes mineflayer to throw because the chunk is assumed to be loaded.

This fix mirrors the Vanilla client implementation (ignore data if chunk is not loaded)