### PR TITLE
Disable physics during configuration packet

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -449,5 +449,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
   })
+  
+  bot._client.on('start_configuration', () => { shouldUsePhysics = false })
+  bot._client.on('finish_configuration', () => { shouldUsePhysics = true })
+  
   bot.on('end', cleanup)
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -449,9 +449,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
   })
-  
+
   bot._client.on('start_configuration', () => { shouldUsePhysics = false })
   bot._client.on('finish_configuration', () => { shouldUsePhysics = true })
-  
+
   bot.on('end', cleanup)
 }


### PR DESCRIPTION
I've found that connecting to a server with minecraft version `1.20.4` didn't work - throwing quite ambiguous error `An internal error occurred in your connection`, but after trying different things for a while I figured it works well on `1.20` and only some servers throw that error. I compared the packet trace between those two versions and one difference I found was that in 1.20.4, servers send `start_configuration` packets during gameplay to reconfigure clients, but mineflayer's physics plugin was missing handlers for this. The bot continued sending position packets while in configuration state, which is invalid and causes the server to kick the client