### PR TITLE
fix: use dimension data on 1.16.2

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -261,7 +261,7 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       bot.world.setColumn(packet.chunkX, packet.chunkZ, column)
     }
 
-    if (bot.supportFeature('dimensionDataIsAvailable')) {
+    if (bot.supportFeature('newLightingDataFormat')) {
       column.loadParsedLight(packet.skyLight, packet.blockLight, packet.skyLightMask, packet.blockLightMask, packet.emptySkyLightMask, packet.emptyBlockLightMask)
     } else {
       column.loadLight(packet.data, packet.skyLightMask, packet.blockLightMask, packet.emptySkyLightMask, packet.emptyBlockLightMask)

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -52,7 +52,7 @@ function inject (bot, options) {
         bot.game.minY = minY
         bot.game.height = height
       }
-    } else if (bot.supportFeature('dimensionDataIsAvailable')) { // 1.18
+    } else if (bot.supportFeature('dimensionDataIsAvailable')) { // 1.16.2+
       const dimensionData = nbt.simplify(packet.dimension)
       bot.game.minY = dimensionData.min_y
       bot.game.height = dimensionData.height


### PR DESCRIPTION
dimension packet is available starting from 1.16.2

finishing https://github.com/PrismarineJS/minecraft-data/pull/877