### PR TITLE
Fix for physics lock-up in 1.21.4

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -79,7 +79,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
-      physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
+      const prevPos = bot.entity.position.clone();
+      physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot) 
+
+      if (!Number.isFinite(bot.entity.position.x)) {
+        bot.entity.position = prevPos
+      } 
       bot.emit('physicsTick')
       bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
     }


### PR DESCRIPTION
During my testing (and also documented here: https://github.com/PrismarineJS/mineflayer/issues/3882), bots on at least 1.21.4 will permanently lock up when hit by an arrow. This is because prismarine physics returns NaN for pos.x and pos.z. This edit just catches and rejects the illegal position, shouldn't affect anything that already works.