### PR TITLE
Enchantments minor restructure

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -730,6 +730,7 @@ export class Anvil {
 
 export interface Enchantment {
   level: number
+  expected: { enchant: string | null, level: number }
 }
 
 export class Villager extends Window<ConditionalStorageEvents> {

--- a/lib/plugins/enchantment_table.js
+++ b/lib/plugins/enchantment_table.js
@@ -40,7 +40,10 @@ function inject (bot) {
         enchantmentTable.xpseed = packet.value
       } else if (packet.property < 7) {
         const slot = slots[packet.property - 4]
-        slot.expected.enchant = packet.value
+        if (packet.value === -1) { slot.expected.enchant = null }
+        else {
+          slot.expected.enchant = bot.registry.enchantments[packet.value].name
+        } 
       } else if (packet.property < 10) {
         const slot = slots[packet.property - 7]
         slot.expected.level = packet.value


### PR DESCRIPTION
I changed the structure of the enchantments to use strings instead of numerical IDs.

Before:
```js
[
  { level: 5, expected: { enchant: 21, level: 1 } },
  { level: 11, expected: { enchant: 6, level: 1 } },
  { level: 30, expected: { enchant: 5, level: 3 } }
]
```
**AFTER:**
```js
[
  { level: 5, expected: { enchant: 'unbreaking', level: 1 } },
  { level: 11, expected: { enchant: 'aqua_affinity', level: 1 } },
  { level: 30, expected: { enchant: 'respiration', level: 3 } }
]
```

This will help a lot with conditions involving enchantments since people wont have to manually check their ID for no reason.

The commit also comes with typescript types for this new structure, which might conflict with my current types commit
(https://github.com/PrismarineJS/mineflayer/pull/3123)