### PR TITLE
Update scoreboard.js to fix error which caused by already deleted vars

### DIFF
--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -18,6 +18,7 @@ function inject (bot) {
       delete scoreboards[packet.name]
 
       for (const position in ScoreBoard.positions) {
+        if (!ScoreBoard.positions[position]) continue
         const scoreboard = ScoreBoard.positions[position]
         if (scoreboard.name === packet.name) {
           delete ScoreBoard.positions[position]


### PR DESCRIPTION
Fixed;
TypeError: Cannot read properties of undefined (reading 'name')
at Client.<anonymous> (/home/container/node_modules/mineflayer/lib/plugins/scoreboard.js:25:24)