### PR TITLE
Entity Passengers get pushed wrongly

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -809,7 +809,7 @@ function inject (bot) {
     const originalVehicle = passenger.vehicle
     if (originalVehicle !== null) {
       const index = originalVehicle.passengers.indexOf(passenger)
-      originalVehicle.passengers = originalVehicle.passengers.splice(index, 1)
+      originalVehicle.passengers.splice(index, 1)
     }
     passenger.vehicle = vehicle
     vehicle.passengers.push(passenger)
@@ -834,7 +834,7 @@ function inject (bot) {
       const originalVehicle = passengerEntity.vehicle
       if (originalVehicle !== null) {
         const index = originalVehicle.passengers.indexOf(passengerEntity)
-        originalVehicle.passengers = originalVehicle.passengers.splice(index, 1)
+        originalVehicle.passengers.splice(index, 1)
       }
       passengerEntity.vehicle = vehicle
       if (vehicle !== null) {
@@ -868,7 +868,7 @@ function inject (bot) {
     if (entity.vehicle) {
       const index = entity.vehicle.passengers.indexOf(entity)
       if (index !== -1) {
-        entity.vehicle.passengers = entity.vehicle.passengers.splice(index, 1)
+        entity.vehicle.passengers.splice(index, 1)
       }
     }
   })

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -807,7 +807,7 @@ function inject (bot) {
     const vehicle = packet.vehicleId === -1 ? null : fetchEntity(packet.vehicleId)
 
     const originalVehicle = passenger.vehicle
-    if (originalVehicle !== null) {
+    if (originalVehicle) {
       const index = originalVehicle.passengers.indexOf(passenger)
       originalVehicle.passengers.splice(index, 1)
     }
@@ -832,12 +832,12 @@ function inject (bot) {
 
     for (const passengerEntity of passengerEntities) {
       const originalVehicle = passengerEntity.vehicle
-      if (originalVehicle !== null) {
+      if (originalVehicle) {
         const index = originalVehicle.passengers.indexOf(passengerEntity)
         originalVehicle.passengers.splice(index, 1)
       }
       passengerEntity.vehicle = vehicle
-      if (vehicle !== null) {
+      if (vehicle) {
         vehicle.passengers.push(passengerEntity)
       }
     }


### PR DESCRIPTION

```js
originalVehicle.passengers = originalVehicle.passengers.splice(index, 1)
```
Hey! If I understood this correctly: Reassignment is unnecessary, splice already modifies the array itself, which resulted in https://github.com/PrismarineJS/mineflayer/issues/3600