### PR TITLE
Added `switchWorld` event

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -253,6 +253,7 @@
       - ["physicsTick" ()](#physicstick-)
       - ["chat:name" (matches)](#chatname-matches)
       - ["particle"](#particle)
+      - ["switchWorld"](#switchWorld)
     - [Functions](#functions)
       - [bot.blockAt(point, extraInfos=true)](#botblockatpoint-extrainfostrue)
       - [bot.waitForChunksToLoad()](#botwaitforchunkstoload)
@@ -1549,6 +1550,11 @@ Fires when the all of a chat pattern's regexs have matches
 #### "particle"
 
 Fires when a particle is created
+
+
+#### "switchWorld"
+
+Only fires when the world is being switched (unlike `respawn` which also fires after death)
 
 ### Functions
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,6 +163,7 @@ export interface BotEvents {
   bossBarUpdated: (bossBar: BossBar) => Promise<void> | void
   resourcePack: (url: string, hash?: string, uuid?: string) => Promise<void> | void
   particle: (particle: Particle) => Promise<void> | void
+  switchWorld: () => void
 }
 
 export interface CommandBlockOptions {

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -549,6 +549,7 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       dimension = packet.dimension
       worldName = packet.worldName
     }
+    if(!packet.copyMetadata) bot.emit('switchWorld')
     switchWorld()
   })
 


### PR DESCRIPTION
This PR implements the `switchWorld` event, which only fires when the world is being switched (like overworld => end or lobby -> minigame) and not upon death