### PR TITLE
Fix 1.20.4 server resource pack error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -160,7 +160,7 @@ export interface BotEvents {
   teamMemberRemoved: (team: Team) => Promise<void> | void
   bossBarDeleted: (bossBar: BossBar) => Promise<void> | void
   bossBarUpdated: (bossBar: BossBar) => Promise<void> | void
-  resourcePack: (url: string, hash: string) => Promise<void> | void
+  resourcePack: (url: string, hash?: string, uuid?: string) => Promise<void> | void
   particle: (particle: Particle) => Promise<void> | void
 }
 

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -2,7 +2,8 @@ module.exports = inject
 
 function inject (bot) {
   let latestHash
-  const activeResourcePacks = new Set();
+  let latestUUID
+  const activeResourcePacks = {};
   const TEXTURE_PACK_RESULTS = {
     SUCCESSFULLY_LOADED: 0,
     DECLINED: 1,
@@ -10,21 +11,21 @@ function inject (bot) {
     ACCEPTED: 3
   }
 
-  bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but also uuid because that's how active packs are tracked
-    bot.emit('resourcePack', data.url, data.hash, data.uuid)
+  bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
+    bot.emit('resourcePack', data.url, data.uuid)
     // Adding the pack to a set by uuid
-    activeResourcePacks.add(data.uuid)
-    latestHash = data.hash
+    latestUUID = data.uuid
+    activeResourcePacks[data.uuid] = data.url
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
     // if uuid isn't provided remove all packs
     if (data.uuid === undefined) {
-      activeResourcePacks.clear();
+      activeResourcePacks = {};
     } else {
       // Try to remove uuid from set
       try {
-        activeResourcePacks.remove(data.uuid)
+        delete activeResourcePacks[data.uuid]
       } catch (error) {
          console.error("Tried to remove UUID but it was not in the active list.");
       }
@@ -45,6 +46,11 @@ function inject (bot) {
       bot._client.write('resource_pack_receive', {
         result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED,
         hash: latestHash
+      })
+    } else if (bot.version == '1.20.3' || bot.version == '1.20.4') {
+      bot._client.write('resource_pack_recieve', {
+        uuid: latestUUID,
+        result: TEXTURE_PACK_RESULTS.ACCEPTED
       })
     } else {
       bot._client.write('resource_pack_receive', {

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -37,8 +37,14 @@ function inject (bot) {
   })
 
   bot._client.on('resource_pack_send', (data) => {
-    bot.emit('resourcePack', data.url, data.hash)
-    latestHash = data.hash
+    if (bot.supportFeature('resourcePackUsesUUID')) {
+      uuid = new UUID(data.uuid)
+      bot.emit('resourcePack', uuid, data.url)
+      latestUUID = uuid
+    } else {
+      bot.emit('resourcePack', data.url, data.hash)
+      latestHash = data.hash
+    }
   })
 
   function acceptResourcePack () {
@@ -56,6 +62,10 @@ function inject (bot) {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.ACCEPTED
       })
+      bot._client.write('resource_pack_receive', {
+        uuid: latestUUID,
+        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
+      })
     } else {
       bot._client.write('resource_pack_receive', {
         result: TEXTURE_PACK_RESULTS.ACCEPTED
@@ -67,7 +77,7 @@ function inject (bot) {
   }
 
   function denyResourcePack () {
-    if (bot.supportFeature('resourcePackUsesUUID')) {
+    if (bot.version === '1.20.4'/*supportFeature('resourcePackUsesUUID')*/) {
       bot._client.write('resource_pack_receive', {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.DECLINED

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -1,4 +1,3 @@
-
 const UUID = require('uuid-1345')
 
 module.exports = inject
@@ -15,7 +14,7 @@ function inject (bot) {
   }
 
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
-    const uuid = new UUID(data.uuid);
+    const uuid = new UUID(data.uuid)
     // Adding the pack to a set by uuid
     latestUUID = uuid
     activeResourcePacks[uuid] = data.url
@@ -39,7 +38,6 @@ function inject (bot) {
 
   bot._client.on('resource_pack_send', (data) => {
     bot.emit('resourcePack', data.url, data.hash)
-    console.log("emitted")
     latestHash = data.hash
   })
 

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -2,12 +2,34 @@ module.exports = inject
 
 function inject (bot) {
   let latestHash
+  const activeResourcePacks = new Set();
   const TEXTURE_PACK_RESULTS = {
     SUCCESSFULLY_LOADED: 0,
     DECLINED: 1,
     FAILED_DOWNLOAD: 2,
     ACCEPTED: 3
   }
+
+  bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but also uuid because that's how active packs are tracked
+    bot.emit('resourcePack', data.url, data.hash, data.uuid)
+    // Adding the pack to a set by uuid
+    acceptResourcePack.add(data.uuid)
+    latestHash = data.hash
+  })
+
+  bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
+    // if uuid isn't provided remove all packs
+    if (data.uuid === undefined) {
+      acceptResourcePack.clear();
+    } else {
+      // Try to remove uuid from set
+      try {
+        acceptResourcePack.remove(data.uuid)
+      } catch (error) {
+         console.error("Tried to remove UUID but it was not in the active list.");
+      }
+    }
+  })
 
   bot._client.on('resource_pack_send', (data) => {
     bot.emit('resourcePack', data.url, data.hash)

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -1,3 +1,6 @@
+
+const UUID = require('uuid-1345')
+
 module.exports = inject
 
 function inject (bot) {
@@ -12,10 +15,12 @@ function inject (bot) {
   }
 
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
-    bot.emit('resourcePack', data.url, data.uuid)
+    const uuid = new UUID(data.uuid);
     // Adding the pack to a set by uuid
-    latestUUID = data.uuid
-    activeResourcePacks[data.uuid] = data.url
+    latestUUID = uuid
+    activeResourcePacks[uuid] = data.url
+
+    bot.emit('resourcePack', data.url, uuid)
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
@@ -25,7 +30,7 @@ function inject (bot) {
     } else {
       // Try to remove uuid from set
       try {
-        delete activeResourcePacks[data.uuid]
+        delete activeResourcePacks[new UUID(data.uuid)]
       } catch (error) {
         console.error('Tried to remove UUID but it was not in the active list.')
       }
@@ -34,6 +39,7 @@ function inject (bot) {
 
   bot._client.on('resource_pack_send', (data) => {
     bot.emit('resourcePack', data.url, data.hash)
+    console.log("emitted")
     latestHash = data.hash
   })
 
@@ -48,7 +54,7 @@ function inject (bot) {
         hash: latestHash
       })
     } else if (bot.version === '1.20.3' || bot.version === '1.20.4') {
-      bot._client.write('resource_pack_recieve', {
+      bot._client.write('resource_pack_receive', {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.ACCEPTED
       })

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -13,18 +13,18 @@ function inject (bot) {
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but also uuid because that's how active packs are tracked
     bot.emit('resourcePack', data.url, data.hash, data.uuid)
     // Adding the pack to a set by uuid
-    acceptResourcePack.add(data.uuid)
+    acceptResourcePacks.add(data.uuid)
     latestHash = data.hash
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
     // if uuid isn't provided remove all packs
     if (data.uuid === undefined) {
-      acceptResourcePack.clear();
+      acceptResourcePacks.clear();
     } else {
       // Try to remove uuid from set
       try {
-        acceptResourcePack.remove(data.uuid)
+        acceptResourcePacks.remove(data.uuid)
       } catch (error) {
          console.error("Tried to remove UUID but it was not in the active list.");
       }

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -3,7 +3,7 @@ module.exports = inject
 function inject (bot) {
   let latestHash
   let latestUUID
-  const activeResourcePacks = {};
+  let activeResourcePacks = {}
   const TEXTURE_PACK_RESULTS = {
     SUCCESSFULLY_LOADED: 0,
     DECLINED: 1,
@@ -21,13 +21,13 @@ function inject (bot) {
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
     // if uuid isn't provided remove all packs
     if (data.uuid === undefined) {
-      activeResourcePacks = {};
+      activeResourcePacks = {}
     } else {
       // Try to remove uuid from set
       try {
         delete activeResourcePacks[data.uuid]
       } catch (error) {
-         console.error("Tried to remove UUID but it was not in the active list.");
+        console.error('Tried to remove UUID but it was not in the active list.')
       }
     }
   })
@@ -47,7 +47,7 @@ function inject (bot) {
         result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED,
         hash: latestHash
       })
-    } else if (bot.version == '1.20.3' || bot.version == '1.20.4') {
+    } else if (bot.version === '1.20.3' || bot.version === '1.20.4') {
       bot._client.write('resource_pack_recieve', {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.ACCEPTED

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -51,7 +51,7 @@ function inject (bot) {
         result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED,
         hash: latestHash
       })
-    } else if (bot.version === '1.20.3' || bot.version === '1.20.4') {
+    } else if (bot.supportFeature('resourcePackUsesUUID')) {
       bot._client.write('resource_pack_receive', {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.ACCEPTED
@@ -67,6 +67,12 @@ function inject (bot) {
   }
 
   function denyResourcePack () {
+    if (bot.supportFeature('resourcePackUsesUUID')) {
+      bot._client.write('resource_pack_receive', {
+        uuid: latestUUID,
+        result: TEXTURE_PACK_RESULTS.DECLINED
+      })
+    }
     bot._client.write('resource_pack_receive', {
       result: TEXTURE_PACK_RESULTS.DECLINED
     })

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -3,6 +3,7 @@ const UUID = require('uuid-1345')
 module.exports = inject
 
 function inject (bot) {
+  let uuid
   let latestHash
   let latestUUID
   let activeResourcePacks = {}
@@ -77,7 +78,7 @@ function inject (bot) {
   }
 
   function denyResourcePack () {
-    if (bot.version === '1.20.4'/*supportFeature('resourcePackUsesUUID')*/) {
+    if (bot.supportFeature('resourcePackUsesUUID')) {
       bot._client.write('resource_pack_receive', {
         uuid: latestUUID,
         result: TEXTURE_PACK_RESULTS.DECLINED

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -13,18 +13,18 @@ function inject (bot) {
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but also uuid because that's how active packs are tracked
     bot.emit('resourcePack', data.url, data.hash, data.uuid)
     // Adding the pack to a set by uuid
-    acceptResourcePacks.add(data.uuid)
+    activeResourcePacks.add(data.uuid)
     latestHash = data.hash
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
     // if uuid isn't provided remove all packs
     if (data.uuid === undefined) {
-      acceptResourcePacks.clear();
+      activeResourcePacks.clear();
     } else {
       // Try to remove uuid from set
       try {
-        acceptResourcePacks.remove(data.uuid)
+        activeResourcePacks.remove(data.uuid)
       } catch (error) {
          console.error("Tried to remove UUID but it was not in the active list.");
       }


### PR DESCRIPTION
I have updated the code to allow for a bot to join a 1.20.4 server with a specified resource pack. There is still an error in the bot.emit() method or the minecraft-protocol/src/datatypes/compiler-minecraft.js:48:25 because compiler-minecraft.js is unable to read the uuid length.