### PR TITLE
make timeout condition configurable for advanced options

### DIFF
--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -11,7 +11,7 @@ function inject (bot) {
     let newBlock = bot.blockAt(dest)
     if (oldBlock.type === newBlock.type) {
       [oldBlock, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
-        timeout: 5000,
+        timeout: options.timeout || 5000,
         // Condition to wait to receive block update actually changing the block type, in case the bot receives block updates with no changes
         // oldBlock and newBlock will both be null when the world unloads
         checkCondition: (oldBlock, newBlock) => !oldBlock || !newBlock || oldBlock.type !== newBlock.type


### PR DESCRIPTION
Allows the user to configure how long the placement timeout should be. 5000ms is often too long. 