### PR TITLE
Fix #3935: blockAtEntityCursor() for zero yaw/pitch values

### DIFF
--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -55,7 +55,10 @@ module.exports = (bot) => {
   }
 
   bot.blockAtEntityCursor = (entity = bot.entity, maxDistance = 256, matcher = null) => {
-    if (!entity.position || !entity.height || !entity.pitch || !entity.yaw) return null
+    const isMissing = !entity.position || entity.height == null || entity.pitch == null || entity.yaw == null
+    const isInvalid = !Number.isFinite(entity.height) || !Number.isFinite(entity.pitch) || !Number.isFinite(entity.yaw)
+    if (isMissing || isInvalid) return null
+
     const { position, height, pitch, yaw } = entity
 
     const eyePosition = position.offset(0, height, 0)


### PR DESCRIPTION
Fixes [#3935](https://github.com/PrismarineJS/mineflayer/issues/3935)
[ray_trace.js](https://github.com/PrismarineJS/mineflayer/blob/master/lib/plugins/ray_trace.js)
blockAtEntityCursor() validated entity.pitch and entity.yaw using truthiness checks, causing legitimate 0 values to be treated as missing. Bots facing due south (yaw = 0) or looking level (pitch = 0) would incorrectly return null instead of performing the ray trace.

Replace the truthiness checks with explicit nullish validation and Number.isFinite() so zero remains a valid orientation while still rejecting missing or invalid values.

I didn't have a great way to add a correct test in [rayTrace.js](https://github.com/PrismarineJS/mineflayer/blob/master/test/externalTests/rayTrace.js) because it requires a block in front of the entity as well and I wasn't sure about doing that.

However, the testing and the logs that resulted pointed to it being a valid fix (it's fairly trivial anyways).