### PR TITLE
Fix typos

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1597,7 +1597,7 @@ Finds the closest blocks from the given point.
    - `matching` - A function that returns true if the given block is a match. Also supports this value being a block id or array of block ids.
    - `useExtraInfo` - To preserve backward compatibility can result in two behavior depending on the type
       - **boolean** - Provide your `matching` function more data - noticeably slower approach
-      - **function** - Creates two stage maching, if block passes `matching` function it is passed further to `useExtraInfo` with additional info
+      - **function** - Creates two stage matching, if block passes `matching` function it is passed further to `useExtraInfo` with additional info
    - `maxDistance` - The furthest distance for the search, defaults to 16.
    - `count` - Number of blocks to find before returning the search. Default to 1. Can return less if not enough blocks are found exploring the whole area.
 
@@ -1627,7 +1627,7 @@ with `metadata`.
 
 #### bot.recipesAll(itemType, metadata, craftingTable)
 
-The same as bot.recipesFor except that it does not check wether the bot has enough materials for the recipe.
+The same as bot.recipesFor except that it does not check whether the bot has enough materials for the recipe.
 
 #### bot.nearestEntity(match = (entity) => { return true })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -974,7 +974,7 @@ Default true, whether or not you receive color codes in chats from the server.
 
 #### bot.settings.viewDistance
 
-Can be a string listed below or a postive number.
+Can be a string listed below or a positive number.
 Choices:
  * `far` (default)
  * `normal`
@@ -1035,7 +1035,7 @@ saturation of 5.0. Eating food increases the saturation as well as the food bar.
 
 #### bot.oxygenLevel
 
-Number in the range [0, 20] respresenting the number of water-icons known as oxygen level.
+Number in the range [0, 20] representing the number of water-icons known as oxygen level.
 
 #### bot.physics
 
@@ -1554,7 +1554,7 @@ Fires when a particle is created
 
 #### bot.blockAt(point, extraInfos=true)
 
-Returns the block at `point` or `null` if that point is not loaded. If `extraInfos` set to true, also returns informations about signs, paintings and block entities (slower).
+Returns the block at `point` or `null` if that point is not loaded. If `extraInfos` set to true, also returns information about signs, paintings and block entities (slower).
 See `Block`.
 
 #### bot.waitForChunksToLoad()
@@ -1596,7 +1596,7 @@ Finds the closest blocks from the given point.
    - `point` - The start position of the search (center). Default is the bot position.
    - `matching` - A function that returns true if the given block is a match. Also supports this value being a block id or array of block ids.
    - `useExtraInfo` - To preserve backward compatibility can result in two behavior depending on the type
-      - **boolean** - Provide your `matching` function more data - noticeably slower aproach
+      - **boolean** - Provide your `matching` function more data - noticeably slower approach
       - **function** - Creates two stage maching, if block passes `matching` function it is passed further to `useExtraInfo` with additional info
    - `maxDistance` - The furthest distance for the search, defaults to 16.
    - `count` - Number of blocks to find before returning the search. Default to 1. Can return less if not enough blocks are found exploring the whole area.
@@ -1635,7 +1635,7 @@ Return the nearest entity to the bot, matching the function (default to all enti
 
 Example:
 ```js
-const cow = bot.nearestEntity(entity => entity.name.toLowerCase() === 'cow') // we use .toLowercase() because in 1.8 cow was capitalized, for newer versions that can be ommitted
+const cow = bot.nearestEntity(entity => entity.name.toLowerCase() === 'cow') // we use .toLowercase() because in 1.8 cow was capitalized, for newer versions that can be omitted
 ```
 
 ### Methods
@@ -1657,7 +1657,7 @@ Requests chat completion from the server.
  * `str` - String to complete.
  * `assumeCommand` - Field sent to server, defaults to false.
  * `sendBlockInSight` - Field sent to server, defaults to true. Set this option to false if you want more performance.
- * `timeout` - Timeout in milliseconds, after which the function will return an ampty array, defaults to 5000.
+ * `timeout` - Timeout in milliseconds, after which the function will return an empty array, defaults to 5000.
 
 #### bot.chat(message)
 
@@ -1683,11 +1683,11 @@ Adds a regex pattern to the bot's chat matching. Useful for bukkit servers where
 make an event that is called every time the pattern is matched to a message,
 the event will be called `"chat:name"`, with name being the name passed
 * `name` - the name used to listen for the event
-* `pattern` - regular expression to match to messages recieved
+* `pattern` - regular expression to match to messages received
 * `chatPatternOptions` - object
   * `repeat` - defaults to true, whether to listen for this event after the first match
   * `parse` - instead of returning the actual message that was matched, return the capture groups from the regex
-  * `deprecated` - (**unstable**) used by bot.chatAddPattern to keep compatability, likely to be removed
+  * `deprecated` - (**unstable**) used by bot.chatAddPattern to keep compatibility, likely to be removed
 
 returns a number which can be used with bot.removeChatPattern() to only delete this pattern
 
@@ -1695,10 +1695,10 @@ returns a number which can be used with bot.removeChatPattern() to only delete t
 
 #### bot.addChatPatternSet(name, patterns, chatPatternOptions)
 
-make an event that is called every time all patterns havee been matched to messages,
+make an event that is called every time all patterns have been matched to messages,
 the event will be called `"chat:name"`, with name being the name passed
 * `name` - the name used to listen for the event
-* `patterns` - array of regular expression to match to messages recieved
+* `patterns` - array of regular expression to match to messages received
 * `chatPatternOptions` - object
   * `repeat` - defaults to true, whether to listen for this event after the first match
   * `parse` - instead of returning the actual message that was matched, return the capture groups from the regex

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -453,7 +453,7 @@ The function could also be called when an error occurs.
 
 Below is an example of a bot that will craft oak logs into oak planks and then into sticks.
 
-Incorect approach ❌:
+Incorrect approach ❌:
 
 ```js
 function craft (bot) {

--- a/examples/advanced/chest_confirm.md
+++ b/examples/advanced/chest_confirm.md
@@ -1,4 +1,4 @@
-# Menual Chest Confirm
+# Manual Chest Confirm
 
 This code snippet will tell the bot not to wait for chest confirmations that some spigot plugins will not send
 

--- a/examples/chatterbox.js
+++ b/examples/chatterbox.js
@@ -10,7 +10,7 @@
  * may flood the chat, feel free to check them out for other purposes though.
  *
  * This bot also replies to some specific chat messages so you can ask him
- * a few informations while you are in game.
+ * a few information while you are in game.
  */
 const mineflayer = require('mineflayer')
 const { Vec3 } = require('vec3')

--- a/examples/looker.js
+++ b/examples/looker.js
@@ -1,5 +1,5 @@
 /*
- * This script will automaticly look at the closest entity.
+ * This script will automatically look at the closest entity.
  * It checks for a near entity every tick.
  */
 const mineflayer = require('mineflayer')

--- a/examples/perfectShotBow.js
+++ b/examples/perfectShotBow.js
@@ -30,7 +30,7 @@ bot.on('spawn', function () {
 
   // Auto attack every 1,2 secs with bow
   // With crossbow attack when crossbow is charget (enchant 3 = 0.5s)
-  // ['snowball', 'ender_pearl', 'egg', 'splash_potion'] auto attack every 0,1 sec, no recomended use autoAttack for these items, instead use "bot.hawkEye.oneShot(target, weapon)"
+  // ['snowball', 'ender_pearl', 'egg', 'splash_potion'] auto attack every 0,1 sec, no recommended use autoAttack for these items, instead use "bot.hawkEye.oneShot(target, weapon)"
 
   bot.hawkEye.autoAttack(target, weapon)
   // If you force stop attack use:

--- a/examples/python/chatterbox.py
+++ b/examples/python/chatterbox.py
@@ -10,7 +10,7 @@
 # may flood the chat, feel free to check them out for other purposes though.
 #
 # This bot also replies to some specific chat messages so you can ask him
-# a few informations while you are in game.
+# a few information while you are in game.
 # ===========================================================================
 import sys, re
 from javascript import require, On, Once, console

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -196,7 +196,7 @@ function inject (bot, options) {
   bot.tabComplete = tabComplete
 
   function addDefaultPatterns () {
-    // 1.19 changes the chat format to move <sender> prefix from message contents to a seperate field.
+    // 1.19 changes the chat format to move <sender> prefix from message contents to a separate field.
     // TODO: new chat lister to handle this
     if (!defaultChatPatterns) return
     bot.addChatPattern('whisper', new RegExp(`^${USERNAME_REGEX} whispers(?: to you)?:? (.*)$`), { deprecated: true })

--- a/test/externalTests/placeEntity.js
+++ b/test/externalTests/placeEntity.js
@@ -16,7 +16,7 @@ module.exports = (version) => {
   addTest('place crystal', async (bot) => {
     if (!bot.registry.itemsByName.end_crystal) return // unsupported
     await bot.test.setBlock({ z: 1, relative: true, blockName: 'obsidian' })
-    await bot.test.awaitItemRecieved(`/give ${bot.username} end_crystal`)
+    await bot.test.awaitItemReceived(`/give ${bot.username} end_crystal`)
     const crystal = await bot.placeEntity(bot.blockAt(bot.entity.position.offset(0, 0, 1)), new Vec3(0, 1, 0))
     assert(crystal !== null)
     let name = 'EnderCrystal'
@@ -45,7 +45,7 @@ module.exports = (version) => {
     }
 
     await placeBlocksForTest('water')
-    await bot.test.awaitItemRecieved(`/give ${bot.username} ${bot.registry.oak_boat ? 'oak_boat' : 'boat'}`)
+    await bot.test.awaitItemReceived(`/give ${bot.username} ${bot.registry.oak_boat ? 'oak_boat' : 'boat'}`)
     const boat = await bot.placeEntity(bot.blockAt(bot.entity.position.offset(0, -1, -2)), new Vec3(0, -1, 0))
     assert(boat !== null)
     const name = bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'Boat' : 'boat'
@@ -69,7 +69,7 @@ module.exports = (version) => {
     } else {
       command = '/give @p zombie_spawn_egg 1' // >1.12
     }
-    await bot.test.awaitItemRecieved(command)
+    await bot.test.awaitItemReceived(command)
     const zombie = await bot.placeEntity(bot.blockAt(bot.entity.position.offset(0, 0, 1)), new Vec3(0, 1, 0))
     assert(zombie !== null)
     const name = bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'Zombie' : 'zombie'
@@ -80,7 +80,7 @@ module.exports = (version) => {
   })
 
   addTest('place armor stand', async (bot) => {
-    await bot.test.awaitItemRecieved(`/give ${bot.username} armor_stand`)
+    await bot.test.awaitItemReceived(`/give ${bot.username} armor_stand`)
     const armorStand = await bot.placeEntity(bot.blockAt(bot.entity.position.offset(0, 0, 1)), new Vec3(0, 1, 0))
     assert(armorStand !== null)
     let name

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -28,7 +28,7 @@ function inject (bot) {
     return new Promise((resolve) => { setTimeout(resolve, ms) })
   }
 
-  bot.test.awaitItemRecieved = async (command) => {
+  bot.test.awaitItemReceived = async (command) => {
     const p = once(bot.inventory, 'updateSlot')
     bot.chat(command)
     await p // await getting the item


### PR DESCRIPTION
Typos found after cherry-picking via [`typos -w`](https://github.com/crate-ci/typos)

Fixed typos mainly for
- Comments
- Documentations

Only one typo fix for a test helper method.

> Fixes only applicable to English language