### PR TITLE
Fix `bot.heldItem` and `bot.entity.equipment`

### DIFF
--- a/docs/zh/README_ZH_CN.md
+++ b/docs/zh/README_ZH_CN.md
@@ -240,6 +240,7 @@ Mineflayer 支持插件；任何人都可以创建一个插件，在 Mineflayer 
 ### 示例
 
 `npm run mocha_test -- -g "1.18.1.*BlockFinder"` 进行1.18.1寻路测试
+
 ## 许可证
 
 [MIT](../LICENSE)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -44,10 +44,24 @@ function inject (bot, { hideErrors }) {
   bot.inventory = windows.createWindow(0, 'minecraft:inventory', 'Inventory')
   bot.currentWindow = null
   bot.usingHeldItem = false
-  Object.defineProperty(o, 'heldItem', {
+  Object.defineProperty(bot, 'heldItem', {
     get: function () {
       return bot.inventory.slots[bot.QUICK_BAR_START + bot.quickBarSlot]
-    },
+    }
+  })
+
+  bot.on('spawn', () => {
+    Object.defineProperty(bot.entity, 'equipment', {
+      get: bot.supportFeature('doesntHaveOffHandSlot')
+        ? function () {
+          return [bot.heldItem, bot.inventory.slots[8], bot.inventory.slots[7],
+            bot.inventory.slots[6], bot.inventory.slots[5]]
+        }
+        : function () {
+          return [bot.heldItem, bot.inventory.slots[45], bot.inventory.slots[8],
+            bot.inventory.slots[7], bot.inventory.slots[6], bot.inventory.slots[5]]
+        }
+    })
   })
 
   bot._client.on('entity_status', (packet) => {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -43,8 +43,12 @@ function inject (bot, { hideErrors }) {
   bot.quickBarSlot = null
   bot.inventory = windows.createWindow(0, 'minecraft:inventory', 'Inventory')
   bot.currentWindow = null
-  bot.heldItem = null
   bot.usingHeldItem = false
+  Object.defineProperty(o, 'heldItem', {
+    get: function () {
+      return bot.inventory.slots[bot.QUICK_BAR_START + bot.quickBarSlot]
+    },
+  })
 
   bot._client.on('entity_status', (packet) => {
     if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && !eatingTask.done) {
@@ -364,9 +368,7 @@ function inject (bot, { hideErrors }) {
   }
 
   function updateHeldItem () {
-    bot.heldItem = bot.inventory.slots[bot.QUICK_BAR_START + bot.quickBarSlot]
-    bot.entity.heldItem = bot.heldItem
-    bot.emit('heldItemChanged', bot.entity.heldItem)
+    bot.emit('heldItemChanged', bot.heldItem)
   }
 
   function closeWindow (window) {

--- a/test/externalTests/heldItem.js
+++ b/test/externalTests/heldItem.js
@@ -1,0 +1,16 @@
+const assert = require('assert')
+
+module.exports = () => async (bot) => {
+  const Item = require('prismarine-item')(bot.registry)
+
+  await bot.test.becomeCreative()
+  await bot.test.clearInventory()
+  assert.equal(bot.heldItem, null)
+
+  const stoneId = bot.registry.itemsByName.stone.id
+  await bot.test.setInventorySlot(36, new Item(stoneId, 1))
+  assert.strictEqual(bot.heldItem.id, bot.stoneId)
+
+  await bot.tossStack(bot.heldItem)
+  assert.equal(bot.heldItem, null)
+}


### PR DESCRIPTION
Made `bot.heldItem` and `bot.entity.equipment` two getter functions. Note `bot.entity.heldItem` may still be incorrect, and that was fixed in https://github.com/PrismarineJS/prismarine-entity/pull/73

Fixes #3224
Fixes #397