### PR TITLE
Fix crash issue when trying to parse bad skin JSON

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -943,8 +943,13 @@ function extractSkinInformation (properties) {
     return undefined
   }
 
-  const skinTexture = JSON.parse(Buffer.from(props.textures.value, 'base64').toString('utf8'))
+  const skinTextureString = Buffer.from(props.textures.value, 'base64').toString('utf8')
+  .split("{textures:").join("{\"textures\":")
+  .split("{SKIN:").join("{\"SKIN\":")
+  .split("{url:").join("{\"url\":")
 
+  const skinTexture = JSON.parse(skinTextureString)
+  
   const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? undefined
   const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? undefined
 


### PR DESCRIPTION
Bad skin JSON sometimes occur with NPC players on servers, this will fix the JSON by adding missing quotes if found.

Example of JSON of a NPC player (notice the missing quotes) :
```js
{textures:{SKIN:{url:"http://textures.minecraft.net/texture/b67168621fdb0cf3f7e57cb5166d48e9e9c87d677494339f3b8feec8c3a36b"}}}
```

For comparison, this is what a normal player skin data looks like :
```js
{
  "timestamp" : 1754070097924,
  "profileId" : "ec7732e7890547fdae796508b583fef3",
  "profileName" : "wtfsofie",
  "signatureRequired" : true,
  "textures" : {
    "SKIN" : {
      "url" : "http://textures.minecraft.net/texture/c000d56909bcbb3542c65a2eb1b1c4810f907b277d041da2a1b16c894a96030c",
      "metadata" : {
        "model" : "slim"
      }
    },
    "CAPE" : {
      "url" : "http://textures.minecraft.net/texture/cb40a92e32b57fd732a00fc325e7afb00a7ca74936ad50d8e860152e482cfbde"
    }
  }
}```
