### PR TITLE
fix `inventory.clickWindow` `mode` assertion

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -530,7 +530,7 @@ function inject (bot, { hideErrors }) {
     }
     const window = bot.currentWindow || bot.inventory
 
-    assert.ok(mode >= 0 && mode <= 4)
+    assert.ok(mode >= 0 && mode <= 6)
     const actionId = createActionNumber()
 
     const click = {


### PR DESCRIPTION
This is the right assertion:

https://github.com/PrismarineJS/prismarine-windows/blob/42122d1c70f668b850bd4dfc647dacd2f52e8252/lib/Window.js#L28