### PR TITLE
Fix flaky CI: increase before-hook timeout and guard after-hook

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -52,7 +52,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       console.log(`Port chosen: ${PORT}`)
     })
     before(function (done) {
-      this.timeout(1000 * 60)
+      this.timeout(1000 * 120)
       function begin () {
         bot = mineflayer.createBot({
           username: 'flatbot',
@@ -116,7 +116,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
 
     after((done) => {
-      bot.quit()
+      if (bot) bot.quit()
       wrap.stopServer((err) => {
         if (err) {
           console.log(err)


### PR DESCRIPTION
## Summary
- Increased the `before` hook timeout from 60s to 120s in `test/externalTest.js`. The 1.9.4 CI run was consistently timing out because downloading + starting the server + bot connection + op message all had to complete within 60 seconds, which is too tight for CI runners.
- Added a null guard (`if (bot) bot.quit()`) in the `after` hook so it doesn't crash with `TypeError: Cannot read properties of undefined (reading 'quit')` when the `before` hook fails before `bot` is created.

Fixes the flaky failures seen in https://github.com/PrismarineJS/mineflayer/actions/runs/21787055711/job/62860150995

## Test plan
- CI should pass for all versions including 1.9.4

Made with [Cursor](https://cursor.com)