### PR TITLE
Convert yaw/pitch in sync_entity_position handler

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -349,8 +349,8 @@ function inject (bot) {
     const entity = fetchEntity(packet.entityId)
     entity.position.set(packet.x, packet.y, packet.z)
     entity.velocity.set(packet.dx, packet.dy, packet.dz)
-    entity.yaw = packet.yaw
-    entity.pitch = packet.pitch
+    entity.yaw = conv.fromNotchianYaw(packet.yaw)
+    entity.pitch = conv.fromNotchianPitch(packet.pitch)
     bot.emit('entityMoved', entity)
   })
 


### PR DESCRIPTION
The 1.21.3+ `sync_entity_position` packet handler was assigning `entity.yaw` / `entity.pitch` directly from the raw packet fields, skipping the notchian-degrees → radians conversion the older movement handlers in this file apply via `conv.fromNotchianYawByte` / `fromNotchianPitchByte`.

As a result, tracked entities (other players, mobs) had raw protocol values surfacing in the public `entity.yaw` / `entity.pitch` fields rather than radians. Downstream consumers (e.g. prismarine-viewer) interpret these as radians, which produced wildly wrong rotations on every move.

### Why was this only really visible after a jump?

`sync_entity_position` fires on **every** entity movement, including y-only changes. Walking entities also emit `entity_look` / `entity_head_rotation` packets shortly after, which set yaw correctly via the byte helper — that overwrite happens within the viewer's tween duration, so the bogus value was rarely visible during normal walking. **Jumping doesn't change yaw, so no look packet fires** — the bogus yaw from `sync_entity_position` persists through the jump arc, making the bug obvious as a snap.

### Fix

```diff
-    entity.yaw = packet.yaw
-    entity.pitch = packet.pitch
+    entity.yaw = conv.fromNotchianYaw(packet.yaw)
+    entity.pitch = conv.fromNotchianPitch(packet.pitch)
```

`sync_entity_position` carries full-precision degrees (not byte-encoded), so `fromNotchianYaw` / `fromNotchianPitch` are the right conversions — same as the older handlers a few lines above already use for the same physical quantity.

### Verification

- 1.21.11 vanilla server, two bots, walk + jump cycles. Before: `bot.players.<name>.entity.yaw` produced values like `106.019`; after: matches the radian range used by `bot.entity.yaw`.
- prismarine-viewer renders entity rotations consistently across jumps after this lands; before, the model snapped to a different orientation each y-only move.