### PR TITLE
activateBlock: raycast-based face + cursor auto-detection (alt to #3852)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1962,8 +1962,8 @@ This function returns a `Promise`, with `void` as its argument upon completion.
 Punch a note block, open a door, etc.
 
  * `block` - the block to activate
- * `direction` Optional defaults to `new Vec3(0, 1, 0)` (up). A vector off the direction the container block should be interacted with. Does nothing when a container entity is targeted.
- * `cursorPos` Optional defaults to `new Vec3(0.5, 0.5, 0.5)` (block center). The curos position when opening the block instance. This is send with the activate block packet. Does nothing when a container entity is targeted.
+ * `direction` Optional. The face vector the block should be interacted with. If omitted, mineflayer raycasts from the bot's eyes to pick the face the bot can actually see (and falls back to the nearest face by bot position when the block isn't directly visible). Pass an explicit `Vec3` (e.g. `new Vec3(0, 1, 0)` for the top face) to force a specific face. Previously defaulted to `new Vec3(0, 1, 0)` (up), which silently failed for two-block-tall blocks such as doors. Does nothing when a container entity is targeted.
+ * `cursorPos` Optional. The cursor position on the clicked face, sent with the activate block packet. When `direction` is auto-detected this defaults to the raycast hit point on that face; otherwise it defaults to `new Vec3(0.5, 0.5, 0.5)` (block center). Does nothing when a container entity is targeted.
 
 #### bot.activateEntity(entity)
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -184,7 +184,24 @@ function inject (bot, { hideErrors }) {
   }
 
   async function activateBlock (block, direction, cursorPos) {
-    direction = direction ?? new Vec3(0, 1, 0)
+    if (direction == null) {
+      // Auto-detect the approach face from bot position relative to block center.
+      // The old default (Vec3(0,1,0) = UP) silently fails for 2-block-tall blocks
+      // like bamboo_door: clicking the top face of the lower half is rejected by
+      // the server because the upper half already occupies y+1.
+      const botPos = bot.entity.position
+      const dx = botPos.x - (block.position.x + 0.5)
+      const dz = botPos.z - (block.position.z + 0.5)
+      // Use bot midpoint Y so horizontal interactions near eye height aren't
+      // misclassified as UP/DOWN.
+      const dy = (botPos.y + (bot.entity.height ?? 1.8) * 0.5) - (block.position.y + 0.5)
+      const adx = Math.abs(dx)
+      const ady = Math.abs(dy)
+      const adz = Math.abs(dz)
+      if (adx >= adz && adx >= ady) direction = new Vec3(dx > 0 ? 1 : -1, 0, 0)
+      else if (adz >= adx && adz >= ady) direction = new Vec3(0, 0, dz > 0 ? 1 : -1)
+      else direction = new Vec3(0, dy > 0 ? 1 : -1, 0)
+    }
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
     cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
     // TODO: tell the server that we are not sneaking while doing this

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -187,29 +187,68 @@ function inject (bot, { hideErrors }) {
     }
   }
 
+  // Maps a prismarine-world raycast face index to a unit direction vector.
+  // Index = BlockFace: 0 down(-Y) 1 up(+Y) 2 north(-Z) 3 south(+Z) 4 west(-X) 5 east(+X),
+  // matching both the block_place `direction` field and vectorToDirection().
+  const faceToVector = [
+    new Vec3(0, -1, 0),
+    new Vec3(0, 1, 0),
+    new Vec3(0, 0, -1),
+    new Vec3(0, 0, 1),
+    new Vec3(-1, 0, 0),
+    new Vec3(1, 0, 0)
+  ]
+
+  // Pick the face the bot can actually see by raycasting from its eyes to the
+  // block, mirroring how bot.dig(..., 'raycast') chooses a server-acceptable
+  // face. Returns { direction, cursorPos } with the cursor on the hit point, or
+  // null when the target block isn't directly visible (occluded / out of reach).
+  function raycastInteractFace (block) {
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0)
+    const center = block.position.offset(0.5, 0.5, 0.5)
+    // Range = real distance (+ margin) so we always reach the intended block;
+    // the hit-is-target check below still rejects clicks blocked by occluders.
+    const range = eye.distanceTo(center) + 0.5
+    const hit = bot.world.raycast(eye, center.minus(eye).normalize(), range)
+    if (!hit || !hit.position.equals(block.position)) return null
+    return {
+      direction: faceToVector[hit.face],
+      cursorPos: hit.intersect.minus(block.position) // block-relative, on the face
+    }
+  }
+
   async function activateBlock (block, direction, cursorPos) {
     if (direction == null) {
-      // Auto-detect the approach face from bot position relative to block center.
-      // The old default (Vec3(0,1,0) = UP) silently fails for 2-block-tall blocks
-      // like bamboo_door: clicking the top face of the lower half is rejected by
-      // the server because the upper half already occupies y+1.
-      const botPos = bot.entity.position
-      const dx = botPos.x - (block.position.x + 0.5)
-      const dz = botPos.z - (block.position.z + 0.5)
-      // Use bot midpoint Y so horizontal interactions near eye height aren't
-      // misclassified as UP/DOWN.
-      const dy = (botPos.y + (bot.entity.height ?? 1.8) * 0.5) - (block.position.y + 0.5)
-      const adx = Math.abs(dx)
-      const ady = Math.abs(dy)
-      const adz = Math.abs(dz)
-      if (adx >= adz && adx >= ady) direction = new Vec3(dx > 0 ? 1 : -1, 0, 0)
-      else if (adz >= adx && adz >= ady) direction = new Vec3(0, 0, dz > 0 ? 1 : -1)
-      else direction = new Vec3(0, dy > 0 ? 1 : -1, 0)
+      // No face given: reproduce the server's ray-trace so the face and cursor we
+      // send describe a surface the server can actually reach. This fixes silent
+      // failures on 2-block-tall blocks like bamboo_door, where the old default
+      // (Vec3(0,1,0) = UP) clicks the lower half's top face — occluded by the
+      // upper half — and the server drops the interaction with no error.
+      const hit = raycastInteractFace(block)
+      if (hit) {
+        direction = hit.direction
+        cursorPos = cursorPos ?? hit.cursorPos
+      } else {
+        // Block not directly visible: fall back to the nearest face by bot
+        // position (still better than a fixed UP default). Use bot midpoint Y so
+        // horizontal interactions near eye height aren't misclassified as UP/DOWN.
+        const botPos = bot.entity.position
+        const dx = botPos.x - (block.position.x + 0.5)
+        const dz = botPos.z - (block.position.z + 0.5)
+        const dy = (botPos.y + (bot.entity.height ?? 1.8) * 0.5) - (block.position.y + 0.5)
+        const adx = Math.abs(dx)
+        const ady = Math.abs(dy)
+        const adz = Math.abs(dz)
+        if (adx >= adz && adx >= ady) direction = new Vec3(dx > 0 ? 1 : -1, 0, 0)
+        else if (adz >= adx && adz >= ady) direction = new Vec3(0, 0, dz > 0 ? 1 : -1)
+        else direction = new Vec3(0, dy > 0 ? 1 : -1, 0)
+      }
     }
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
     cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
     // TODO: tell the server that we are not sneaking while doing this
-    await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
+    // Look at the actual click point so look direction, face and cursor agree.
+    await bot.lookAt(block.position.plus(cursorPos), false)
     // place block message
     // TODO: logic below can likely be simplified
     if (bot.supportFeature('blockPlaceHasHeldItem')) {

--- a/test/externalTests/activateBlockFace.js
+++ b/test/externalTests/activateBlockFace.js
@@ -1,0 +1,60 @@
+const assert = require('assert')
+const { Vec3 } = require('vec3')
+const { once } = require('../../lib/promise_utils')
+
+module.exports = () => async (bot) => {
+  // Direction numbers: 0=down(-Y), 1=up(+Y), 2=north(-Z), 3=south(+Z), 4=west(-X), 5=east(+X)
+
+  const groundY = bot.test.groundY
+  const blockPos = new Vec3(5, groundY + 1, 5)
+  const blockPosStr = blockPos.toArray().join(' ')
+
+  // Place a stone block to activate against (lever needs a base, but stone is simpler to test)
+  const blockUpdate = once(bot.world, `blockUpdate:(${blockPos.x}, ${blockPos.y}, ${blockPos.z})`)
+  bot.chat(`/setblock ${blockPosStr} stone`)
+  await blockUpdate
+  await bot.test.wait(500)
+
+  // Helper: intercept the next block_place packet and return the direction field
+  function captureNextBlockPlaceDirection () {
+    return new Promise((resolve) => {
+      const origWrite = bot._client.write
+      bot._client.write = function (name, data) {
+        origWrite.apply(bot._client, arguments)
+        if (name === 'block_place') {
+          bot._client.write = origWrite
+          resolve(data.direction)
+        }
+      }
+    })
+  }
+
+  // Test cases: [botPosition, expectedDirection, label]
+  // Bot east of block (+X) => should click east face (direction 5)
+  // Bot west of block (-X) => should click west face (direction 4)
+  // Bot south of block (+Z) => should click south face (direction 3)
+  // Bot north of block (-Z) => should click north face (direction 2)
+  const testCases = [
+    [blockPos.offset(3, 0, 0), 5, 'east (+X)'],
+    [blockPos.offset(-3, 0, 0), 4, 'west (-X)'],
+    [blockPos.offset(0, 0, 3), 3, 'south (+Z)'],
+    [blockPos.offset(0, 0, -3), 2, 'north (-Z)']
+  ]
+
+  for (const [botPosition, expectedDir, label] of testCases) {
+    await bot.test.teleport(botPosition)
+    await bot.test.wait(500)
+
+    const block = bot.blockAt(blockPos)
+    assert(block, `Could not find block at ${blockPos}`)
+
+    const dirPromise = captureNextBlockPlaceDirection()
+    await bot.activateBlock(block)
+    const actualDir = await dirPromise
+
+    bot.test.sayEverywhere(`activateBlock face ${label}: expected=${expectedDir} actual=${actualDir}`)
+    assert.strictEqual(actualDir, expectedDir, `Face direction mismatch for ${label}: expected ${expectedDir}, got ${actualDir}`)
+  }
+
+  bot.test.sayEverywhere('activateBlock face direction test: pass')
+}

--- a/test/externalTests/activateBlockFace.js
+++ b/test/externalTests/activateBlockFace.js
@@ -15,18 +15,30 @@ module.exports = () => async (bot) => {
   await blockUpdate
   await bot.test.wait(500)
 
-  // Helper: intercept the next block_place packet and return the direction field
-  function captureNextBlockPlaceDirection () {
+  // Helper: intercept the next block_place packet and return its full data
+  function captureNextBlockPlace () {
     return new Promise((resolve) => {
       const origWrite = bot._client.write
       bot._client.write = function (name, data) {
         origWrite.apply(bot._client, arguments)
         if (name === 'block_place') {
           bot._client.write = origWrite
-          resolve(data.direction)
+          resolve(data)
         }
       }
     })
+  }
+
+  // The cursor is scaled by 16 on older versions and raw [0,1] on newer ones.
+  // Assert it lands on the reported face.
+  const faceAxis = ['y', 'y', 'z', 'z', 'x', 'x']
+  const faceValue = [0, 1, 0, 1, 0, 1]
+  function assertCursorOnFace (data, dir) {
+    const scale = (Math.abs(data.cursorX) > 1.001 || Math.abs(data.cursorY) > 1.001 || Math.abs(data.cursorZ) > 1.001) ? 16 : 1
+    const cursor = { x: data.cursorX / scale, y: data.cursorY / scale, z: data.cursorZ / scale }
+    const axis = faceAxis[dir]
+    assert.ok(Math.abs(cursor[axis] - faceValue[dir]) < 0.05,
+      `Cursor ${axis}=${cursor[axis]} not on the expected face (${faceValue[dir]}) for direction ${dir}`)
   }
 
   // Test cases: [botPosition, expectedDirection, label]
@@ -48,12 +60,46 @@ module.exports = () => async (bot) => {
     const block = bot.blockAt(blockPos)
     assert(block, `Could not find block at ${blockPos}`)
 
-    const dirPromise = captureNextBlockPlaceDirection()
+    const placePromise = captureNextBlockPlace()
     await bot.activateBlock(block)
-    const actualDir = await dirPromise
+    const data = await placePromise
 
-    bot.test.sayEverywhere(`activateBlock face ${label}: expected=${expectedDir} actual=${actualDir}`)
-    assert.strictEqual(actualDir, expectedDir, `Face direction mismatch for ${label}: expected ${expectedDir}, got ${actualDir}`)
+    bot.test.sayEverywhere(`activateBlock face ${label}: expected=${expectedDir} actual=${data.direction}`)
+    assert.strictEqual(data.direction, expectedDir, `Face direction mismatch for ${label}: expected ${expectedDir}, got ${data.direction}`)
+    assertCursorOnFace(data, expectedDir)
+  }
+
+  // Regression for #3851: a 2-block-tall door must actually open with the default
+  // (no direction). The old UP default clicked the lower half's top face, which the
+  // server rejects because the upper half occupies y+1 — the door silently stayed shut.
+  const doorName = ['bamboo_door', 'oak_door'].find(n => bot.registry.blocksByName[n])
+  if (doorName) {
+    const lower = new Vec3(9, groundY + 1, 9)
+    const upper = lower.offset(0, 1, 0)
+    const ls = lower.toArray().join(' ')
+    const us = upper.toArray().join(' ')
+    // facing=west => the door front faces the bot, which stands to its west (lower x)
+    bot.chat(`/setblock ${ls} air`)
+    bot.chat(`/setblock ${us} air`)
+    await bot.test.wait(300)
+    bot.chat(`/setblock ${ls} minecraft:${doorName}[half=lower,facing=west,hinge=left,open=false,powered=false]`)
+    bot.chat(`/setblock ${us} minecraft:${doorName}[half=upper,facing=west,hinge=left,powered=false]`)
+    await bot.test.wait(600)
+
+    await bot.test.teleport(lower.offset(-2, 0, 0))
+    await bot.test.wait(500)
+
+    const isOpen = () => {
+      const p = bot.blockAt(lower).getProperties()
+      return p.open === true || p.open === 'true'
+    }
+    assert.strictEqual(isOpen(), false, `${doorName} should start closed`)
+
+    await bot.activateBlock(bot.blockAt(lower)) // no direction -> auto-detect
+    await bot.test.wait(800)
+
+    bot.test.sayEverywhere(`activateBlock ${doorName}: open after default activate = ${isOpen()}`)
+    assert.strictEqual(isOpen(), true, `${doorName} did not open with the auto-detected face (regression of #3851)`)
   }
 
   bot.test.sayEverywhere('activateBlock face direction test: pass')

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -304,6 +304,87 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock face direction', () => {
+      // Direction mapping: 0=down(-y), 1=up(+y), 2=north(-z), 3=south(+z), 4=west(-x), 5=east(+x)
+      const blockPos = vec3(8, 65, 8)
+
+      async function setupAndActivate (botPosition, done, expectedDirection) {
+        return new Promise((resolve, reject) => {
+          server.on('playerJoin', async (client) => {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            const stoneId = bot.registry.blocksByName.stone.id
+            chunk.setBlockType(blockPos, stoneId)
+            client.write('map_chunk', generateChunkPacket(chunk))
+
+            await once(bot, 'chunkColumnLoad')
+
+            // Teleport bot to desired position
+            const posPacket = {
+              x: botPosition.x,
+              y: botPosition.y,
+              z: botPosition.z,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+              teleportId: 1
+            }
+            client.write('position', posPacket)
+            await once(bot, 'forcedMove')
+
+            // Listen for block_place packet to check direction
+            client.on('packet', (data, meta) => {
+              if (meta.name === 'block_place') {
+                try {
+                  assert.strictEqual(data.direction, expectedDirection,
+                    `Expected direction ${expectedDirection} but got ${data.direction}`)
+                  resolve()
+                } catch (e) {
+                  reject(e)
+                }
+              }
+            })
+
+            const block = bot.blockAt(blockPos)
+            bot.activateBlock(block).catch(reject)
+          })
+        })
+      }
+
+      it('should pick east (+x) face when bot is east of block', async function () {
+        // Bot at x=11 vs block center x=8.5 => dx > 0 => east face => direction 5
+        await setupAndActivate(vec3(11, 65, 8.5), null, 5)
+      })
+
+      it('should pick west (-x) face when bot is west of block', async function () {
+        // Bot at x=5 vs block center x=8.5 => dx < 0 => west face => direction 4
+        await setupAndActivate(vec3(5, 65, 8.5), null, 4)
+      })
+
+      it('should pick south (+z) face when bot is south of block', async function () {
+        // Bot at z=11 vs block center z=8.5 => dz > 0 => south face => direction 3
+        await setupAndActivate(vec3(8.5, 65, 11), null, 3)
+      })
+
+      it('should pick north (-z) face when bot is north of block', async function () {
+        // Bot at z=5 vs block center z=8.5 => dz < 0 => north face => direction 2
+        await setupAndActivate(vec3(8.5, 65, 5), null, 2)
+      })
+
+      it('should pick up (+y) face when bot is above block', async function () {
+        // Bot at y=70 vs block center y=65.5 => dy > 0 => up face => direction 1
+        await setupAndActivate(vec3(8.5, 70, 8.5), null, 1)
+      })
+
+      it('should pick down (-y) face when bot is below block', async function () {
+        // Bot at y=60 vs block center y=65.5 => dy < 0 => down face => direction 0
+        await setupAndActivate(vec3(8.5, 60, 8.5), null, 0)
+      })
+    })
+
     describe('physics', () => {
       const pos = vec3(1, 65, 1)
       const goldId = 41

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -307,6 +307,19 @@ for (const supportedVersion of mineflayer.testedVersions) {
     describe('activateBlock face direction', () => {
       // Direction mapping: 0=down(-y), 1=up(+y), 2=north(-z), 3=south(+z), 4=west(-x), 5=east(+x)
       const blockPos = vec3(8, 65, 8)
+      // For each direction, the cursor axis that should sit on the face boundary, and its value (0 = min side, 1 = max side)
+      const faceAxis = ['y', 'y', 'z', 'z', 'x', 'x']
+      const faceValue = [0, 1, 0, 1, 0, 1]
+
+      // The cursor is sent scaled by 16 on older versions and raw [0,1] on newer ones;
+      // detect the scale from the in-face coordinates (which sit around the block middle).
+      function assertCursorOnFace (data, expectedDirection) {
+        const scale = (Math.abs(data.cursorX) > 1.001 || Math.abs(data.cursorY) > 1.001 || Math.abs(data.cursorZ) > 1.001) ? 16 : 1
+        const cursor = { x: data.cursorX / scale, y: data.cursorY / scale, z: data.cursorZ / scale }
+        const axis = faceAxis[expectedDirection]
+        assert.ok(Math.abs(cursor[axis] - faceValue[expectedDirection]) < 0.05,
+          `Cursor ${axis}=${cursor[axis]} not on the expected face (${faceValue[expectedDirection]}) for direction ${expectedDirection}`)
+      }
 
       async function setupAndActivate (botPosition, done, expectedDirection) {
         return new Promise((resolve, reject) => {
@@ -341,6 +354,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
                 try {
                   assert.strictEqual(data.direction, expectedDirection,
                     `Expected direction ${expectedDirection} but got ${data.direction}`)
+                  assertCursorOnFace(data, expectedDirection)
                   resolve()
                 } catch (e) {
                   reject(e)


### PR DESCRIPTION
## Alternative to #3852 — raycast-based `activateBlock` face detection

This is a **draft alternative** to #3852 (it is **stacked on top of it**, see note below). It keeps that PR's goal — auto-detecting the interaction face for `bot.activateBlock(block)` so the default no longer fails on two-block-tall blocks like doors — but chooses the face differently.

Builds on @jerry1091's work in #3852 / #3851 (their commits are included here).

### What's different from #3852

| | #3852 (heuristic) | this PR (raycast) |
|---|---|---|
| Face selection | dominant-axis from bot position | raycast from bot eyes → the face actually seen (`bot.world.raycast`, same mechanism `bot.dig(..., 'raycast')` uses) |
| `cursorPos` | left at block center (off the face) | the ray hit point, on the chosen face |
| `lookAt` | block center | the actual click point |
| Fallback | — | the #3852 positional heuristic, when the block isn't directly visible |

The motivation: the face, the cursor, and the look direction stay **mutually consistent**, which is exactly what a server's interaction ray-trace (and anti-cheat) validates. `prismarine-world`'s `BlockFace` enum matches the `block_place` `direction` field, so the mapping round-trips through the existing `vectorToDirection()`.

### Validation

- ✅ `standard` + `standard-markdown` clean.
- ✅ **162 internal tests pass** (`test/internalTest.js`, 6 faces × all supported versions). These run against a mocked server but use the real `bot.world.raycast` against real block shapes. Adds a cursor-on-face assertion (handles both the old ×16 and modern raw cursor encodings).
- ✅ End-to-end: a real 2-tall `bamboo_door` opens via the auto-detected face on vanilla and Paper, 1.21.1 and 1.21.11.

### ⚠️ Important finding about the original bug

While testing end-to-end I **could not reproduce the reported silent failure** on stock servers — the old `UP` default opens the door on **vanilla and Paper, at both 1.21.1 and 1.21.11**. On a stock server, a right-click *interaction* is processed largely independent of the clicked face, so any face toggles the door.

The failure in #3851 most plausibly requires an **anti-cheat plugin** that ray-traces the interaction and rejects a face/cursor that doesn't match where the player is looking (the reporter ran Paper offline-mode). That's precisely the case this raycast approach is best suited to. Practical implications:

- The change is **low-risk**: it does not regress stock servers (door still opens), and is strictly better on strict/anti-cheat servers.
- The door open/close test added here is, on the vanilla servers CI runs, **not a true regression guard** (UP also opens the door there) — its value is as an integration sanity check. The packet-direction and cursor-on-face assertions are the meaningful guards.
- Worth confirming with the original reporter which anti-cheat was in play.

### Behavior change to note

Callers passing an explicit `direction` are unaffected. For the default path, `activateBlock` while **holding a placeable item** would now target the visible face instead of the top — `placeBlock` remains the intended placement API.

### Note on stacking

This branch is stacked on #3852, so its commit list includes that PR's commits. **Merge #3852 first**; GitHub will then reduce this PR to just the raycast commit. The "Files changed" tab already shows only the net feature diff. #3852 is left untouched.

Refs #3851. Alternative to #3852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
