### PR TITLE
Fixed buckets

### DIFF
--- a/examples/bucketer.js
+++ b/examples/bucketer.js
@@ -1,7 +1,7 @@
 const mineflayer = require('mineflayer')
 
 // put the bot on grass, give it a water bucket, and say "water_bucket grass_block"
-// this just uses any item type on any target block, but is not bot.useOnBlock
+// this just uses any item type on any target block, but is not bot.activateBlock
 
 const bot = mineflayer.createBot({
   host: 'localhost',

--- a/examples/bucketer.js
+++ b/examples/bucketer.js
@@ -4,34 +4,34 @@ const mineflayer = require('mineflayer')
 // this just uses any item type on any target block, but is not bot.useOnBlock
 
 const bot = mineflayer.createBot({
-    host: 'localhost',  
-    port: 55916,
-    username: 'bucket_bot',
-});
+  host: 'localhost',
+  port: 55916,
+  username: 'bucket_bot'
+})
 
 bot.on('login', async () => {
-    bot.on('chat', async (username, message) => {
-        if (username === 'bucket_bot') return;
-        const [tool_name, target_name] = message.split(' ');
-        // equip water bucket
-        let bucket = bot.inventory.items().find(item => item.name === tool_name);
-        if (!bucket) {
-            bot.chat('no ' + tool_name);
-            return;
-        }
-        await bot.equip(bucket, 'hand');
+  bot.on('chat', async (username, message) => {
+    if (username === 'bucket_bot') return
+    const [toolName, targetName] = message.split(' ')
+    // equip water bucket
+    const bucket = bot.inventory.items().find(item => item.name === toolName)
+    if (!bucket) {
+      bot.chat('no ' + toolName)
+      return
+    }
+    await bot.equip(bucket, 'hand')
 
-        let target = bot.findBlock({
-            matching: block => block.name === target_name.toLowerCase(),
-            maxDistance: 3
-        });
+    const target = bot.findBlock({
+      matching: block => block.name === targetName.toLowerCase(),
+      maxDistance: 3
+    })
 
-        if (!target) {
-            bot.chat('no target');
-            return;
-        }
+    if (!target) {
+      bot.chat('no target')
+      return
+    }
 
-        await bot.lookAt(target.position.offset(0.5, 0.5, 0.5))
-        await bot.activateItem() // dont use activateBlock
-    });
-});
+    await bot.lookAt(target.position.offset(0.5, 0.5, 0.5))
+    await bot.activateItem() // dont use activateBlock
+  })
+})

--- a/examples/bucketer.js
+++ b/examples/bucketer.js
@@ -1,0 +1,37 @@
+const mineflayer = require('mineflayer')
+
+// put the bot on grass, give it a water bucket, and say "water_bucket grass_block"
+// this just uses any item type on any target block, but is not bot.useOnBlock
+
+const bot = mineflayer.createBot({
+    host: 'localhost',  
+    port: 55916,
+    username: 'bucket_bot',
+});
+
+bot.on('login', async () => {
+    bot.on('chat', async (username, message) => {
+        if (username === 'bucket_bot') return;
+        const [tool_name, target_name] = message.split(' ');
+        // equip water bucket
+        let bucket = bot.inventory.items().find(item => item.name === tool_name);
+        if (!bucket) {
+            bot.chat('no ' + tool_name);
+            return;
+        }
+        await bot.equip(bucket, 'hand');
+
+        let target = bot.findBlock({
+            matching: block => block.name === target_name.toLowerCase(),
+            maxDistance: 3
+        });
+
+        if (!target) {
+            bot.chat('no target');
+            return;
+        }
+
+        await bot.lookAt(target.position.offset(0.5, 0.5, 0.5))
+        await bot.activateItem() // dont use activateBlock
+    });
+});

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -125,10 +125,16 @@ function inject (bot, { hideErrors }) {
         cursorZ: -1
       })
     } else if (bot.supportFeature('useItemWithOwnPacket')) {
+      // convert from bot's rotation radians to client's shifted/inverted degrees
+      const yawDeg = -bot.entity.yaw * 180 / Math.PI + 180 // invert + shift
+      const pitchDeg = -bot.entity.pitch * 180 / Math.PI // invert
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
         sequence,
-        rotation: { x: 0, y: 0 }
+        rotation: {
+          x: yawDeg,
+          y: pitchDeg
+        }
       })
     }
   }


### PR DESCRIPTION
Fixed buckets by fixing `activateItem`.

Previously, the `rotation` parameters were hard-coded and forced the wrong rotation, so I convert current bot.entity.rotation to the expected x, y. 

Added an example script `bucketer.js` to test and to document bucket usage, which isn't obvious. `placeBlock` and `activateBlock` don't work with buckets.