### PR TITLE
Fix isAlive state for non-death respawns

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -4,7 +4,7 @@ function inject (bot, options) {
   bot.isAlive = true
 
   bot._client.on('respawn', (packet) => {
-    bot.isAlive = false
+    if (bot.health <= 0) bot.isAlive = false
     bot.emit('respawn')
   })
 

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -6,6 +6,7 @@ function inject (bot, options) {
   bot._client.on('respawn', (packet) => {
     if (bot.health <= 0) bot.isAlive = false
     bot.emit('respawn')
+    if (bot.health > 0) bot.emit('spawn')
   })
 
   bot._client.once('update_health', (packet) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -525,7 +525,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
 
     describe('health', () => {
-      it('keeps isAlive true for non-death respawn packets', (done) => {
+      it('keeps isAlive true and emits spawn for non-death respawn packets', (done) => {
         const loginPacket = bot.test.generateLoginPacket()
         let respawnPacket
         if (bot.supportFeature('usesLoginPacket')) {
@@ -581,8 +581,10 @@ for (const supportedVersion of mineflayer.testedVersions) {
           assert.strictEqual(bot.isAlive, true)
 
           const respawnPromise = once(bot, 'respawn')
+          const spawnPromise = once(bot, 'spawn')
           client.write('respawn', respawnPacket)
           await respawnPromise
+          await spawnPromise
           assert.strictEqual(bot.isAlive, true)
           done()
         })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -524,6 +524,71 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('health', () => {
+      it('keeps isAlive true for non-death respawn packets', (done) => {
+        const loginPacket = bot.test.generateLoginPacket()
+        let respawnPacket
+        if (bot.supportFeature('usesLoginPacket')) {
+          loginPacket.worldName = 'minecraft:overworld'
+          loginPacket.hashedSeed = [0, 0]
+          loginPacket.entityId = 0
+          respawnPacket = {
+            dimension: bot.supportFeature('dimensionDataInCodec') ? 'minecraft:overworld' : loginPacket.dimension,
+            worldName: loginPacket.worldName,
+            hashedSeed: loginPacket.hashedSeed,
+            gamemode: 0,
+            previousGamemode: 255,
+            isDebug: false,
+            isFlat: false,
+            copyMetadata: true,
+            death: {
+              dimensionName: '',
+              location: {
+                x: 0,
+                y: 0,
+                z: 0
+              }
+            }
+          }
+          if (bot.supportFeature('spawnRespawnWorldDataField')) {
+            respawnPacket = {
+              worldState: respawnPacket
+            }
+            respawnPacket.worldState.name = loginPacket.worldName
+            respawnPacket.worldState.dimension = loginPacket.dimension
+          }
+        } else {
+          respawnPacket = {
+            dimension: 0,
+            hashedSeed: [0, 0],
+            gamemode: 0,
+            levelType: 'default'
+          }
+        }
+
+        server.on('playerJoin', async (client) => {
+          const loginPromise = once(bot, 'login')
+          client.write('login', loginPacket)
+          await loginPromise
+
+          const healthPromise = once(bot, 'health')
+          client.write('update_health', {
+            health: 20,
+            food: 20,
+            foodSaturation: 0
+          })
+          await healthPromise
+          assert.strictEqual(bot.isAlive, true)
+
+          const respawnPromise = once(bot, 'respawn')
+          client.write('respawn', respawnPacket)
+          await respawnPromise
+          assert.strictEqual(bot.isAlive, true)
+          done()
+        })
+      })
+    })
+
     describe('game', () => {
       it('responds to ping / transaction packets', (done) => { // only on 1.17
         server.on('playerJoin', async (client) => {


### PR DESCRIPTION
Fixes #3905.

This PR prevents `bot.isAlive` from being set to `false` for every `respawn` packet.

Some servers/proxies can send `respawn` packets for non-death transitions, such as server transfers or world changes. In those cases the bot is still alive, but Mineflayer marked it as dead, which could stop physics position updates.

Now `bot.isAlive` is only set to `false` on `respawn` if `bot.health <= 0`.

Added an internal regression test to verify healthy respawn packets keep `bot.isAlive === true`.

Tested with:

- `npm run mocha_test -- test/internalTest.js -g "keeps isAlive true"`
- `npm run lint`