### PR TITLE
Fixed invalid Storage Events type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -649,7 +649,7 @@ export class Painting {
 interface StorageEvents {
   open: () => void
   close: () => void
-  updateSlot: (oldItem: Item | null, newItem: Item | null) => void
+  updateSlot: (slot: number, oldItem: Item | null, newItem: Item | null) => void
 }
 
 interface FurnaceEvents extends StorageEvents {


### PR DESCRIPTION
Fix for StorageEvents type. StorageEvents represents a type for storing a window. But it is incorrect, as follows from the code and documentation of prismarine-windows 
![image](https://github.com/user-attachments/assets/a485319a-0e05-4920-903e-9e00d263afb8)
![image](https://github.com/user-attachments/assets/46db7c53-421d-4f35-86a1-3fd1d5b7d5dd)
- the "updateSlot" event is called with three arguments, the first is the slot index, the second is the previous element, the third is the new element. And StorageEvents specifies a type with 2 arguments updateSlot: (oldItem: Item | null, newItem: Item | null) => void. I suggest a fix.