### PR TITLE
Add function to get the total xp points the bot has.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -503,6 +503,7 @@ export interface Experience {
   level: number
   points: number
   progress: number
+  getXpPoints: () => number
 }
 
 export interface PhysicsOptions {

--- a/lib/plugins/experience.js
+++ b/lib/plugins/experience.js
@@ -12,4 +12,12 @@ function inject (bot) {
     bot.experience.progress = packet.experienceBar
     bot.emit('experience')
   })
+
+  bot.experience.getXpPoints() = function () {
+    let levelToXpPoints = bot.experience.convertLevelsToXpPoints(bot.experience.level)
+    let incrementedLevelToXpPoints = bot.experience.convertLevelsToXpPoints(bot.experience.level + 1)
+    let xpForNextLevel = incrementedLevelToXpPoints - levelToXpPoints
+
+    return Math.floor(levelToXpPoints + bot.experience.progress * xpForNextLevel)
+  }
 }


### PR DESCRIPTION
Unlike its title, the `bot.experience.points` property does NOT provide one with the xp points the bot has, but rather its score, displayed only when one dies.

![image](https://github.com/PrismarineJS/mineflayer/assets/65046191/a6e2a686-10b0-4167-8193-4aab39d70806)

This PR adds a function that does precisely that, correctly get the bot's xp points.