### PR TITLE
Add look2 and getNotchYawPitch methods to adapt to the game's rotation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -297,6 +297,14 @@ export interface Bot extends TypedEmitter<BotEvents> {
     force?: boolean
   ) => Promise<void>
 
+  look2: (
+    notchYaw: number,
+    notchPitch: number,
+    force?: boolean
+  ) => Promise<void>
+
+  getNotchYawPitch: () => { yaw: number, pitch: number }
+
   updateSign: (block: Block, text: string, back?: boolean) => void
 
   equip: (

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -354,12 +354,27 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     await lookingTask.promise
   }
 
+  bot.look2 = (notchYaw, notchPitch, force) => {
+    return bot.look(
+      conv.fromNotchianYaw(notchYaw),
+      conv.fromNotchianPitch(notchPitch),
+      force
+    )
+  }
+
   bot.lookAt = async (point, force) => {
     const delta = point.minus(bot.entity.position.offset(0, bot.entity.eyeHeight, 0))
     const yaw = Math.atan2(-delta.x, -delta.z)
     const groundDistance = Math.sqrt(delta.x * delta.x + delta.z * delta.z)
     const pitch = Math.atan2(delta.y, groundDistance)
     await bot.look(yaw, pitch, force)
+  }
+
+  bot.getNotchYawPitch = () => {
+    return {
+      yaw: conv.toNotchianYaw(bot.entity.yaw),
+      pitch: conv.toNotchianPitch(bot.entity.pitch)
+    }
   }
 
   // 1.21.3+


### PR DESCRIPTION
```js
// The result is the same
bot.look2(90, 0)  // use degree, more detail see https://minecraft.wiki/w/Rotation#Entity_format
bot.look(Math.PI / 2, 0)
```

Related to #3220 
I can't understand why the perspective system of the game needs to be transformed into other systems, which makes it even more complex.