### PR TITLE
Patches isInWater for digSpeed

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -242,7 +242,7 @@ function inject (bot) {
     return block.digTime(
       type,
       creative,
-      bot.entity.isInWater,
+      bot.blockAt(bot.entity.position.offset(0, bot.entity.eyeHeight, 0)).name === 'water',
       !bot.entity.onGround,
       enchantments,
       bot.entity.effects


### PR DESCRIPTION
If the bot is standing in water it should not be slowed, however passing isInWater is slowing it, while digSpeed should only be slowed if the block at eyeHeight is water