### PR TITLE
fix: auto-detect activateBlock face direction from bot position

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -184,7 +184,24 @@ function inject (bot, { hideErrors }) {
   }
 
   async function activateBlock (block, direction, cursorPos) {
-    direction = direction ?? new Vec3(0, 1, 0)
+    if (direction == null) {
+      // Auto-detect the approach face from bot position relative to block center.
+      // The old default (Vec3(0,1,0) = UP) silently fails for 2-block-tall blocks
+      // like bamboo_door: clicking the top face of the lower half is rejected by
+      // the server because the upper half already occupies y+1.
+      const botPos = bot.entity.position
+      const dx = botPos.x - (block.position.x + 0.5)
+      const dz = botPos.z - (block.position.z + 0.5)
+      // Use bot midpoint Y so horizontal interactions near eye height aren't
+      // misclassified as UP/DOWN.
+      const dy = (botPos.y + (bot.entity.height ?? 1.8) * 0.5) - (block.position.y + 0.5)
+      const adx = Math.abs(dx)
+      const ady = Math.abs(dy)
+      const adz = Math.abs(dz)
+      if (adx >= adz && adx >= ady) direction = new Vec3(dx > 0 ? 1 : -1, 0, 0)
+      else if (adz >= adx && adz >= ady) direction = new Vec3(0, 0, dz > 0 ? 1 : -1)
+      else direction = new Vec3(0, dy > 0 ? 1 : -1, 0)
+    }
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
     cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
     // TODO: tell the server that we are not sneaking while doing this

--- a/test/externalTests/activateBlockFace.js
+++ b/test/externalTests/activateBlockFace.js
@@ -1,0 +1,60 @@
+const assert = require('assert')
+const { Vec3 } = require('vec3')
+const { once } = require('../../lib/promise_utils')
+
+module.exports = () => async (bot) => {
+  // Direction numbers: 0=down(-Y), 1=up(+Y), 2=north(-Z), 3=south(+Z), 4=west(-X), 5=east(+X)
+
+  const groundY = bot.test.groundY
+  const blockPos = new Vec3(5, groundY + 1, 5)
+  const blockPosStr = blockPos.toArray().join(' ')
+
+  // Place a stone block to activate against (lever needs a base, but stone is simpler to test)
+  const blockUpdate = once(bot.world, `blockUpdate:(${blockPos.x}, ${blockPos.y}, ${blockPos.z})`)
+  bot.chat(`/setblock ${blockPosStr} stone`)
+  await blockUpdate
+  await bot.test.wait(500)
+
+  // Helper: intercept the next block_place packet and return the direction field
+  function captureNextBlockPlaceDirection () {
+    return new Promise((resolve) => {
+      const origWrite = bot._client.write
+      bot._client.write = function (name, data) {
+        origWrite.apply(bot._client, arguments)
+        if (name === 'block_place') {
+          bot._client.write = origWrite
+          resolve(data.direction)
+        }
+      }
+    })
+  }
+
+  // Test cases: [botPosition, expectedDirection, label]
+  // Bot east of block (+X) => should click east face (direction 5)
+  // Bot west of block (-X) => should click west face (direction 4)
+  // Bot south of block (+Z) => should click south face (direction 3)
+  // Bot north of block (-Z) => should click north face (direction 2)
+  const testCases = [
+    [blockPos.offset(3, 0, 0), 5, 'east (+X)'],
+    [blockPos.offset(-3, 0, 0), 4, 'west (-X)'],
+    [blockPos.offset(0, 0, 3), 3, 'south (+Z)'],
+    [blockPos.offset(0, 0, -3), 2, 'north (-Z)']
+  ]
+
+  for (const [botPosition, expectedDir, label] of testCases) {
+    await bot.test.teleport(botPosition)
+    await bot.test.wait(500)
+
+    const block = bot.blockAt(blockPos)
+    assert(block, `Could not find block at ${blockPos}`)
+
+    const dirPromise = captureNextBlockPlaceDirection()
+    await bot.activateBlock(block)
+    const actualDir = await dirPromise
+
+    bot.test.sayEverywhere(`activateBlock face ${label}: expected=${expectedDir} actual=${actualDir}`)
+    assert.strictEqual(actualDir, expectedDir, `Face direction mismatch for ${label}: expected ${expectedDir}, got ${actualDir}`)
+  }
+
+  bot.test.sayEverywhere('activateBlock face direction test: pass')
+}

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -304,6 +304,87 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock face direction', () => {
+      // Direction mapping: 0=down(-y), 1=up(+y), 2=north(-z), 3=south(+z), 4=west(-x), 5=east(+x)
+      const blockPos = vec3(8, 65, 8)
+
+      async function setupAndActivate (botPosition, done, expectedDirection) {
+        return new Promise((resolve, reject) => {
+          server.on('playerJoin', async (client) => {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            const stoneId = bot.registry.blocksByName.stone.id
+            chunk.setBlockType(blockPos, stoneId)
+            client.write('map_chunk', generateChunkPacket(chunk))
+
+            await once(bot, 'chunkColumnLoad')
+
+            // Teleport bot to desired position
+            const posPacket = {
+              x: botPosition.x,
+              y: botPosition.y,
+              z: botPosition.z,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+              teleportId: 1
+            }
+            client.write('position', posPacket)
+            await once(bot, 'forcedMove')
+
+            // Listen for block_place packet to check direction
+            client.on('packet', (data, meta) => {
+              if (meta.name === 'block_place') {
+                try {
+                  assert.strictEqual(data.direction, expectedDirection,
+                    `Expected direction ${expectedDirection} but got ${data.direction}`)
+                  resolve()
+                } catch (e) {
+                  reject(e)
+                }
+              }
+            })
+
+            const block = bot.blockAt(blockPos)
+            bot.activateBlock(block).catch(reject)
+          })
+        })
+      }
+
+      it('should pick east (+x) face when bot is east of block', async function () {
+        // Bot at x=11 vs block center x=8.5 => dx > 0 => east face => direction 5
+        await setupAndActivate(vec3(11, 65, 8.5), null, 5)
+      })
+
+      it('should pick west (-x) face when bot is west of block', async function () {
+        // Bot at x=5 vs block center x=8.5 => dx < 0 => west face => direction 4
+        await setupAndActivate(vec3(5, 65, 8.5), null, 4)
+      })
+
+      it('should pick south (+z) face when bot is south of block', async function () {
+        // Bot at z=11 vs block center z=8.5 => dz > 0 => south face => direction 3
+        await setupAndActivate(vec3(8.5, 65, 11), null, 3)
+      })
+
+      it('should pick north (-z) face when bot is north of block', async function () {
+        // Bot at z=5 vs block center z=8.5 => dz < 0 => north face => direction 2
+        await setupAndActivate(vec3(8.5, 65, 5), null, 2)
+      })
+
+      it('should pick up (+y) face when bot is above block', async function () {
+        // Bot at y=70 vs block center y=65.5 => dy > 0 => up face => direction 1
+        await setupAndActivate(vec3(8.5, 70, 8.5), null, 1)
+      })
+
+      it('should pick down (-y) face when bot is below block', async function () {
+        // Bot at y=60 vs block center y=65.5 => dy < 0 => down face => direction 0
+        await setupAndActivate(vec3(8.5, 60, 8.5), null, 0)
+      })
+    })
+
     describe('physics', () => {
       const pos = vec3(1, 65, 1)
       const goldId = 41


### PR DESCRIPTION
Fixes #3851

## Problem

`bot.activateBlock(block)` defaults to `direction = new Vec3(0, 1, 0)` (UP — click the top face). For 2-block-tall blocks like `bamboo_door`, this silently fails: clicking the top face of the lower half is rejected by the server because the upper half already occupies `y+1`. The door does not open and no error is raised.

Single-block interactables (fence gates, buttons, levers, trapdoors) are unaffected because nothing occupies the block above them.

## Fix

Replace the hardcoded UP default with a position-based face detection. When `direction` is not provided, find the dominant axis between the bot's midpoint and the block's center, and use the corresponding face vector.

Using the bot's midpoint Y (rather than eye height or feet) prevents horizontal interactions near eye level from being misclassified as UP/DOWN — which is the failure mode that the old UP default introduced.

```js
// Before
direction = direction ?? new Vec3(0, 1, 0)

// After
if (direction == null) {
  const botPos = bot.entity.position
  const dx = botPos.x - (block.position.x + 0.5)
  const dz = botPos.z - (block.position.z + 0.5)
  const dy = (botPos.y + (bot.entity.height ?? 1.8) * 0.5) - (block.position.y + 0.5)
  const adx = Math.abs(dx), ady = Math.abs(dy), adz = Math.abs(dz)
  if (adx >= adz && adx >= ady) direction = new Vec3(dx > 0 ? 1 : -1, 0, 0)
  else if (adz >= adx && adz >= ady) direction = new Vec3(0, 0, dz > 0 ? 1 : -1)
  else direction = new Vec3(0, dy > 0 ? 1 : -1, 0)
}
```

## Backward compatibility

Callers that already pass an explicit `direction` are completely unaffected. Only callers relying on the default get the new behavior — which was already broken for any 2-block-tall block.

## Tested against

- `bamboo_door` (2-block-tall) — confirmed opens correctly when bot approaches from east, west, north, south
- `bamboo_fence_gate` (1-block) — unaffected, continues to work
- Minecraft 1.21.11 / Paper (offline mode)