### PR TITLE
 Fix window.deposit requiring item.count

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -263,7 +263,7 @@ function inject (bot, { hideErrors }) {
     const itemType = options.itemType
     const metadata = options.metadata
     const nbt = options.nbt
-    let count = options.count === null ? 1 : options.count
+    let count = (options.count === undefined || options.count === null) ? 1 : options.count
     let firstSourceSlot = null
 
     // ranges


### PR DESCRIPTION
Patches window.deposit throwing an error if "count" arg is undefined, figured this out with WhoTho since you should be able to only specify window.deposit(item.type), as the other args can be "null", however as WhoTho pointed out--

```
    undefined == null
    but
    undefined !== null
```

I messed up my last PR I think, still learning about PR stuff