### PR TITLE
Updated setCommandBlock's 3rd argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -379,7 +379,14 @@ export interface Bot extends TypedEmitter<BotEvents> {
     times?: number
   ) => Promise<void>
 
-  setCommandBlock: (pos: Vec3, command: string, trackOutput: boolean) => void
+  
+  export interface CommandBlockOptions {
+    mode: number,
+    trackOutput: boolean,
+    conditional: boolean,
+    alwaysActive: boolean
+  }
+  export function setCommandBlock(pos: Vec3, command: string, options: CommandBlockOptions) => void
 
   clickWindow: (
     slot: number,


### PR DESCRIPTION
The 3rd argument is now a dict that needs users to set several options on the command block, not just a boolean called `trackOutput`.
<br/>

#### Please consider dynamically generating the index.d.ts from now on.
This file is seemingly manually written as its outdated in some parts, compared to [docs/api.md](https://github.com/PrismarineJS/mineflayer/blob/master/docs/api.md#botsetcommandblockpos-command-options) (which contains the latest docs).
This makes it very difficult to work with TypeScript, as some functions make no sense. I have spent 5 whole hours trying to figure out a way I could execute commands longer than 256 characters, being unable to set the command on the command block even after engineering 4 completely different methods of doing it, and I've only now just found out there's a convenient argument to the `setCommandBlock` to do just that.
I've spotted other cases where the completion is wrong earlier but I can't list any of them from the top of my head.

You could use JSDoc, and in fact you kind of should as it would also provide ordinary JavaScript users with completion. Then there are tools to automatically generate an `index.d.ts` from the JSDoc inside a project.
