### PR TITLE
Added missing bot.teams definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,6 +194,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   isSleeping: boolean
   scoreboards: { [name: string]: ScoreBoard }
   scoreboard: { [slot in DisplaySlot]: ScoreBoard }
+  teams: { [name: string]: Team }
   teamMap: { [name: string]: Team }
   controlState: ControlStateStatus
   creative: creativeMethods


### PR DESCRIPTION
Like the title says. Info was in api.md, but not in the index.d.ts, so now it is