### PR TITLE
Fix TypeError when removing event listeners in switchWorld

### DIFF
--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -508,7 +508,7 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       }
 
       for (const [name, listener] of Object.entries(bot._events)) {
-        if (name.startsWith('blockUpdate:')) {
+        if (name.startsWith('blockUpdate:') && typeof listener === 'function') {
           bot.emit(name, null, null)
           bot.off(name, listener)
         }


### PR DESCRIPTION
Added a check to ensure only valid function listeners are removed using bot.off, preventing the TypeError.