### PR TITLE
Adjust game height and minimum Y values

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -56,8 +56,8 @@ function inject (bot, options) {
       bot.registry.loadDimensionCodec(packet.dimensionCodec)
     }
 
-    bot.game.minY = 0
-    bot.game.height = 256
+    bot.game.minY = -64
+    bot.game.height = 320
 
     if (bot.supportFeature('dimensionDataInCodec')) { // 1.19+
       // pre 1.20.5 before we consolidated login and respawn's SpawnInfo structure into one type,


### PR DESCRIPTION
The minimum Y was wrong for versions >1.17, and height was wrong for >1.18