### PR TITLE
fix incorrect rotation during useItem()

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -128,7 +128,7 @@ function inject (bot, { hideErrors }) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
         sequence,
-        rotation: { x: 0, y: 0 }
+        rotation: { yaw: 0, pitch: 0 }
       })
     }
   }


### PR DESCRIPTION
For 1.21, #3480 introduces a new field `rotation` for `useItem`. However, the field may not be correct. According to [Minecraft Protocol](https://minecraft.wiki/w/Java_Edition_protocol#Use_Item), `rotation` should have fields `yaw` and `pitch`, but not `x` and `y`. In practice, lacking the two field will lead to bot facing default direction when `useItem` is called.