### PR TITLE
Fix ambigious function naming

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -138,8 +138,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     return dYaw
   }
 
-  // returns false if packet should be sent, true if not
-  function sendPositionPacketInDeath () {
+  // returns false if bot should send position packets
+  function isEntityRemoved () {
     if (bot.isAlive === true) deadTicks = 0
     if (bot.isAlive === false && deadTicks <= 20) deadTicks++
     if (deadTicks >= 20) return true
@@ -148,7 +148,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   function updatePosition (now) {
     // Only send updates for 20 ticks after death
-    if (sendPositionPacketInDeath()) return
+    if (isEntityRemoved()) return
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
     const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)


### PR DESCRIPTION
As noted here: https://github.com/PrismarineJS/mineflayer/pull/2492#discussion_r1297309964, the function to determine whether an entity is dead for physics purposes has very ambigious naming which could potentially lead to confusion (and worsened maintainability).

Vanilla client handles this by actually removing the entity, so my naming reflects that behaviour (but note the PR does not actually implement such behaviour).