### PR TITLE
Fixes `fireworkRocketDuration` calculation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1429,9 +1429,11 @@ This occurs whether the process was completed or aborted.
 
  * `block` - the block that still exists
 
-#### "usedfirework"
+#### "usedFirework" (fireworkEntityId)
 
 Fires when the bot uses a firework while elytra flying.
+
+ * `fireworkEntityId` - the entity id of the firework.
 
 #### "move"
 

--- a/docs/zh/README_ZH_CN.md
+++ b/docs/zh/README_ZH_CN.md
@@ -240,6 +240,7 @@ Mineflayer 支持插件；任何人都可以创建一个插件，在 Mineflayer 
 ### 示例
 
 `npm run mocha_test -- -g "1.18.1.*BlockFinder"` 进行1.18.1寻路测试
+
 ## 许可证
 
 [MIT](../LICENSE)

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -1339,6 +1339,12 @@ This occurs whether the process was completed or aborted.
 
  * `block` - 方块仍然存在
 
+#### "usedFirework" (fireworkEntityId)
+
+在机器人在鞘翅飞行时使用烟花火箭时触发
+
+ * `fireworkEntityId` - 烟花火箭的实体编号
+
 #### "move"
 
 当机器人移动时触发. 如果需要当前位置，请使用

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -377,7 +377,7 @@ function inject (bot) {
     }
   }
 
-  const knownFireworks = new Set();
+  const knownFireworks = new Set()
   function handleBotUsedFireworkRocket (fireworkEntityId, fireworkInfo) {
     if (knownFireworks.has(fireworkEntityId)) return
     knownFireworks.add(fireworkEntityId)

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -369,7 +369,7 @@ function inject (bot) {
     }
     if (bot.fireworkRocketDuration !== 0 && entity.id === bot.entity?.id && !elytraFlying) {
       bot.fireworkRocketDuration = 0
-      knownFireworks.splice(0, knownFireworks.length)
+      knownFireworks.clear()
     }
 
     if (startedFlying) {
@@ -377,28 +377,17 @@ function inject (bot) {
     }
   }
 
-  const knownFireworks = []
+  const knownFireworks = new Set();
   function handleBotUsedFireworkRocket (fireworkEntityId, fireworkInfo) {
-    if (knownFireworks.includes(fireworkEntityId)) return
-    knownFireworks.push(fireworkEntityId)
-    let flightDur = 1
-    if (fireworkInfo?.nbtData != null) {
-      let nbt = fireworkInfo.nbtData
-      if (nbt.type === 'compound' && nbt.value.Fireworks != null) {
-        nbt = nbt.value.Fireworks
-        if (nbt.type === 'compound' && nbt.value.Flight != null) {
-          nbt = nbt.value.Flight
-          if (nbt.type === 'int') {
-            flightDur += nbt.value
-          }
-        }
-      }
-    }
-    const baseDuration = 10 * flightDur
+    if (knownFireworks.has(fireworkEntityId)) return
+    knownFireworks.add(fireworkEntityId)
+    let flightDur = fireworkInfo?.nbtData?.value?.Fireworks?.value?.Flight.value ?? 1
+    if (typeof flightDur !== 'number') { flightDur = 1 }
+    const baseDuration = 10 * (flightDur + 1)
     const randomDuration = Math.floor(Math.random() * 6) + Math.floor(Math.random() * 7)
     bot.fireworkRocketDuration = baseDuration + randomDuration
 
-    bot.emit('usedFirework')
+    bot.emit('usedFirework', fireworkEntityId)
   }
 
   let fireworkEntityName


### PR DESCRIPTION
## The problem

`fireworkRocketDuration` is set to wrong values that cause elytra to fly shorter (#3221). The correct formula is: 10 × (number of gunpowder + 1) + random value from 0 to 5 + random value from 0 to 6

![example picture](https://github.com/PrismarineJS/mineflayer/assets/33175397/fec4bac8-e86d-4dae-adde-bb47049ce004)

The above figure illustrates the difference: the plank post on the left stands for mineflayer's fly height, the log post on the right stands for notchian client fly height (both are done with 1 rocket with flight of 1).

The problem is about the following part:

https://github.com/PrismarineJS/mineflayer/blob/08208e2f110af2c6de41fac9a389597aac916412/lib/plugins/entities.js#L384-L399

There are two bug in this code:

- Line 385: the nbt may does not exists, but that means the rocket has a flight of 1 instead of 0.
- Line 391: the type should be `byte` instead of `int` (at least for 1.20.1)

## Changes

In this pull request:

- Modified function `handleBotUsedFireworkRocket` to fix `fireworkRocketDuration` calculation.
- Made variable `knownFireworks` a [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set), this in more efficient than using Array.
- Fixed a typo about event `usedFirework` in the API document (`usedfirework` to `usedFirework`).
- Added an argument to event `usedFirework`:
  - `fireworkEntityId` - the entity id of the firework.
- Updated the document of Simplified Chinese to add the `usedfirework` event. I am a native speaker of that language.

Fixes #3221
 