### PR TITLE
fix: Fix `heldItemChanged` was not fired in all cases when the held item was changed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,6 +163,7 @@ export interface BotEvents {
   bossBarUpdated: (bossBar: BossBar) => Promise<void> | void
   resourcePack: (url: string, hash?: string, uuid?: string) => Promise<void> | void
   particle: (particle: Particle) => Promise<void> | void
+  heldItemChanged: (newItem: Item | null) => Promise<void> | void
 }
 
 export interface CommandBlockOptions {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -698,8 +698,12 @@ function inject (bot, { hideErrors }) {
     const newItem = Item.fromNotch(packet.item)
     const oldItem = window.slots[packet.slot]
     window.updateSlot(packet.slot, newItem)
-    updateHeldItem()
     bot.emit(`setSlot:${window.id}`, oldItem, newItem)
+  })
+  bot.inventory.on('updateSlot', (index) => {
+    if (index === bot.quickBarSlot + bot.inventory.hotbarStart) {
+      bot.emit('heldItemChanged')
+    }
   })
   bot._client.on('window_items', (packet) => {
     const window = packet.windowId === 0 ? bot.inventory : bot.currentWindow


### PR DESCRIPTION
it should not be in set_slot event, it should be updated whenever the slot is actually updated (e.g. by inventory manipulation)