### PR TITLE
fix firing heldItemChanged, add type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,7 @@ export interface BotEvents {
   bossBarDeleted: (bossBar: BossBar) => Promise<void> | void
   bossBarUpdated: (bossBar: BossBar) => Promise<void> | void
   resourcePack: (url: string, hash?: string, uuid?: string) => Promise<void> | void
+  heldItemChanged: (newItem: Item | null) => Promise<void> | void
   particle: (particle: Particle) => Promise<void> | void
 }
 
@@ -386,8 +387,8 @@ export interface Bot extends TypedEmitter<BotEvents> {
     times?: number
   ) => Promise<void>
 
-  
-  
+
+
   setCommandBlock: (pos: Vec3, command: string, options: CommandBlockOptions) => void
 
   clickWindow: (

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -547,7 +547,7 @@ function inject (bot, { hideErrors }) {
     }
     const window = bot.currentWindow || bot.inventory
 
-    assert.ok(mode >= 0 && mode <= 4)
+    assert.ok(mode >= 0 && mode <= 6)
     const actionId = createActionNumber()
 
     const click = {
@@ -727,6 +727,11 @@ function inject (bot, { hideErrors }) {
     if (!window || window.id !== packet.windowId) return
     const newItem = Item.fromNotch(packet.item)
     bot._setSlot(packet.slot, newItem, window)
+  })
+  bot.inventory.on('updateSlot', (index) => {
+    if (index === bot.quickBarSlot + bot.inventory.hotbarStart) {
+      bot.emit('heldItemChanged')
+    }
   })
   bot._client.on('window_items', (packet) => {
     const window = packet.windowId === 0 ? bot.inventory : bot.currentWindow


### PR DESCRIPTION
Make sure to *always* fire `heldItemChanged` when its actually changed from windows API or any other external call that messes with the prismarine windows