### PR TITLE
Import changedSlots computation from prismarine-windows

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -479,6 +479,23 @@ function inject (bot, { hideErrors }) {
     }
   }
 
+  function getChangedSlots (oldSlots, newSlots) {
+    assert.equal(oldSlots.length, newSlots.length)
+
+    const changedSlots = []
+
+    for (let i = 0; i < newSlots.length; i++) {
+      if (!Item.equal(oldSlots[i], newSlots[i])) {
+        changedSlots.push({
+          location: i,
+          item: newSlots[i]
+        })
+      }
+    }
+
+    return changedSlots
+  }
+
   async function clickWindow (slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
@@ -507,7 +524,12 @@ function inject (bot, { hideErrors }) {
     if (bot.supportFeature('transactionPacketExists')) {
       windowClickQueue.push(click)
     } else {
-      changedSlots = window.acceptClick(click)
+      const oldSlots = JSON.parse(JSON.stringify(this.slots))
+
+      window.acceptClick(click)
+
+      // this is required to satisfy mc versions >= 1.17
+      changedSlots = getChangedSlots(oldSlots, this.slots).map(slotChange => { slotChange.item = Item.toNotch(slotChange.item) })
     }
 
     // WHEN ADDING SUPPORT FOR OTHER CLICKS, MAKE SURE TO CHANGE changedSlots TO SUPPORT THEM

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -524,12 +524,28 @@ function inject (bot, { hideErrors }) {
     if (bot.supportFeature('transactionPacketExists')) {
       windowClickQueue.push(click)
     } else {
-      const oldSlots = JSON.parse(JSON.stringify(this.slots))
+      if (
+        // this array indicates the clicks that return changedSlots
+        [
+        0,
+        // 1,
+        // 2,
+        3,
+        4,
+        // 5,
+        // 6
+      ].includes(click.mode)) {
+        changedSlots = window.acceptClick(click)
+      } else {
+        // this is used as a fallback
+        const oldSlots = JSON.parse(JSON.stringify(this.slots))
 
-      window.acceptClick(click)
+        window.acceptClick(click)
 
-      // this is required to satisfy mc versions >= 1.17
-      changedSlots = getChangedSlots(oldSlots, this.slots).map(slotChange => { slotChange.item = Item.toNotch(slotChange.item) })
+        changedSlots = getChangedSlots(oldSlots, this.slots)
+      }
+
+      changedSlots.forEach(slotChange => { slotChange.item = Item.toNotch(slotChange.item) })
     }
 
     // WHEN ADDING SUPPORT FOR OTHER CLICKS, MAKE SURE TO CHANGE changedSlots TO SUPPORT THEM

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -538,11 +538,11 @@ function inject (bot, { hideErrors }) {
         changedSlots = window.acceptClick(click)
       } else {
         // this is used as a fallback
-        const oldSlots = JSON.parse(JSON.stringify(this.slots))
+        const oldSlots = JSON.parse(JSON.stringify(window.slots))
 
         window.acceptClick(click)
 
-        changedSlots = getChangedSlots(oldSlots, this.slots)
+        changedSlots = getChangedSlots(oldSlots, window.slots)
       }
 
       changedSlots.forEach(slotChange => { slotChange.item = Item.toNotch(slotChange.item) })

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -525,16 +525,16 @@ function inject (bot, { hideErrors }) {
       windowClickQueue.push(click)
     } else {
       if (
-        // this array indicates the clicks that return changedSlots
-        [
-        0,
-        // 1,
-        // 2,
-        3,
-        4,
-        // 5,
-        // 6
-      ].includes(click.mode)) {
+          // this array indicates the clicks that return changedSlots
+          [
+          0,
+          // 1,
+          // 2,
+          3,
+          4
+          // 5,
+          // 6
+        ].includes(click.mode)) {
         changedSlots = window.acceptClick(click)
       } else {
         // this is used as a fallback

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -525,8 +525,8 @@ function inject (bot, { hideErrors }) {
       windowClickQueue.push(click)
     } else {
       if (
-          // this array indicates the clicks that return changedSlots
-          [
+      // this array indicates the clicks that return changedSlots
+        [
           0,
           // 1,
           // 2,

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -486,10 +486,7 @@ function inject (bot, { hideErrors }) {
 
     for (let i = 0; i < newSlots.length; i++) {
       if (!Item.equal(oldSlots[i], newSlots[i])) {
-        changedSlots.push({
-          location: i,
-          item: newSlots[i]
-        })
+        changedSlots.push(i)
       }
     }
 
@@ -545,7 +542,12 @@ function inject (bot, { hideErrors }) {
         changedSlots = getChangedSlots(oldSlots, window.slots)
       }
 
-      changedSlots.forEach(slotChange => { slotChange.item = Item.toNotch(slotChange.item) })
+      changedSlots = changedSlots.map(slot => {
+        return {
+          location: slot,
+          item: Item.toNotch(window.slots[slot])
+        }
+      })
     }
 
     // WHEN ADDING SUPPORT FOR OTHER CLICKS, MAKE SURE TO CHANGE changedSlots TO SUPPORT THEM

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prismarine-physics": "^1.7.0",
     "prismarine-recipe": "^1.3.0",
     "prismarine-registry": "^1.5.0",
-    "prismarine-windows": "github:kaduvert/prismarine-windows#return-changed-slots",
+    "prismarine-windows": "^2.8.0",
     "prismarine-world": "^3.6.0",
     "protodef": "^1.14.0",
     "typed-emitter": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prismarine-physics": "^1.7.0",
     "prismarine-recipe": "^1.3.0",
     "prismarine-registry": "^1.5.0",
-    "prismarine-windows": "^2.5.0",
+    "prismarine-windows": "github:kaduvert/prismarine-windows#return-changed-slots",
     "prismarine-world": "^3.6.0",
     "protodef": "^1.14.0",
     "typed-emitter": "^1.0.0",


### PR DESCRIPTION
moves the slot-comparing calculation of changedSlots here because it's of no use in prismarine-windows
the clicks can still return changedSlots directly to save computation. some of them do

depends on https://github.com/PrismarineJS/prismarine-windows/pull/102 for ci