### PR TITLE
Add Velocity proxy support for Minecraft 1.20.2+ configuration phase

### DIFF
--- a/examples/velocity_manual_resourcepack.js
+++ b/examples/velocity_manual_resourcepack.js
@@ -1,0 +1,56 @@
+/*
+ * This example shows how to disable the velocity plugin
+ * and manually handle resource packs during Velocity transfers
+ *
+ * Use this if you want full control over resource pack acceptance
+ * instead of the automatic behavior.
+ *
+ * WARNING: Disabling the velocity plugin will cause bot disconnections
+ * during Velocity server transfers unless you handle the configuration
+ * phase manually (advanced users only).
+ */
+const mineflayer = require('mineflayer')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node velocity_manual_resourcepack.js <host> <port> [<name>] [online?]')
+  process.exit(1)
+}
+
+const bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4] ? process.argv[4] : 'manual_bot',
+  auth: process.argv[5] ? 'microsoft' : 'offline',
+  // Disable the velocity plugin
+  plugins: {
+    velocity: false
+  }
+})
+
+bot.on('login', () => {
+  console.log('Logged in (velocity plugin disabled)')
+})
+
+bot.on('spawn', () => {
+  console.log('Spawned in server:', bot.game.dimension)
+})
+
+// Manually accept resource packs
+bot.on('resourcePack', (url, uuid) => {
+  console.log('Resource pack received:', url)
+  console.log('Accepting manually...')
+  bot.acceptResourcePack()
+})
+
+bot.on('end', (reason) => {
+  console.log('Bot disconnected:', reason)
+})
+
+bot.on('error', (err) => {
+  console.error('Error:', err.message)
+})
+
+bot.on('kicked', (reason) => {
+  console.log('Kicked:', reason)
+  console.log('Note: If kicked during transfer, you may need to enable the velocity plugin')
+})

--- a/examples/velocity_transfer.js
+++ b/examples/velocity_transfer.js
@@ -1,0 +1,69 @@
+/*
+ * This example demonstrates connecting to a Velocity proxy server
+ * and handling server transfers (1.20.2+)
+ *
+  * The velocity plugin is loaded by default and will automatically:
+ * - Handle the configuration phase during transfers
+ * - Accept resource packs during configuration
+ * - Block physics packets while in configuration phase
+ * - Re-enable physics after configuration completes
+ *
+ * To disable the velocity plugin, add to createBot options:
+ *   plugins: { velocity: false }
+ *
+ * Note: The plugin is harmless even if loaded - it only activates
+ * during configuration phase (Velocity transfers, not normal gameplay)
+ *
+ * This fixes the issue: https://github.com/PrismarineJS/mineflayer/issues/3764
+ */
+const mineflayer = require('mineflayer')
+
+if (process.argv.length < 4 || process.argv.length > 6) {
+  console.log('Usage : node velocity_transfer.js <host> <port> [<name>] [online?]')
+  process.exit(1)
+}
+
+const bot = mineflayer.createBot({
+  host: process.argv[2],
+  port: parseInt(process.argv[3]),
+  username: process.argv[4] ? process.argv[4] : 'velocity_bot',
+  auth: process.argv[5] ? 'microsoft' : 'offline'
+  // The velocity plugin is enabled by default
+  // To disable it, uncomment the following line:
+  // plugins: { velocity: false }
+})
+
+bot.on('login', () => {
+  console.log('Logged in to Velocity proxy')
+})
+
+bot.on('spawn', () => {
+  console.log('Spawned in server:', bot.game.dimension)
+})
+
+// Track configuration phase events
+bot.on('configurationPhase', (phase) => {
+  if (phase === 'start') {
+    console.log('Entering configuration phase (server transfer starting...)')
+  } else if (phase === 'end') {
+    console.log('Exiting configuration phase (server transfer complete)')
+  }
+})
+
+// Optional: Track resource pack acceptance
+bot.on('resourcePack', (url, uuid) => {
+  console.log('Resource pack received:', url)
+  console.log('Note: Resource packs are automatically accepted during configuration phase')
+})
+
+bot.on('end', (reason) => {
+  console.log('Bot disconnected:', reason)
+})
+
+bot.on('error', (err) => {
+  console.error('Error:', err.message)
+})
+
+bot.on('kicked', (reason) => {
+  console.log('Kicked:', reason)
+})

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -25,6 +25,7 @@ const plugins = {
   health: require('./plugins/health'),
   inventory: require('./plugins/inventory'),
   kick: require('./plugins/kick'),
+  velocity: require('./plugins/velocity'),
   physics: require('./plugins/physics'),
   place_block: require('./plugins/place_block'),
   rain: require('./plugins/rain'),

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -98,6 +98,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function sendPacketPosition (position, onGround) {
+    // Don't send position packets during configuration phase (Velocity support)
+    if (bot.inConfigurationPhase) return
+
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.x = position.x
@@ -110,6 +113,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function sendPacketLook (yaw, pitch, onGround) {
+    // Don't send look packets during configuration phase (Velocity support)
+    if (bot.inConfigurationPhase) return
+
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.yaw = yaw
@@ -121,6 +127,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function sendPacketPositionAndLook (position, yaw, pitch, onGround) {
+    // Don't send position_look packets during configuration phase (Velocity support)
+    if (bot.inConfigurationPhase) return
+
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.x = position.x
@@ -153,6 +162,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function updatePosition (now) {
     // Only send updates for 20 ticks after death
     if (isEntityRemoved()) return
+
+    // Don't send any position packets during configuration phase (Velocity support)
+    if (bot.inConfigurationPhase) return
 
     // Increment the yaw in baby steps so that notchian clients (not the server) can keep up.
     const dYaw = deltaYaw(bot.entity.yaw, lastSentYaw)

--- a/lib/plugins/velocity.js
+++ b/lib/plugins/velocity.js
@@ -1,0 +1,180 @@
+/**
+ * Velocity proxy support for Minecraft 1.20.2+ configuration phase
+ *
+ * This plugin manages the configuration phase introduced in Minecraft 1.20.2
+ * and extended in 1.21+, which is required for proper server transfers via
+ * Velocity proxy.
+ *
+ * During the configuration phase:
+ * - Gameplay packets (movement, physics) are not allowed
+ * - Only configuration packets should be sent
+ * - Resource packs must be handled correctly
+ *
+ * Issue: https://github.com/PrismarineJS/mineflayer/issues/3764
+ */
+
+module.exports = inject
+
+function inject (bot) {
+  // Track whether we're in configuration phase
+  bot.inConfigurationPhase = false
+  let configurationFinished = false
+
+  // Resource pack response codes
+  const TEXTURE_PACK_RESULTS = {
+    SUCCESSFULLY_LOADED: 0,
+    DECLINED: 1,
+    FAILED_DOWNLOAD: 2,
+    ACCEPTED: 3
+  }
+
+  /**
+   * Enter configuration phase
+   */
+  function enterConfigurationPhase () {
+    if (bot.inConfigurationPhase) return
+
+    bot.inConfigurationPhase = true
+    configurationFinished = false
+
+    // Disable physics during configuration to prevent movement packets
+    if (bot.physicsEnabled !== undefined) {
+      bot._physicsWasEnabled = bot.physicsEnabled
+      bot.physicsEnabled = false
+    }
+
+    bot.emit('configurationPhase', 'start')
+  }
+
+  /**
+   * Exit configuration phase
+   */
+  function exitConfigurationPhase () {
+    if (!bot.inConfigurationPhase) return
+
+    bot.inConfigurationPhase = false
+
+    // Re-enable physics after configuration
+    setTimeout(() => {
+      if (bot._physicsWasEnabled && !bot._ended) {
+        bot.physicsEnabled = true
+        delete bot._physicsWasEnabled
+      }
+    }, 2000)
+
+    bot.emit('configurationPhase', 'end')
+  }
+
+  // === CONFIGURATION PHASE DETECTION ===
+
+  // Method 1: start_configuration event (1.20.2+)
+  bot._client.on('start_configuration', () => {
+    enterConfigurationPhase()
+  })
+
+  // Method 2: select_known_packs event (1.21+)
+  bot._client.on('select_known_packs', (packet) => {
+    enterConfigurationPhase()
+    // Note: No response needed for select_known_packs
+  })
+
+  // Method 3: registry_data event (1.20.2+)
+  bot._client.on('registry_data', (packet) => {
+    // Only enter if not already in configuration phase
+    // (registry_data can be sent multiple times)
+    if (!bot.inConfigurationPhase) {
+      enterConfigurationPhase()
+    }
+  })
+
+  // Method 4: transfer event (1.20.5+)
+  bot._client.on('transfer', (packet) => {
+    enterConfigurationPhase()
+  })
+
+  // === AUTOMATIC RESOURCE PACK ACCEPTANCE ===
+
+  /**
+   * Automatically accept resource packs during configuration phase
+   * This is required for Velocity transfers to complete successfully
+   */
+
+  // Handle add_resource_pack (1.20.3+)
+  bot._client.prependListener('add_resource_pack', (data) => {
+    if (!bot.inConfigurationPhase) return
+
+    // Send ACCEPTED immediately
+    bot._client.write('resource_pack_receive', {
+      uuid: data.uuid,
+      result: TEXTURE_PACK_RESULTS.ACCEPTED
+    })
+
+    // Send SUCCESSFULLY_LOADED immediately
+    // Server needs this before sending finish_configuration
+    bot._client.write('resource_pack_receive', {
+      uuid: data.uuid,
+      result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
+    })
+  })
+
+  // Handle resource_pack_send (older versions with UUID support)
+  bot._client.prependListener('resource_pack_send', (data) => {
+    if (!bot.inConfigurationPhase) return
+    if (!data.uuid) return // Only handle UUID-based resource packs
+
+    const UUID = require('uuid-1345')
+    const uuid = new UUID(data.uuid)
+
+    // Send ACCEPTED immediately
+    bot._client.write('resource_pack_receive', {
+      uuid: uuid,
+      result: TEXTURE_PACK_RESULTS.ACCEPTED
+    })
+
+    // Send SUCCESSFULLY_LOADED immediately
+    bot._client.write('resource_pack_receive', {
+      uuid: uuid,
+      result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
+    })
+  })
+
+  // === FINISH CONFIGURATION ===
+
+  bot._client.on('finish_configuration', () => {
+    configurationFinished = true
+
+    // Acknowledge finish_configuration
+    try {
+      bot._client.write('finish_configuration', {})
+    } catch (err) {
+      // Ignore if packet doesn't exist for this version
+    }
+
+    // Exit configuration phase after a short delay
+    setTimeout(() => {
+      exitConfigurationPhase()
+    }, 500)
+  })
+
+  // === FALLBACKS ===
+
+  // Fallback: Exit on login if we're still in configuration phase
+  bot.on('login', () => {
+    if (bot.inConfigurationPhase && configurationFinished) {
+      exitConfigurationPhase()
+    }
+  })
+
+  // Fallback: Exit on spawn if we're still in configuration phase
+  bot.on('spawn', () => {
+    if (bot.inConfigurationPhase) {
+      exitConfigurationPhase()
+    }
+  })
+
+  // Cleanup on end
+  bot.on('end', () => {
+    bot.inConfigurationPhase = false
+    configurationFinished = false
+  })
+}


### PR DESCRIPTION
# Fix Velocity Proxy Support for Minecraft 1.20.2+ Configuration Phase

## Summary

This PR fixes bot disconnections when connecting through Velocity proxy servers with Minecraft 1.20.2+ versions. The issue occurred during server transfers when the bot sent gameplay packets (movement, physics) during the configuration phase, causing the server to kick the bot with error: "Disconnected, while in configuration phase".

Fixes #3764

## Problem Description

### Background

Minecraft 1.20.2 introduced a new "configuration phase" that occurs:
- During initial login
- During server transfers via Velocity proxy
- When changing resource packs

During this phase:
- **Only configuration packets are allowed** (registry_data, resource_pack, finish_configuration, etc.)
- **Gameplay packets are NOT allowed** (movement, position, look, etc.)
- Sending gameplay packets causes immediate disconnection

### What Was Broken

Mineflayer was sending physics/movement packets during the configuration phase, causing:
1. **Server kicks** with error: "Disconnected, while in configuration phase server_resource_pack"
2. **Failed transfers** between Velocity backend servers
3. **Resource pack deadlocks** - server waiting for SUCCESSFULLY_LOADED before sending finish_configuration

## Solution

### 1. New Velocity Plugin (`lib/plugins/velocity.js`)

A new plugin that:
- **Tracks configuration phase state** via `bot.inConfigurationPhase` flag
- **Detects configuration phase** through multiple events:
  - `start_configuration` (1.20.2+)
  - `select_known_packs` (1.21+)
  - `registry_data` (1.20.2+)
  - `transfer` (1.20.5+)
- **Disables physics** during configuration to prevent movement packets
- **Automatically accepts resource packs** during configuration phase (sends ACCEPTED + SUCCESSFULLY_LOADED immediately)
- **Re-enables physics** after configuration completes (after finish_configuration)
- **Emits events** for tracking: `bot.on('configurationPhase', (phase) => {})`

### 2. Physics Plugin Modification (`lib/plugins/physics.js`)

Added checks to prevent sending movement packets during configuration:
- `sendPacketPosition()` - Returns early if `bot.inConfigurationPhase`
- `sendPacketLook()` - Returns early if `bot.inConfigurationPhase`
- `sendPacketPositionAndLook()` - Returns early if `bot.inConfigurationPhase`
- `updatePosition()` - Returns early if `bot.inConfigurationPhase`

### 3. Loader Update (`lib/loader.js`)

Added velocity plugin to internal plugins list, loaded before physics plugin (order matters).

### 4. Example (`examples/velocity_transfer.js`)

New example demonstrating Velocity proxy connection and server transfer handling.

## Technical Details

### Configuration Phase Flow

```
1. Server sends: start_configuration or transfer
   ↓
2. Bot enters configuration phase
   - Sets bot.inConfigurationPhase = true
   - Disables physics (blocks movement packets)
   - Emits 'configurationPhase' event with 'start'
   ↓
3. Server sends: registry_data, resource_pack, etc.
   ↓
4. Bot handles configuration packets
   - Automatically accepts resource packs (ACCEPTED + SUCCESSFULLY_LOADED)
   ↓
5. Server sends: finish_configuration
   ↓
6. Bot acknowledges and exits configuration phase
   - Sends finish_configuration acknowledgment
   - Sets bot.inConfigurationPhase = false
   - Re-enables physics after 2s delay
   - Emits 'configurationPhase' event with 'end'
```

### Resource Pack Handling

The plugin uses `prependListener` to intercept resource pack events **before** the resource_pack plugin processes them. This ensures:
- Packets are sent with correct UUID from raw packet data
- No race conditions with event handlers
- Immediate ACCEPTED + SUCCESSFULLY_LOADED response (required for server to continue)

### Why Automatic Resource Pack Acceptance?

During Velocity transfers, resource packs must be accepted immediately or the configuration phase hangs indefinitely. The server waits for `SUCCESSFULLY_LOADED` before sending `finish_configuration`. Users can still manually handle resource packs outside of configuration phase.

## Testing

### Tested Scenarios

✅ Velocity proxy connection (1.21.8)
✅ Server transfers between backend servers
✅ Resource pack acceptance during transfers
✅ Multiple consecutive transfers
✅ Physics re-enabling after transfer
✅ Fallback to spawn/login events if finish_configuration doesn't fire

### Test Servers

- Velocity proxy with multiple backend servers (1.20.2 - 1.21.8)
- Backend servers with mandatory resource packs
- Backend servers with custom NBT tags

### How to Test

```bash
# Run the example
node examples/velocity_transfer.js <velocity-host> <velocity-port> <username>

# Expected behavior:
# 1. Bot connects to Velocity proxy
# 2. Bot logs in successfully
# 3. Bot spawns on backend server
# 4. Use server transfer command (e.g., /server hub)
# 5. Bot enters configuration phase (logged)
# 6. Bot accepts resource pack automatically
# 7. Bot exits configuration phase (logged)
# 8. Bot spawns on new backend server
```

## Breaking Changes

**None**. This is a purely additive change:
- New plugin that can be disabled: `plugins: { velocity: false }`
- Existing bots continue to work as before
- Only affects behavior during configuration phase (which was broken before)

## Backward Compatibility

- ✅ Works with Minecraft 1.20.2+ (configuration phase versions)
- ✅ Compatible with older versions (plugin does nothing if configuration phase never triggered)
- ✅ Existing resource pack handling still works outside configuration phase
- ✅ Users can still manually call `bot.acceptResourcePack()` for normal gameplay

## Additional Notes

### Why a New Plugin?

The configuration phase handling requires:
1. State tracking across multiple plugins (physics, resource_pack)
2. Packet interception before other plugins
3. Event coordination (disable/enable physics)

A dedicated plugin is cleaner than modifying multiple existing plugins.

### Plugin Load Order

The velocity plugin must load **before** physics plugin because:
- Physics plugin needs `bot.inConfigurationPhase` flag
- Load order in `loader.js` ensures correct initialization

## Files Changed

- ✨ `lib/plugins/velocity.js` - New plugin (180 lines)
- 🔧 `lib/plugins/physics.js` - Added configuration phase checks (4 locations)
- 🔧 `lib/loader.js` - Added velocity to plugins list (1 line)
- 📚 `examples/velocity_transfer.js` - New example (55 lines)

## Credits

Based on investigation of issue #3764 and testing with Velocity proxy servers.