### PR TITLE
fix prismarine-windows to use registry

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -23,7 +23,7 @@ const ALWAYS_CONSUMABLES = [
 
 function inject (bot, { hideErrors }) {
   const Item = require('prismarine-item')(bot.registry)
-  const windows = require('prismarine-windows')(bot.version)
+  const windows = require('prismarine-windows')(bot.registry)
 
   let eatingTask = createDoneTask()
   let sequence = 0


### PR DESCRIPTION
Reasoning: breaks certain plugins otherwise, not entirely sure why. 

Using registry is the best choice though, and is properly supported by prismarine-windows.