### PR TITLE
add pitchSpeed as an option in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -541,6 +541,7 @@ export interface PhysicsOptions {
   playerHeight: number
   jumpSpeed: number
   yawSpeed: number
+  pitchSpeed: number
   sprintSpeed: number
   maxGroundSpeedSoulSand: number
   maxGroundSpeedWater: number


### PR DESCRIPTION
There is no mention of PhysicsOptions in the docs afaik (search didn't result in anything) so I believe this is the only change necessary.

yawSpeed is currently included, and both are used like so:

![image](https://github.com/user-attachments/assets/7ef2e00a-369a-412f-b9e9-2b62ef4817ae)


Relevant since https://github.com/nxg-org/mineflayer-smooth-look uses both pitchSpeed and yawSpeed to estimate duration of required tween.