### PR TITLE
Fix out of bounds access leading to crash at spawn

### DIFF
--- a/lib/plugins/breath.js
+++ b/lib/plugins/breath.js
@@ -11,7 +11,7 @@ function inject (bot) {
     if (bot.entity.id !== packet.entityId) return
     for (const metadata of packet.metadata) {
       if (metadata.key === 1) {
-        bot.oxygenLevel = Math.round(packet.metadata[1].value / 15)
+        bot.oxygenLevel = Math.round(metadata.value / 15)
         bot.emit('breath')
       }
     }


### PR DESCRIPTION
More information about the issue at #3534 

TLDR is that the previous iteration of the code would access element 1, even if it didn't exist, causing a crash when trying to read its field "value".