### PR TITLE
Switch to entity.displayName

### DIFF
--- a/examples/armor_stand.js
+++ b/examples/armor_stand.js
@@ -26,7 +26,7 @@ bot.on('chat', async (username, message) => {
   const [mainCommand, subCommand] = message.split(' ')
   if (mainCommand !== 'equip' && mainCommand !== 'unequip') return
 
-  const armorStand = bot.nearestEntity(e => e.mobType === 'Armor Stand' && bot.entity.position.distanceTo(e.position) < 4)
+  const armorStand = bot.nearestEntity(e => e.displayName === 'Armor Stand' && bot.entity.position.distanceTo(e.position) < 4)
   if (!armorStand) {
     bot.chat('No armor stands nearby!')
     return

--- a/examples/chatterbox.js
+++ b/examples/chatterbox.js
@@ -176,11 +176,11 @@ bot.on('playerCollect', (collector, collected) => {
 
 bot.on('entitySpawn', (entity) => {
   if (entity.type === 'mob') {
-    console.log(`Look out! A ${entity.mobType} spawned at ${entity.position}`)
+    console.log(`Look out! A ${entity.displayName} spawned at ${entity.position}`)
   } else if (entity.type === 'player') {
     bot.chat(`Look who decided to show up: ${entity.username}`)
   } else if (entity.type === 'object') {
-    console.log(`There's a ${entity.objectType} at ${entity.position}`)
+    console.log(`There's a ${entity.displayName} at ${entity.position}`)
   } else if (entity.type === 'global') {
     bot.chat('Ooh lightning!')
   } else if (entity.type === 'orb') {
@@ -189,7 +189,7 @@ bot.on('entitySpawn', (entity) => {
 })
 bot.on('entityHurt', (entity) => {
   if (entity.type === 'mob') {
-    bot.chat(`Haha! The ${entity.mobType} got hurt!`)
+    bot.chat(`Haha! The ${entity.displayName} got hurt!`)
   } else if (entity.type === 'player') {
     bot.chat(`Aww, poor ${entity.username} got hurt. Maybe you shouldn't have a ping of ${bot.players[entity.username].ping}`)
   }
@@ -214,12 +214,12 @@ bot.on('entityEat', (entity) => {
 })
 bot.on('entityAttach', (entity, vehicle) => {
   if (entity.type === 'player' && vehicle.type === 'object') {
-    bot.chat(`Sweet, ${entity.username} is riding that ${vehicle.objectType}`)
+    bot.chat(`Sweet, ${entity.username} is riding that ${vehicle.displayName}`)
   }
 })
 bot.on('entityDetach', (entity, vehicle) => {
   if (entity.type === 'player' && vehicle.type === 'object') {
-    bot.chat(`Lame, ${entity.username} stopped riding the ${vehicle.objectType}`)
+    bot.chat(`Lame, ${entity.username} stopped riding the ${vehicle.displayName}`)
   }
 })
 bot.on('entityEquipmentChange', (entity) => {

--- a/examples/guard.js
+++ b/examples/guard.js
@@ -59,7 +59,7 @@ bot.on('physicsTick', () => {
 
   // Only look for mobs within 16 blocks
   const filter = e => e.type === 'mob' && e.position.distanceTo(bot.entity.position) < 16 &&
-                    e.mobType !== 'Armor Stand' // Mojang classifies armor stands as mobs for some reason?
+                    e.displayName !== 'Armor Stand' // Mojang classifies armor stands as mobs for some reason?
 
   const entity = bot.nearestEntity(filter)
   if (entity) {

--- a/examples/jumper.js
+++ b/examples/jumper.js
@@ -108,9 +108,9 @@ bot.once('spawn', () => {
 })
 
 bot.on('mount', () => {
-  bot.chat(`mounted ${bot.vehicle.objectType}`)
+  bot.chat(`mounted ${bot.vehicle.displayName}`)
 })
 
 bot.on('dismount', (vehicle) => {
-  bot.chat(`dismounted ${vehicle.objectType}`)
+  bot.chat(`dismounted ${vehicle.displayName}`)
 })

--- a/examples/python/chatterbox.py
+++ b/examples/python/chatterbox.py
@@ -224,12 +224,12 @@ def playerCollect(this, collector, collected):
 def entitySpawn(this, entity):
     if entity.type == "mob":
         p = entity.position
-        console.log(f"Look out! A {entity.mobType} spawned at {p.toString()}")
+        console.log(f"Look out! A {entity.displayName} spawned at {p.toString()}")
     elif entity.type == "player":
         bot.chat(f"Look who decided to show up: {entity.username}")
     elif entity.type == "object":
         p = entity.position
-        console.log(f"There's a {entity.objectType} at {p.toString()}")
+        console.log(f"There's a {entity.displayName} at {p.toString()}")
     elif entity.type == "global":
         bot.chat("Ooh lightning!")
     elif entity.type == "orb":
@@ -239,7 +239,7 @@ def entitySpawn(this, entity):
 @On(bot, "entityHurt")
 def entityHurt(this, entity):
     if entity.type == "mob":
-        bot.chat(f"Haha! The ${entity.mobType} got hurt!")
+        bot.chat(f"Haha! The ${entity.displayName} got hurt!")
     elif entity.type == "player":
         if entity.username in bot.players:
             ping = bot.players[entity.username].ping
@@ -279,13 +279,13 @@ def entityEat(this, entity):
 @On(bot, "entityAttach")
 def entityAttach(this, entity, vehicle):
     if entity.type == "player" and vehicle.type == "object":
-        print(f"Sweet, {entity.username} is riding that {vehicle.objectType}")
+        print(f"Sweet, {entity.username} is riding that {vehicle.displayName}")
 
 
 @On(bot, "entityDetach")
 def entityDetach(this, entity, vehicle):
     if entity.type == "player" and vehicle.type == "object":
-        print(f"Lame, {entity.username} stopped riding the {vehicle.objectType}")
+        print(f"Lame, {entity.username} stopped riding the {vehicle.displayName}")
 
 
 @On(bot, "entityEquipmentChange")

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -176,8 +176,6 @@ function inject (bot) {
       entityData = entitiesArray.find(entity => entity.internalId === type)
     }
     if (entityData) {
-      entity.mobType = entityData.displayName
-      entity.objectType = entityData.displayName
       entity.displayName = entityData.displayName
       entity.entityType = entityData.id
       entity.name = entityData.name
@@ -188,7 +186,6 @@ function inject (bot) {
       // unknown entity
       entity.type = 'other'
       entity.entityType = type
-      entity.mobType = 'unknown'
       entity.displayName = 'unknown'
       entity.name = 'unknown'
       entity.kind = 'unknown'

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prismarine-block": "^1.17.0",
     "prismarine-chat": "^1.7.1",
     "prismarine-chunk": "^1.34.0",
-    "prismarine-entity": "^2.2.0",
+    "prismarine-entity": "^2.3.0",
     "prismarine-item": "^1.14.0",
     "prismarine-nbt": "^2.0.0",
     "prismarine-physics": "^1.7.0",

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -714,7 +714,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('metadata', (done) => {
         server.on('login', (client) => {
           bot.on('entitySpawn', (entity) => {
-            assert.strictEqual(entity.mobType, 'Creeper')
+            assert.strictEqual(entity.displayName, 'Creeper')
 
             const lastMeta = entity.metadata
             bot.on('entityUpdate', (entity) => {


### PR DESCRIPTION
- Bump to prismarine-entity 2.3.0, which deprecates mobType and objectType
- Update mineflayer to not use newly deprecated fields