### PR TITLE
add gamemode on player init packet

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -537,6 +537,7 @@ function inject (bot) {
               username: item.name,
               ping: item.ping,
               uuid: item.UUID,
+              gamemode: item.gamemode,
               displayName: new ChatMessage({ text: '', extra: [{ text: item.name }] }),
               skinData: extractSkinInformation(item.properties),
               profileKeys: item.crypto


### PR DESCRIPTION
In my testing singeplayer in the web client works well. I'm using flying-squid (which seems to work only on 1.16) where all events are processed in both clients synchronously. So right after initial player data set, spawn event fires where I should synchronously use gamemode of the current player