### PR TITLE
Updated digging code to account for raycasted tall grass checks

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -14,12 +14,11 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
-
   /**
-   * 
-   * @param {require('prismarine-block').Block} block 
-   * @param {boolean | 'ignore'} forceLook 
-   * @param {Function | 'auto' | 'raycast'} digFace 
+   *
+   * @param {require('prismarine-block').Block} block
+   * @param {boolean | 'ignore'} forceLook
+   * @param {Function | 'auto' | 'raycast'} digFace
    */
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
@@ -115,8 +114,8 @@ function inject (bot) {
           // TODO: do AABB + ray intercept check to this position for diggingFace.
           await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
         } else {
-           // Block is obstructed return error?
-           throw new Error('Block not in view')
+          // Block is obstructed return error?
+          throw new Error('Block not in view')
         }
       } else {
         await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -14,12 +14,7 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
-  /**
-   *
-   * @param {require('prismarine-block').Block} block
-   * @param {boolean | 'ignore'} forceLook
-   * @param {Function | 'auto' | 'raycast'} digFace
-   */
+  
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
       throw new Error('dig was called with an undefined or null block')

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -14,7 +14,6 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
-  
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
       throw new Error('dig was called with an undefined or null block')

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -14,6 +14,13 @@ function inject (bot) {
   bot.targetDigBlock = null
   bot.lastDigTime = null
 
+
+  /**
+   * 
+   * @param {require('prismarine-block').Block} block 
+   * @param {boolean | 'ignore'} forceLook 
+   * @param {Function | 'auto' | 'raycast'} digFace 
+   */
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
       throw new Error('dig was called with an undefined or null block')
@@ -54,6 +61,7 @@ function inject (bot) {
           z: Math.sign(Math.abs(dz) > 0.5 ? dz : 0)
         }
         const validFaces = []
+        const closerBlocks = []
         for (const i in visibleFaces) {
           if (!visibleFaces[i]) continue // skip as this face is not visible
           // target position on the target block face. -> 0.5 + (current face) * 0.5
@@ -65,13 +73,19 @@ function inject (bot) {
           const startPos = bot.entity.position.offset(0, bot.entity.height, 0)
           const rayBlock = bot.world.raycast(startPos, targetPos.clone().subtract(startPos).normalize(), 5)
           if (rayBlock) {
+            if (startPos.distanceTo(rayBlock.intersect) < startPos.distanceTo(targetPos)) {
+              // Block is closer then the raycasted block
+              closerBlocks.push(rayBlock)
+              // continue since if distance is ever less, then we did not intersect the block we wanted,
+              // meaning that the position of the intersected block is not what we want.
+              continue
+            }
             const rayPos = rayBlock.position
             if (
               rayPos.x === block.position.x &&
                             rayPos.y === block.position.y &&
                             rayPos.z === block.position.z
             ) {
-              // console.info(rayBlock)
               validFaces.push({
                 face: rayBlock.face,
                 targetPos: rayBlock.intersect
@@ -95,9 +109,14 @@ function inject (bot) {
           }
           await bot.lookAt(closest.targetPos, forceLook)
           diggingFace = closest.face
+        } else if (closerBlocks.length === 0 && block.shapes.length === 0) {
+          // no other blocks were detected and the block has no shapes.
+          // The block in question is replaceable (like tall grass) so we can just dig it
+          // TODO: do AABB + ray intercept check to this position for diggingFace.
+          await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)
         } else {
-          // Block is obstructed return error?
-          throw new Error('Block not in view')
+           // Block is obstructed return error?
+           throw new Error('Block not in view')
         }
       } else {
         await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), forceLook)


### PR DESCRIPTION
Currently, prismarine-world's implementation of raycasting does not account for blocks with no shapes. If attempting to dig a block such as tall grass, the current raycast implementation fails due to not detecting an intersection and assuming the raycast failed.

This check does boundary checking for found blocks and considers their distance away from the eyePos. If the collision is closer than the expected targetPos intersect, then that viewing angle is invalid.

If no visible faces are detected via the raytrace, then we check for if there were any closer collisons. If there weren't and the block we are checking also has no faces, assume that we can look at the block from any tried face and continue with the dig accordingly.

There is a small TODO to calculate the digging face based on an AABB + ray intersection check, but that is not currently implemented in prismarine-physics's AABB code. An example can be found here: https://github.com/nxg-org/mineflayer-util-plugin/blob/af6612c809e040409365b9f1238aa0af96422f66/src/calcs/aabb.ts#L231