### PR TITLE
minor revisions to digging

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -217,11 +217,13 @@ function inject (bot) {
     } catch (_) {}
   })
 
-  function canDigBlock (block) {
+  // TODO: normalize "reach" here to be bot-global.
+  function canDigBlock (block, reach = 5.1) {
+    // TODO: make this an AABB check.
     return (
       block &&
       block.diggable &&
-      block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, 1.65, 0)) <= 5.1
+      block.position.offset(0.5, 0.5, 0.5).distanceTo(bot.entity.position.offset(0, bot.entity.eyeHeight, 0)) <= reach
     )
   }
 


### PR DESCRIPTION
Fix the canDigBlock check to properly reflect our eye height. Note that this still fails while swimming.