### PR TITLE
Resolved type mismatch

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -348,7 +348,7 @@ function inject (bot) {
   bot._client.on('sync_entity_position', (packet) => {
     const entity = fetchEntity(packet.entityId)
     entity.position.set(packet.x, packet.y, packet.z)
-    entity.velocity.update(packet.dx, packet.dy, packet.dz)
+    entity.velocity.set(packet.dx, packet.dy, packet.dz)
     entity.yaw = packet.yaw
     entity.pitch = packet.pitch
     bot.emit('entityMoved', entity)


### PR DESCRIPTION
Vec3.set(number, number, number)
Vec3.update({x,y,z})

Vec3.update should not be called with three numbers it expects a vector.

<img width="866" height="272" alt="image" src="https://github.com/user-attachments/assets/9f192ad8-ea55-4d0e-bf3e-a2738271eb02" />
<img width="474" height="226" alt="image" src="https://github.com/user-attachments/assets/08c7603d-baca-43f1-bee1-face6aea3d11" />

https://github.com/PrismarineJS/prismarine-entity/issues/106
