### PR TITLE
add dynamic tick interval support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1044,6 +1044,8 @@ Number in the range [0, 20] representing the number of water-icons known as oxyg
 Edit these numbers to tweak gravity, jump speed, terminal velocity, etc.
 Do this at your own risk.
 
+`bot.physics.physicsIntervalMs` is the current physics tick interval in milliseconds. To change it, call `bot.physics.setPhysicsIntervalMs(value)`.
+
 #### bot.fireworkRocketDuration
 
 How many physics ticks worth of firework rocket boost are left.

--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,7 @@ export interface PhysicsOptions {
   jumpSpeed: number
   yawSpeed: number
   pitchSpeed: number
+  physicsIntervalMs: number
   sprintSpeed: number
   maxGroundSpeedSoulSand: number
   maxGroundSpeedWater: number

--- a/index.d.ts
+++ b/index.d.ts
@@ -544,6 +544,7 @@ export interface PhysicsOptions {
   yawSpeed: number
   pitchSpeed: number
   physicsIntervalMs: number
+  setPhysicsIntervalMs: (value: number) => void
   sprintSpeed: number
   maxGroundSpeedSoulSand: number
   maxGroundSpeedWater: number

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -11,8 +11,8 @@ module.exports = inject
 
 const PI = Math.PI
 const PI_2 = Math.PI * 2
-const PHYSICS_INTERVAL_MS = 50
-const PHYSICS_TIMESTEP = PHYSICS_INTERVAL_MS / 1000 // 0.05
+const DEFAULT_PHYSICS_INTERVAL_MS = 50
+const DEFAULT_PHYSICS_TIMESTEP = DEFAULT_PHYSICS_INTERVAL_MS / 1000 // 0.05
 
 function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const PHYSICS_CATCHUP_TICKS = maxCatchupTicks ?? 4
@@ -38,6 +38,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
   let shouldUsePhysics = false
+  let physicsIntervalMs = DEFAULT_PHYSICS_INTERVAL_MS
+  let physicsTimestep = DEFAULT_PHYSICS_TIMESTEP
   bot.physicsEnabled = physicsEnabled ?? true
   let deadTicks = 21
 
@@ -67,15 +69,17 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     timeAccumulator += deltaSeconds
     catchupTicks = 0
-    while (timeAccumulator >= PHYSICS_TIMESTEP) {
+    while (timeAccumulator >= physicsTimestep) {
       tickPhysics(now)
-      timeAccumulator -= PHYSICS_TIMESTEP
+      timeAccumulator -= physicsTimestep
       catchupTicks++
       if (catchupTicks >= PHYSICS_CATCHUP_TICKS) break
     }
   }
 
   function tickPhysics (now) {
+    const timestep = physicsTimestep
+
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -96,6 +100,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function cleanup () {
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
+  }
+
+  function restartPhysicsTimer () {
+    if (doPhysicsTimer === null) return
+    clearInterval(doPhysicsTimer)
+    doPhysicsTimer = setInterval(doPhysics, physicsIntervalMs)
   }
 
   function sendPacketPosition (position, onGround) {
@@ -164,8 +174,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const dPitch = bot.entity.pitch - (lastSentPitch || 0)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
-    const maxDeltaYaw = PHYSICS_TIMESTEP * physics.yawSpeed
-    const maxDeltaPitch = PHYSICS_TIMESTEP * physics.pitchSpeed
+    const maxDeltaYaw = timestep * physics.yawSpeed
+    const maxDeltaPitch = timestep * physics.pitchSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
     lastSentPitch += math.clamp(-maxDeltaPitch, dPitch, maxDeltaPitch)
 
@@ -177,8 +187,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     // Only send a position update if necessary, select the appropriate packet
     const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z ||
       // Send a position update every second, even if no other update was made
-      // This function rounds to the nearest 50ms (or PHYSICS_INTERVAL_MS) and checks if a second has passed.
-      (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS) >= 1000
+      // This function rounds to the nearest physics interval and checks if a second has passed.
+      (Math.round((now - lastSent.time) / physicsIntervalMs) * physicsIntervalMs) >= 1000
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
     if (positionUpdated && lookUpdated) {
@@ -201,6 +211,22 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     lastSent.onGround = bot.entity.onGround // onGround is always set
   }
+
+  Object.defineProperty(physics, 'physicsIntervalMs', {
+    enumerable: true,
+    get () {
+      return physicsIntervalMs
+    },
+    set (value) {
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new RangeError('physics.physicsIntervalMs must be a finite number greater than 0')
+      }
+      physicsIntervalMs = value
+      physicsTimestep = value / 1000
+      restartPhysicsTimer()
+      return value
+    }
+  })
 
   bot.physics = physics
 
@@ -484,7 +510,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     shouldUsePhysics = false
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = performance.now()
-      doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
+      doPhysicsTimer = setInterval(doPhysics, physicsIntervalMs)
     }
   })
   bot.on('end', cleanup)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -78,8 +78,6 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function tickPhysics (now) {
-    const timestep = physicsTimestep
-
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -174,8 +172,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const dPitch = bot.entity.pitch - (lastSentPitch || 0)
 
     // Vanilla doesn't clamp yaw, so we don't want to do it either
-    const maxDeltaYaw = timestep * physics.yawSpeed
-    const maxDeltaPitch = timestep * physics.pitchSpeed
+    const maxDeltaYaw = physicsTimestep * physics.yawSpeed
+    const maxDeltaPitch = physicsTimestep * physics.pitchSpeed
     lastSentYaw += math.clamp(-maxDeltaYaw, dYaw, maxDeltaYaw)
     lastSentPitch += math.clamp(-maxDeltaPitch, dPitch, maxDeltaPitch)
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -210,19 +210,19 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.onGround = bot.entity.onGround // onGround is always set
   }
 
+  physics.setPhysicsIntervalMs = (value) => {
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new RangeError('physics.setPhysicsIntervalMs must be called with a finite number greater than 0')
+    }
+    physicsIntervalMs = value
+    physicsTimestep = value / 1000
+    restartPhysicsTimer()
+  }
+
   Object.defineProperty(physics, 'physicsIntervalMs', {
     enumerable: true,
     get () {
       return physicsIntervalMs
-    },
-    set (value) {
-      if (!Number.isFinite(value) || value <= 0) {
-        throw new RangeError('physics.physicsIntervalMs must be a finite number greater than 0')
-      }
-      physicsIntervalMs = value
-      physicsTimestep = value / 1000
-      restartPhysicsTimer()
-      return value
     }
   })
 


### PR DESCRIPTION
Currently, the default execution of ticks is 50ms. This is representative of normal minecraft behavior. However, being able to change that tickrate is helpful for debugging various applications, as we can see the bot's movement in-game, step by step. Further decreasing the time between tick executions also opens the door for machine learning code using an actual nmp client as an agent.