### PR TITLE
Fix potential null vehicle passengers array in entities plugin

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -830,6 +830,10 @@ function inject (bot) {
     const passengerEntities = passengers.map((passengerId) => fetchEntity(passengerId))
     const vehicle = entityId === -1 ? null : bot.entities[entityId]
 
+    if (vehicle && !vehicle.passengers) {
+      vehicle.passengers = []
+    }
+    
     for (const passengerEntity of passengerEntities) {
       const originalVehicle = passengerEntity.vehicle
       if (originalVehicle !== null) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -806,13 +806,21 @@ function inject (bot) {
     const passenger = fetchEntity(packet.entityId)
     const vehicle = packet.vehicleId === -1 ? null : fetchEntity(packet.vehicleId)
 
+    // Initialize passengers arrays if they don't exist
+    if (!passenger.passengers) passenger.passengers = []
+    if (vehicle && !vehicle.passengers) vehicle.passengers = []
+
     const originalVehicle = passenger.vehicle
-    if (originalVehicle !== null) {
+    if (originalVehicle && originalVehicle.passengers && Array.isArray(originalVehicle.passengers)) {
       const index = originalVehicle.passengers.indexOf(passenger)
-      originalVehicle.passengers = originalVehicle.passengers.splice(index, 1)
+      if (index !== -1) {
+        originalVehicle.passengers.splice(index, 1)
+      }
     }
     passenger.vehicle = vehicle
-    vehicle.passengers.push(passenger)
+    if (vehicle && vehicle.passengers && Array.isArray(vehicle.passengers)) {
+      vehicle.passengers.push(passenger)
+    }
 
     if (packet.entityId === bot.entity.id) {
       const vehicle = bot.vehicle
@@ -830,18 +838,28 @@ function inject (bot) {
     const passengerEntities = passengers.map((passengerId) => fetchEntity(passengerId))
     const vehicle = entityId === -1 ? null : bot.entities[entityId]
 
+    // Initialize passengers arrays
     if (vehicle && !vehicle.passengers) {
       vehicle.passengers = []
     }
     
     for (const passengerEntity of passengerEntities) {
-      const originalVehicle = passengerEntity.vehicle
-      if (originalVehicle !== null) {
-        const index = originalVehicle.passengers.indexOf(passengerEntity)
-        originalVehicle.passengers = originalVehicle.passengers.splice(index, 1)
+      if (!passengerEntity) continue; // Skip if passenger entity is null
+      
+      if (!passengerEntity.passengers) {
+        passengerEntity.passengers = []
       }
+      
+      const originalVehicle = passengerEntity.vehicle
+      if (originalVehicle && originalVehicle.passengers && Array.isArray(originalVehicle.passengers)) {
+        const index = originalVehicle.passengers.indexOf(passengerEntity)
+        if (index !== -1) {
+          originalVehicle.passengers.splice(index, 1) // Fixed: use splice directly instead of reassignment
+        }
+      }
+      
       passengerEntity.vehicle = vehicle
-      if (vehicle !== null) {
+      if (vehicle && vehicle.passengers && Array.isArray(vehicle.passengers)) {
         vehicle.passengers.push(passengerEntity)
       }
     }
@@ -860,19 +878,23 @@ function inject (bot) {
 
   // dismounting when the vehicle is gone
   bot._client.on('entityGone', (entity) => {
+    if (!entity) return;
+    
     if (bot.vehicle === entity) {
       bot.vehicle = null
       bot.emit('dismount', (entity))
     }
-    if (entity.passengers) {
+    if (entity.passengers && Array.isArray(entity.passengers)) {
       for (const passenger of entity.passengers) {
-        passenger.vehicle = null
+        if (passenger) {
+          passenger.vehicle = null
+        }
       }
     }
-    if (entity.vehicle) {
+    if (entity.vehicle && entity.vehicle.passengers && Array.isArray(entity.vehicle.passengers)) {
       const index = entity.vehicle.passengers.indexOf(entity)
       if (index !== -1) {
-        entity.vehicle.passengers = entity.vehicle.passengers.splice(index, 1)
+        entity.vehicle.passengers.splice(index, 1)
       }
     }
   })
@@ -979,7 +1001,13 @@ function inject (bot) {
   }
 
   function fetchEntity (id) {
-    return bot.entities[id] || (bot.entities[id] = new Entity(id))
+    if (!bot.entities[id]) {
+      const entity = new Entity(id)
+      entity.passengers = []
+      bot.entities[id] = entity
+      return entity
+    }
+    return bot.entities[id]
   }
 }
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -842,14 +842,14 @@ function inject (bot) {
     if (vehicle && !vehicle.passengers) {
       vehicle.passengers = []
     }
-    
+
     for (const passengerEntity of passengerEntities) {
-      if (!passengerEntity) continue; // Skip if passenger entity is null
-      
+      if (!passengerEntity) continue // Skip if passenger entity is null
+
       if (!passengerEntity.passengers) {
         passengerEntity.passengers = []
       }
-      
+
       const originalVehicle = passengerEntity.vehicle
       if (originalVehicle && originalVehicle.passengers && Array.isArray(originalVehicle.passengers)) {
         const index = originalVehicle.passengers.indexOf(passengerEntity)
@@ -857,7 +857,7 @@ function inject (bot) {
           originalVehicle.passengers.splice(index, 1) // Fixed: use splice directly instead of reassignment
         }
       }
-      
+
       passengerEntity.vehicle = vehicle
       if (vehicle && vehicle.passengers && Array.isArray(vehicle.passengers)) {
         vehicle.passengers.push(passengerEntity)
@@ -878,11 +878,11 @@ function inject (bot) {
 
   // dismounting when the vehicle is gone
   bot._client.on('entityGone', (entity) => {
-    if (!entity) return;
-    
+    if (!entity) return
+
     if (bot.vehicle === entity) {
       bot.vehicle = null
-      bot.emit('dismount', (entity))
+      bot.emit('dismount', entity)
     }
     if (entity.passengers && Array.isArray(entity.passengers)) {
       for (const passenger of entity.passengers) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -838,13 +838,12 @@ function inject (bot) {
     const passengerEntities = passengers.map((passengerId) => fetchEntity(passengerId))
     const vehicle = entityId === -1 ? null : bot.entities[entityId]
 
-    // Initialize passengers arrays
     if (vehicle && !vehicle.passengers) {
       vehicle.passengers = []
     }
 
     for (const passengerEntity of passengerEntities) {
-      if (!passengerEntity) continue // Skip if passenger entity is null
+      if (!passengerEntity) continue
 
       if (!passengerEntity.passengers) {
         passengerEntity.passengers = []
@@ -854,7 +853,7 @@ function inject (bot) {
       if (originalVehicle && originalVehicle.passengers && Array.isArray(originalVehicle.passengers)) {
         const index = originalVehicle.passengers.indexOf(passengerEntity)
         if (index !== -1) {
-          originalVehicle.passengers.splice(index, 1) // Fixed: use splice directly instead of reassignment
+          originalVehicle.passengers.splice(index, 1)
         }
       }
 

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -65,10 +65,12 @@ function inject (bot, options) {
       if (packet.worldType && !bot.game.dimension) {
         bot.game.dimension = packet.worldType.replace('minecraft:', '')
       }
-      const dimData = bot.registry.dimensionsByName[bot.game.dimension]
-      if (dimData) {
-        bot.game.minY = dimData.minY
-        bot.game.height = dimData.height
+      if (bot.registry.dimensionsByName) {
+        const dimData = bot.registry.dimensionsByName[bot.game.dimension]
+        if (dimData) {
+          bot.game.minY = dimData.minY
+          bot.game.height = dimData.height
+        }
       }
     } else if (bot.supportFeature('dimensionDataIsAvailable')) { // 1.16.2+
       const dimensionData = nbt.simplify(packet.dimension)


### PR DESCRIPTION
Fix crash caused by undefined vehicle entity in entities.js

This commit fixes a crash occurring when attempting to access `vehicle.passengers` 
on an undefined `vehicle` entity. The issue was triggered in:

lib\plugins\entities.js:841


```
TypeError: Cannot read properties of undefined (reading 'passengers')
    at Client.<anonymous> (C:\ops/mineflayer\lib\plugins\entities.js:841:17)
    at Client.emit (node:events:517:28)
    at emitPacket (C:\opsminecraft-protocol\src\client.js:84:12)
    at Array.forEach (<anonymous>)
    at FullPacketParser.<anonymous> (C:REDACTEDnode_modules\minecraft-protocol\src\client.js:99:26)
    at FullPacketParser.emit (node:events:517:28)
    at addChunk (C:REDACTEDnode_modules\readable-stream\lib\internal\streams\readable.js:323:12)
    at readableAddChunk (C:REDACTEDnode_modules\readable-stream\lib\internal\streams\readable.js:300:9)
    at Readable.push (C:REDACTEDnode_modules\readable-stream\lib\internal\streams\readable.js:246:10)
    at FullPacketParser._transform (C:REDACTEDnode_modules\protodef\src\serializer.js:89:10)
```
