### PR TITLE
Fix vehicle passengers array in entities being null

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -166,6 +166,7 @@ function inject (bot) {
       entity.kind = entityData.category
       entity.height = entityData.height
       entity.width = entityData.width
+      entity.passengers = []
     } else {
       // unknown entity
       entity.type = 'other'


### PR DESCRIPTION
Fixes `TypeError: Cannot read properties of undefined (reading 'passengers')` by adding passengers array in `setEntityData`