### PR TITLE
Deleted scoreboards not being updated

### DIFF
--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -16,6 +16,14 @@ function inject (bot) {
     if (packet.action === 1) {
       bot.emit('scoreboardDeleted', scoreboards[packet.name])
       delete scoreboards[packet.name]
+
+      for (const position in ScoreBoard.positions) {
+        const scoreboard = ScoreBoard.positions[position]
+        if (scoreboard.name === packet.name) {
+          delete ScoreBoard.positions[position]
+          break
+        }
+      }
     }
 
     if (packet.action === 2) {


### PR DESCRIPTION
Deleted scoreboards were deleted from `bot.scoreboards`, but not from `bot.scoreboard` (`ScoreBoard.positions`). In result, a scoreboard existed till another one would take it's place.