### PR TITLE
fix gamemode incorrect reset

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -24,8 +24,10 @@ function inject (bot, options) {
 
   function handleRespawnPacketData (packet) {
     bot.game.levelType = packet.levelType ?? (packet.isFlat ? 'flat' : 'default')
-    bot.game.hardcore = packet.isHardcore ?? Boolean(packet.gameMode & 0b100)
-    bot.game.gameMode = parseGameMode(packet.gameMode)
+    if (packet.gameMode != undefined) {
+      bot.game.hardcore = packet.isHardcore ?? Boolean(packet.gameMode & 0b100)
+      bot.game.gameMode = parseGameMode(packet.gameMode)
+    }
     if (bot.supportFeature('dimensionIsAnInt')) {
       bot.game.dimension = dimensionNames[packet.dimension]
     } else if (bot.supportFeature('dimensionIsAString')) {

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -24,7 +24,7 @@ function inject (bot, options) {
 
   function handleRespawnPacketData (packet) {
     bot.game.levelType = packet.levelType ?? (packet.isFlat ? 'flat' : 'default')
-    if (packet.gameMode != undefined) {
+    if (packet.gameMode !== undefined) {
       bot.game.hardcore = packet.isHardcore ?? Boolean(packet.gameMode & 0b100)
       bot.game.gameMode = parseGameMode(packet.gameMode)
     }


### PR DESCRIPTION
When the packet's gamemode is undefined, the bot's gamemode resets to survival (when gamemode in server is unchanged at respawn).