### PR TITLE
allow the use of plugins/physics without plugins/blocks as a dep

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -17,14 +17,14 @@ const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000 // 0.05
 function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const PHYSICS_CATCHUP_TICKS = maxCatchupTicks ?? 4
   const world = {
-  getBlock: (pos) => {
-    if (typeof bot.blockAt === 'function') {
-      return bot.blockAt(pos, false)
+    getBlock: (pos) => {
+      if (typeof bot.blockAt === 'function') {
+        return bot.blockAt(pos, false)
+      }
+      // if blocks plugin is unloaded, return a minimal air block object
+      return { name: 'air', type: 0, boundingBox: 'empty', shapes: [], position: pos }
     }
-    // if blocks plugin is unloaded, return a minimal air block object
-    return { name: 'air', type: 0, boundingBox: 'empty', shapes: [], position: pos }
   }
-}
   const physics = Physics(bot.registry, world)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')


### PR DESCRIPTION
I choose to use the built-in functionality of setting loadInternalPlugins to false so I can pick and choose which ones to load (namely, disabling the blocks plugin since the block change packets are using too much throughput for what I'm doing and are causing async lag and CPU overload).
I'd still like to use the physics plugin without requiring the bots' knowledge of the world state, so the solution I've found is to pass an air block into the physics module. 