### PR TITLE
Add Minecraft-Youtube-Follower to Projects Using Mineflayer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -250,8 +250,6 @@ The most updated and useful are :
  * [PrismarineJS/mineflayer-builder](https://github.com/PrismarineJS/mineflayer-builder) - Prints minecraft schematics in survival, keeping orientation
  * [SilkePilon/OpenDeliveryBot](https://github.com/SilkePilon/OpenDeliveryBot) - Minecraft bot in python to deliver items from place to place.
  * [GeiserX/Minecraft-Youtube-Follower](https://github.com/GeiserX/Minecraft-Youtube-Follower) - 24/7 automated spectator bot that follows players with a smart third-person camera and streams to YouTube/Twitch, fully Dockerized.
-   - [YouTube - automated server stream](https://youtube.com/live/7pPMtL0e8eE)
-   - [YouTube - player following demo](https://youtube.com/live/9ns0jZ_VBC4)
  * [and hundreds more](https://github.com/PrismarineJS/mineflayer/network/dependents) - All the projects that github detected are using mineflayer
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -249,6 +249,9 @@ The most updated and useful are :
  * [hexatester/minetelegram](https://github.com/hexatester/minetelegram) -  Minecraft - Telegram bridge, build on top of mineflayer & telegraf.
  * [PrismarineJS/mineflayer-builder](https://github.com/PrismarineJS/mineflayer-builder) - Prints minecraft schematics in survival, keeping orientation
  * [SilkePilon/OpenDeliveryBot](https://github.com/SilkePilon/OpenDeliveryBot) - Minecraft bot in python to deliver items from place to place.
+ * [GeiserX/Minecraft-Youtube-Follower](https://github.com/GeiserX/Minecraft-Youtube-Follower) - 24/7 automated spectator bot that follows players with a smart third-person camera and streams to YouTube/Twitch, fully Dockerized.
+   - [YouTube - automated server stream](https://youtube.com/live/7pPMtL0e8eE)
+   - [YouTube - player following demo](https://youtube.com/live/9ns0jZ_VBC4)
  * [and hundreds more](https://github.com/PrismarineJS/mineflayer/network/dependents) - All the projects that github detected are using mineflayer
 
 


### PR DESCRIPTION
Adds [Minecraft-Youtube-Follower](https://github.com/GeiserX/Minecraft-Youtube-Follower) to the "Projects Using Mineflayer" section in `docs/README.md`.

It is a Docker-based system for 24/7 automated streaming of Minecraft servers. A Mineflayer spectator bot follows players with a smart third-person camera and streams to YouTube or Twitch.

**Demo streams:**
- https://youtube.com/live/7pPMtL0e8eE
- https://youtube.com/live/9ns0jZ_VBC4