### PR TITLE
Added if (vehicle) check

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -813,7 +813,9 @@ function inject (bot) {
       originalVehicle.passengers.splice(index, 1)
     }
     passenger.vehicle = vehicle
-    vehicle.passengers.push(passenger)
+    if (vehicle) {
+      vehicle.passengers.push(passenger)
+    }
 
     if (packet.entityId === bot.entity.id) {
       const vehicle = bot.vehicle


### PR DESCRIPTION
In line 816 of entities.js, a null/undefined check for vehicle was missing.

Noticed it while dismounting from a horse on an `mcproxy` 1.8.8 instance