### PR TITLE
Synchronize inventory when received close_window packet

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -709,6 +709,8 @@ function inject (bot, { hideErrors }) {
   bot._client.on('close_window', (packet) => {
     // close window
     const oldWindow = bot.currentWindow
+    if (!oldWindow) return
+    copyInventory(oldWindow)
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })


### PR DESCRIPTION
Fix: When the bot opens a container, if the bot's inventory items are updated but the container is suddenly damaged, the updated items during this period will not be synchronized to the `bot.inventory`