### PR TITLE
Remove --depth flag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ npm install mineflayer
 
 To update mineflayer (or any Node.js) package and its dependencies, use 
 ```bash
-npm update --depth 9999
+npm update
 ```
 
 ## Documentation


### PR DESCRIPTION
remove --depth flag as it no longer works.

npm warn update The --depth option no longer has any effect. See RFC0019. npm warn update https://github.com/npm/rfcs/blob/latest/implemented/0019-remove-update-depth-option.md