### PR TITLE
Change bot.experience.points to bot.score, the packed has been mislabeled

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -177,6 +177,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   food: number
   foodSaturation: number
   oxygenLevel: number
+  score: number
   physics: PhysicsOptions
   physicsEnabled: boolean
   time: Time
@@ -501,7 +502,6 @@ export interface GameSettings {
 
 export interface Experience {
   level: number
-  points: number
   progress: number
 }
 

--- a/lib/plugins/experience.js
+++ b/lib/plugins/experience.js
@@ -3,12 +3,13 @@ module.exports = inject
 function inject (bot) {
   bot.experience = {
     level: null,
-    points: null,
     progress: null
   }
+  bot.score = null
+
   bot._client.on('experience', (packet) => {
     bot.experience.level = packet.level
-    bot.experience.points = packet.totalExperience
+    bot.score = packet.totalExperience
     bot.experience.progress = packet.experienceBar
     bot.emit('experience')
   })


### PR DESCRIPTION
The packet has been incorrectly labeled as "xp points" for a while on both mineflayer and wiki.vg. In reality, it only represents a player's score.

One's score is all the xp they have gathered in one life, and is displayed on death. I would consider it a simplistic stat and a general attribute of a player which is why I am moving it to the bot object.

![image](https://github.com/PrismarineJS/mineflayer/assets/65046191/0e51392a-1dc2-41ba-9b5b-1a9319c0290c)


(https://discord.com/channels/413438066984747026/413438150594265099/1134240353738825790)