### PR TITLE
Fix knockback physics crash (#3635)

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -296,7 +296,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     // TODO: emit an explosion event with more info
     if (bot.physicsEnabled && bot.game.gameMode !== 'creative') {
       if (explosion.playerKnockback) { // 1.21.3+
-        bot.entity.velocity.add(explosion.playerMotionX, explosion.playerMotionY, explosion.playerMotionZ)
+        // Fixes issue #3635
+        bot.entity.velocity.x += explosion.playerKnockback.x
+        bot.entity.velocity.y += explosion.playerKnockback.y
+        bot.entity.velocity.z += explosion.playerKnockback.z
       }
       if ('playerMotionX' in explosion) {
         bot.entity.velocity.x += explosion.playerMotionX


### PR DESCRIPTION
Pretty simple fix to stop the bot from crashing when trying to handle knockback from explosions on newer minecraft versions.

Fixes: #3635 and #3648

This has been bugging me ever since i started using mineflayer, so i fixed it.