### PR TITLE
activateItem: Added argument for degree, default fallback 

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -21,7 +21,7 @@ const ALWAYS_CONSUMABLES = [
   'golden_apple'
 ]
 
-function inject(bot, { hideErrors }) {
+function inject (bot, { hideErrors }) {
   const Item = require('prismarine-item')(bot.registry)
   const windows = require('prismarine-windows')(bot.version)
 
@@ -56,11 +56,11 @@ function inject(bot, { hideErrors }) {
       get: bot.supportFeature('doesntHaveOffHandSlot')
         ? function () {
           return [bot.heldItem, bot.inventory.slots[8], bot.inventory.slots[7],
-          bot.inventory.slots[6], bot.inventory.slots[5]]
+            bot.inventory.slots[6], bot.inventory.slots[5]]
         }
         : function () {
           return [bot.heldItem, bot.inventory.slots[45], bot.inventory.slots[8],
-          bot.inventory.slots[7], bot.inventory.slots[6], bot.inventory.slots[5]]
+            bot.inventory.slots[7], bot.inventory.slots[6], bot.inventory.slots[5]]
         }
     })
   })
@@ -95,7 +95,7 @@ function inject(bot, { hideErrors }) {
     bot.usingHeldItem = false
   })
 
-  async function consume() {
+  async function consume () {
     if (!eatingTask.done) {
       eatingTask.cancel(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
@@ -111,7 +111,7 @@ function inject(bot, { hideErrors }) {
     await withTimeout(eatingTask.promise, CONSUME_TIMEOUT)
   }
 
-  function activateItem(offHand = false, DegreeX, DegreeY) {
+  function activateItem (offHand = false, DegreeX, DegreeY) {
     const degMath = 180 / Math.PI;
     // IF the Degrees do not exist then resort to bots current angle
     DegreeX ??= -bot.entity.yaw * degMath + 180;
@@ -136,8 +136,7 @@ function inject(bot, { hideErrors }) {
       })
     }
   }
-
-  function deactivateItem() {
+  function deactivateItem () {
     const body = {
       status: 5,
       location: new Vec3(0, 0, 0),
@@ -154,7 +153,7 @@ function inject(bot, { hideErrors }) {
     bot.usingHeldItem = false
   }
 
-  async function putSelectedItemRange(start, end, window, slot) {
+  async function putSelectedItemRange (start, end, window, slot) {
     // put the selected item back indow the slot range in window
 
     // try to put it in an item that already exists and just increase
@@ -180,14 +179,14 @@ function inject(bot, { hideErrors }) {
       }
     }
 
-    async function tossLeftover() {
+    async function tossLeftover () {
       if (window.selectedItem) {
         await clickWindow(-999, 0, 0)
       }
     }
   }
 
-  async function activateBlock(block, direction, cursorPos) {
+  async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
     cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
@@ -240,7 +239,7 @@ function inject(bot, { hideErrors }) {
     bot.swingArm()
   }
 
-  async function activateEntity(entity) {
+  async function activateEntity (entity) {
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(entity.position.offset(0, 1, 0), false)
     bot._client.write('use_entity', {
@@ -251,7 +250,7 @@ function inject(bot, { hideErrors }) {
     })
   }
 
-  async function activateEntityAt(entity, position) {
+  async function activateEntityAt (entity, position) {
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(position, false)
     bot._client.write('use_entity', {
@@ -265,7 +264,7 @@ function inject(bot, { hideErrors }) {
     })
   }
 
-  async function transfer(options) {
+  async function transfer (options) {
     const window = options.window || bot.currentWindow || bot.inventory
     const itemType = options.itemType
     const metadata = options.metadata
@@ -283,7 +282,7 @@ function inject(bot, { hideErrors }) {
 
     await transferOne()
 
-    async function transferOne() {
+    async function transferOne () {
       if (count === 0) {
         await putSelectedItemRange(sourceStart, sourceEnd, window, firstSourceSlot)
         return
@@ -302,7 +301,7 @@ function inject(bot, { hideErrors }) {
       }
       await clickDest()
 
-      async function clickDest() {
+      async function clickDest () {
         assert.notStrictEqual(window.selectedItem.type, null)
         assert.notStrictEqual(window.selectedItem.metadata, null)
         let destItem
@@ -343,7 +342,7 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  function extendWindow(window) {
+  function extendWindow (window) {
     window.close = () => {
       closeWindow(window)
       window.emit('close')
@@ -382,30 +381,30 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  async function openBlock(block, direction, cursorPos) {
+  async function openBlock (block, direction, cursorPos) {
     bot.activateBlock(block, direction, cursorPos)
     const [window] = await once(bot, 'windowOpen')
     extendWindow(window)
     return window
   }
 
-  async function openEntity(entity) {
+  async function openEntity (entity) {
     bot.activateEntity(entity)
     const [window] = await once(bot, 'windowOpen')
     extendWindow(window)
     return window
   }
 
-  function createActionNumber() {
+  function createActionNumber () {
     nextActionNumber = nextActionNumber === 32767 ? 1 : nextActionNumber + 1
     return nextActionNumber
   }
 
-  function updateHeldItem() {
+  function updateHeldItem () {
     bot.emit('heldItemChanged', bot.heldItem)
   }
 
-  function closeWindow(window) {
+  function closeWindow (window) {
     bot._client.write('close_window', {
       windowId: window.id
     })
@@ -414,7 +413,7 @@ function inject(bot, { hideErrors }) {
     bot.emit('windowClose', window)
   }
 
-  function copyInventory(window) {
+  function copyInventory (window) {
     const slotOffset = window.inventoryStart - bot.inventory.inventoryStart
     for (let i = window.inventoryStart; i < window.inventoryEnd; i++) {
       const item = window.slots[i]
@@ -426,7 +425,7 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  function tradeMatch(limitItem, targetItem) {
+  function tradeMatch (limitItem, targetItem) {
     return (
       targetItem !== null &&
       limitItem !== null &&
@@ -435,7 +434,7 @@ function inject(bot, { hideErrors }) {
     )
   }
 
-  function expectTradeUpdate(window) {
+  function expectTradeUpdate (window) {
     const trade = window.selectedTrade
     const hasItem = !!window.slots[2]
 
@@ -448,7 +447,7 @@ function inject(bot, { hideErrors }) {
     return false
   }
 
-  async function waitForWindowUpdate(window, slot) {
+  async function waitForWindowUpdate (window, slot) {
     if (window.type === 'minecraft:inventory') {
       if (slot >= 1 && slot <= 4) {
         await once(bot.inventory, 'updateSlot:0')
@@ -477,7 +476,7 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  function confirmTransaction(windowId, actionId, accepted) {
+  function confirmTransaction (windowId, actionId, accepted) {
     // drop the queue entries for all the clicks that the server did not send
     // transaction packets for.
     // Also reject transactions that aren't sent from mineflayer
@@ -509,14 +508,14 @@ function inject(bot, { hideErrors }) {
     }
     updateHeldItem()
 
-    function onAccepted() {
+    function onAccepted () {
       const window = windowId === 0 ? bot.inventory : bot.currentWindow
       if (!window || window.id !== click.windowId) return
       window.acceptClick(click)
       bot.emit(`confirmTransaction${click.id}`, true)
     }
 
-    function onRejected() {
+    function onRejected () {
       bot._client.write('transaction', {
         windowId: click.windowId,
         action: click.id,
@@ -526,7 +525,7 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  function getChangedSlots(oldSlots, newSlots) {
+  function getChangedSlots (oldSlots, newSlots) {
     assert.equal(oldSlots.length, newSlots.length)
 
     const changedSlots = []
@@ -540,7 +539,7 @@ function inject(bot, { hideErrors }) {
     return changedSlots
   }
 
-  async function clickWindow(slot, mouseButton, mode) {
+  async function clickWindow (slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
     if (slot >= bot.QUICK_BAR_START && bot.lastDigTime != null) {
@@ -568,7 +567,7 @@ function inject(bot, { hideErrors }) {
       windowClickQueue.push(click)
     } else {
       if (
-        // this array indicates the clicks that return changedSlots
+      // this array indicates the clicks that return changedSlots
         [
           0,
           // 1,
@@ -645,7 +644,7 @@ function inject(bot, { hideErrors }) {
     }
   }
 
-  async function putAway(slot) {
+  async function putAway (slot) {
     const window = bot.currentWindow || bot.inventory
     const promisePutAway = once(window, `updateSlot:${slot}`)
     await clickWindow(slot, 0, 0)
@@ -655,7 +654,7 @@ function inject(bot, { hideErrors }) {
     await promisePutAway
   }
 
-  async function moveSlotItem(sourceSlot, destSlot) {
+  async function moveSlotItem (sourceSlot, destSlot) {
     await clickWindow(sourceSlot, 0, 0)
     await clickWindow(destSlot, 0, 0)
     // if we're holding an item, put it back where the source item was.
@@ -676,7 +675,7 @@ function inject(bot, { hideErrors }) {
     bot.setQuickBarSlot(packet.slot)
   })
 
-  function prepareWindow(window) {
+  function prepareWindow (window) {
     if (!windowItems || window.id !== windowItems.windowId) {
       // don't emit windowOpen until we have the slot data
       bot.once(`setWindowItems:${window.id}`, () => {
@@ -753,7 +752,7 @@ function inject(bot, { hideErrors }) {
    * @param {Vec3} v
    * @returns {number}
    */
-  function vectorToDirection(v) {
+  function vectorToDirection (v) {
     if (v.y < 0) {
       return 0
     } else if (v.y > 0) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -21,7 +21,7 @@ const ALWAYS_CONSUMABLES = [
   'golden_apple'
 ]
 
-function inject (bot, { hideErrors }) {
+function inject(bot, { hideErrors }) {
   const Item = require('prismarine-item')(bot.registry)
   const windows = require('prismarine-windows')(bot.version)
 
@@ -56,11 +56,11 @@ function inject (bot, { hideErrors }) {
       get: bot.supportFeature('doesntHaveOffHandSlot')
         ? function () {
           return [bot.heldItem, bot.inventory.slots[8], bot.inventory.slots[7],
-            bot.inventory.slots[6], bot.inventory.slots[5]]
+          bot.inventory.slots[6], bot.inventory.slots[5]]
         }
         : function () {
           return [bot.heldItem, bot.inventory.slots[45], bot.inventory.slots[8],
-            bot.inventory.slots[7], bot.inventory.slots[6], bot.inventory.slots[5]]
+          bot.inventory.slots[7], bot.inventory.slots[6], bot.inventory.slots[5]]
         }
     })
   })
@@ -95,7 +95,7 @@ function inject (bot, { hideErrors }) {
     bot.usingHeldItem = false
   })
 
-  async function consume () {
+  async function consume() {
     if (!eatingTask.done) {
       eatingTask.cancel(new Error('Consuming cancelled due to calling bot.consume() again'))
     }
@@ -111,10 +111,14 @@ function inject (bot, { hideErrors }) {
     await withTimeout(eatingTask.promise, CONSUME_TIMEOUT)
   }
 
-  function activateItem (offHand = false) {
+  function activateItem(offHand = false, DegreeX, DegreeY) {
+    const degMath = 180 / Math.PI;
+    // IF the Degrees do not exist then resort to bots current angle
+    DegreeX ??= -bot.entity.yaw * degMath + 180;
+    DegreeY ??= -bot.entity.pitch * degMath;
+    // a
     bot.usingHeldItem = true
     sequence++
-
     if (bot.supportFeature('useItemWithBlockPlace')) {
       bot._client.write('block_place', {
         location: new Vec3(-1, 255, -1),
@@ -128,12 +132,12 @@ function inject (bot, { hideErrors }) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
         sequence,
-        rotation: { x: 0, y: 0 }
+        rotation: { x: DegreeX, y: DegreeY }
       })
     }
   }
 
-  function deactivateItem () {
+  function deactivateItem() {
     const body = {
       status: 5,
       location: new Vec3(0, 0, 0),
@@ -150,7 +154,7 @@ function inject (bot, { hideErrors }) {
     bot.usingHeldItem = false
   }
 
-  async function putSelectedItemRange (start, end, window, slot) {
+  async function putSelectedItemRange(start, end, window, slot) {
     // put the selected item back indow the slot range in window
 
     // try to put it in an item that already exists and just increase
@@ -176,14 +180,14 @@ function inject (bot, { hideErrors }) {
       }
     }
 
-    async function tossLeftover () {
+    async function tossLeftover() {
       if (window.selectedItem) {
         await clickWindow(-999, 0, 0)
       }
     }
   }
 
-  async function activateBlock (block, direction, cursorPos) {
+  async function activateBlock(block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
     cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
@@ -236,7 +240,7 @@ function inject (bot, { hideErrors }) {
     bot.swingArm()
   }
 
-  async function activateEntity (entity) {
+  async function activateEntity(entity) {
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(entity.position.offset(0, 1, 0), false)
     bot._client.write('use_entity', {
@@ -247,7 +251,7 @@ function inject (bot, { hideErrors }) {
     })
   }
 
-  async function activateEntityAt (entity, position) {
+  async function activateEntityAt(entity, position) {
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(position, false)
     bot._client.write('use_entity', {
@@ -261,7 +265,7 @@ function inject (bot, { hideErrors }) {
     })
   }
 
-  async function transfer (options) {
+  async function transfer(options) {
     const window = options.window || bot.currentWindow || bot.inventory
     const itemType = options.itemType
     const metadata = options.metadata
@@ -279,7 +283,7 @@ function inject (bot, { hideErrors }) {
 
     await transferOne()
 
-    async function transferOne () {
+    async function transferOne() {
       if (count === 0) {
         await putSelectedItemRange(sourceStart, sourceEnd, window, firstSourceSlot)
         return
@@ -298,7 +302,7 @@ function inject (bot, { hideErrors }) {
       }
       await clickDest()
 
-      async function clickDest () {
+      async function clickDest() {
         assert.notStrictEqual(window.selectedItem.type, null)
         assert.notStrictEqual(window.selectedItem.metadata, null)
         let destItem
@@ -339,7 +343,7 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  function extendWindow (window) {
+  function extendWindow(window) {
     window.close = () => {
       closeWindow(window)
       window.emit('close')
@@ -378,30 +382,30 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  async function openBlock (block, direction, cursorPos) {
+  async function openBlock(block, direction, cursorPos) {
     bot.activateBlock(block, direction, cursorPos)
     const [window] = await once(bot, 'windowOpen')
     extendWindow(window)
     return window
   }
 
-  async function openEntity (entity) {
+  async function openEntity(entity) {
     bot.activateEntity(entity)
     const [window] = await once(bot, 'windowOpen')
     extendWindow(window)
     return window
   }
 
-  function createActionNumber () {
+  function createActionNumber() {
     nextActionNumber = nextActionNumber === 32767 ? 1 : nextActionNumber + 1
     return nextActionNumber
   }
 
-  function updateHeldItem () {
+  function updateHeldItem() {
     bot.emit('heldItemChanged', bot.heldItem)
   }
 
-  function closeWindow (window) {
+  function closeWindow(window) {
     bot._client.write('close_window', {
       windowId: window.id
     })
@@ -410,7 +414,7 @@ function inject (bot, { hideErrors }) {
     bot.emit('windowClose', window)
   }
 
-  function copyInventory (window) {
+  function copyInventory(window) {
     const slotOffset = window.inventoryStart - bot.inventory.inventoryStart
     for (let i = window.inventoryStart; i < window.inventoryEnd; i++) {
       const item = window.slots[i]
@@ -422,7 +426,7 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  function tradeMatch (limitItem, targetItem) {
+  function tradeMatch(limitItem, targetItem) {
     return (
       targetItem !== null &&
       limitItem !== null &&
@@ -431,7 +435,7 @@ function inject (bot, { hideErrors }) {
     )
   }
 
-  function expectTradeUpdate (window) {
+  function expectTradeUpdate(window) {
     const trade = window.selectedTrade
     const hasItem = !!window.slots[2]
 
@@ -444,7 +448,7 @@ function inject (bot, { hideErrors }) {
     return false
   }
 
-  async function waitForWindowUpdate (window, slot) {
+  async function waitForWindowUpdate(window, slot) {
     if (window.type === 'minecraft:inventory') {
       if (slot >= 1 && slot <= 4) {
         await once(bot.inventory, 'updateSlot:0')
@@ -473,7 +477,7 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  function confirmTransaction (windowId, actionId, accepted) {
+  function confirmTransaction(windowId, actionId, accepted) {
     // drop the queue entries for all the clicks that the server did not send
     // transaction packets for.
     // Also reject transactions that aren't sent from mineflayer
@@ -505,14 +509,14 @@ function inject (bot, { hideErrors }) {
     }
     updateHeldItem()
 
-    function onAccepted () {
+    function onAccepted() {
       const window = windowId === 0 ? bot.inventory : bot.currentWindow
       if (!window || window.id !== click.windowId) return
       window.acceptClick(click)
       bot.emit(`confirmTransaction${click.id}`, true)
     }
 
-    function onRejected () {
+    function onRejected() {
       bot._client.write('transaction', {
         windowId: click.windowId,
         action: click.id,
@@ -522,7 +526,7 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  function getChangedSlots (oldSlots, newSlots) {
+  function getChangedSlots(oldSlots, newSlots) {
     assert.equal(oldSlots.length, newSlots.length)
 
     const changedSlots = []
@@ -536,7 +540,7 @@ function inject (bot, { hideErrors }) {
     return changedSlots
   }
 
-  async function clickWindow (slot, mouseButton, mode) {
+  async function clickWindow(slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
     if (slot >= bot.QUICK_BAR_START && bot.lastDigTime != null) {
@@ -564,7 +568,7 @@ function inject (bot, { hideErrors }) {
       windowClickQueue.push(click)
     } else {
       if (
-      // this array indicates the clicks that return changedSlots
+        // this array indicates the clicks that return changedSlots
         [
           0,
           // 1,
@@ -641,7 +645,7 @@ function inject (bot, { hideErrors }) {
     }
   }
 
-  async function putAway (slot) {
+  async function putAway(slot) {
     const window = bot.currentWindow || bot.inventory
     const promisePutAway = once(window, `updateSlot:${slot}`)
     await clickWindow(slot, 0, 0)
@@ -651,7 +655,7 @@ function inject (bot, { hideErrors }) {
     await promisePutAway
   }
 
-  async function moveSlotItem (sourceSlot, destSlot) {
+  async function moveSlotItem(sourceSlot, destSlot) {
     await clickWindow(sourceSlot, 0, 0)
     await clickWindow(destSlot, 0, 0)
     // if we're holding an item, put it back where the source item was.
@@ -672,7 +676,7 @@ function inject (bot, { hideErrors }) {
     bot.setQuickBarSlot(packet.slot)
   })
 
-  function prepareWindow (window) {
+  function prepareWindow(window) {
     if (!windowItems || window.id !== windowItems.windowId) {
       // don't emit windowOpen until we have the slot data
       bot.once(`setWindowItems:${window.id}`, () => {
@@ -749,7 +753,7 @@ function inject (bot, { hideErrors }) {
    * @param {Vec3} v
    * @returns {number}
    */
-  function vectorToDirection (v) {
+  function vectorToDirection(v) {
     if (v.y < 0) {
       return 0
     } else if (v.y > 0) {


### PR DESCRIPTION
Allows users to specify the degrees to which the bot should turn, defaulting to the bot’s current rotation if no values are provided.

Problem: 
By default, activateItem aims at coordinates (0, 0) if no degrees are specified.
Referenced here: https://github.com/PrismarineJS/mineflayer/blob/f6187f66c16dd122165287be7864c78b2fe7c32c/lib/plugins/inventory.js#L131
