### PR TITLE
Fix silent failure when digging unbreakable blocks

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -24,6 +24,11 @@ function inject (bot) {
       digFace = 'auto'
     }
 
+    const waitTime = bot.digTime(block)
+    if (waitTime === Infinity) {
+      throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
+    }
+
     bot.targetDigFace = 1 // Default (top)
 
     if (forceLook !== 'ignore') {
@@ -127,7 +132,6 @@ function inject (bot) {
       location: block.position,
       face: bot.targetDigFace // default face is 1 (top)
     })
-    const waitTime = bot.digTime(block)
     waitTimeout = setTimeout(finishDigging, waitTime)
     bot.targetDigBlock = block
     bot.swingArm()


### PR DESCRIPTION
The `bot.digTime` function returns `Infinity` if the bot cannot break the block (such as "bedrock" or "barrier"), but if you pass `Infinity` to `setTimeout` it will produce the following warning:
```
TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```
This will result in a silent failure and the `bot.dig` function will resolve.

With this change, it will throw an error in such cases.