### PR TITLE
Prevent lookingTask resolving when pitch incorrect.

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -304,7 +304,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let lookingTask = createDoneTask()
 
   bot.on('move', () => {
-    if (!lookingTask.done && Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001) {
+    if (!lookingTask.done && Math.abs(deltaYaw(bot.entity.yaw, lastSentYaw)) < 0.001 && Math.abs(bot.entity.pitch - lastSentPitch) < 0.001) {
       lookingTask.finish()
     }
   })


### PR DESCRIPTION
lookingTask was getting resolved when the yaw was correct regardless of the pitch. This caused bot.look to resolve immediately when only the pitch changed.
In the following image, bot.dig thinks it is already looking at the block above and started mining it early:
<img width="287" height="273" alt="image" src="https://github.com/user-attachments/assets/8d1fa49a-fe53-4524-9dba-82d150a54ae6" />