### PR TITLE
fix: EntityAttach/entityDetach and bot dismount for set_passengers

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -771,31 +771,50 @@ function inject (bot) {
   })
 
   bot._client.on('set_passengers', ({ entityId, passengers }) => {
-    const passengerEntities = passengers.map((passengerId) => fetchEntity(passengerId))
+    // set_passengers carries a vehicle's *complete* passenger list whenever it
+    // changes. Unlike 1.8's attach_entity it never sends -1 and is not resent when
+    // the vehicle is destroyed (entityGone handles that). To recover who actually
+    // mounted or dismounted we diff the incoming list against the vehicle's previous
+    // passenger list, which mineflayer already keeps in `vehicle.passengers`.
     const vehicle = entityId === -1 ? null : bot.entities[entityId]
+    if (!vehicle) return // unknown vehicle: nothing to diff against
 
-    for (const passengerEntity of passengerEntities) {
-      const originalVehicle = passengerEntity.vehicle
-      if (originalVehicle) {
-        const index = originalVehicle.passengers.indexOf(passengerEntity)
-        originalVehicle.passengers.splice(index, 1)
-      }
-      passengerEntity.vehicle = vehicle
-      if (vehicle) {
-        vehicle.passengers.push(passengerEntity)
-      }
-    }
+    const newPassengers = passengers.map((passengerId) => fetchEntity(passengerId))
+    const oldPassengers = vehicle.passengers ?? []
 
-    if (passengers.includes(bot.entity.id)) {
-      const originalVehicle = bot.vehicle
-      if (entityId === -1) {
+    const left = oldPassengers.filter((entity) => !newPassengers.includes(entity))
+    const joined = newPassengers.filter((entity) => !oldPassengers.includes(entity))
+
+    for (const passenger of left) {
+      passenger.vehicle = null
+      if (passenger === bot.entity) {
         bot.vehicle = null
-        bot.emit('dismount', originalVehicle)
+        bot.emit('dismount', vehicle)
       } else {
-        bot.vehicle = bot.entities[entityId]
-        bot.emit('mount')
+        bot.emit('entityDetach', passenger, vehicle)
       }
     }
+
+    for (const passenger of joined) {
+      // If the passenger was riding a different vehicle, drop it from that one's
+      // list first: that vehicle's own set_passengers may not have arrived yet.
+      const previous = passenger.vehicle
+      if (previous && previous !== vehicle) {
+        const index = previous.passengers.indexOf(passenger)
+        if (index !== -1) previous.passengers.splice(index, 1)
+      }
+      passenger.vehicle = vehicle
+      if (passenger === bot.entity) {
+        bot.vehicle = vehicle
+        bot.emit('mount')
+      } else {
+        bot.emit('entityAttach', passenger, vehicle)
+      }
+    }
+
+    // Commit the new list in the server's order, so passengers[0] is the front seat
+    // (the one steering a boat) and a driver change is detectable by comparing index 0.
+    vehicle.passengers = newPassengers
   })
 
   // dismounting when the vehicle is gone

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -826,6 +826,10 @@ function inject (bot) {
     if (entity.passengers) {
       for (const passenger of entity.passengers) {
         passenger.vehicle = null
+        // The bot's own departure is already reported as 'dismount' above; other
+        // riders of the destroyed vehicle still need an 'entityDetach' (same gap as
+        // the set_passengers path fixed for #2819).
+        if (passenger !== bot.entity) bot.emit('entityDetach', passenger, entity)
       }
     }
     if (entity.vehicle) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -226,6 +226,111 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
     })
+    // set_passengers exists from 1.9 onward; 1.8 uses the attach_entity packet,
+    // which is handled by a separate code path.
+    if (version.majorVersion !== '1.8') {
+      it('mount and dismount via set_passengers', async () => {
+        const vehicleId = 50
+        const botEntityId = 0 // generateLoginPacket sets the bot's entityId to 0
+        const entitiesByName = bot.registry.entitiesByName
+        const vehicleType = (entitiesByName.boat || entitiesByName.oak_boat ||
+          entitiesByName.minecart || entitiesByName.creeper).id
+
+        let client
+        server.on('playerJoin', (c) => {
+          client = c
+          // Sent over one stream and processed in order: login creates bot.entity,
+          // spawn creates the vehicle, then set_passengers mounts the bot onto it.
+          c.write('login', bot.test.generateLoginPacket())
+          c.write(bot.registry.supportFeature('consolidatedEntitySpawnPacket') ? 'spawn_entity' : 'spawn_entity_living', {
+            entityId: vehicleId,
+            entityUUID: '00112233-4455-6677-8899-aabbccddeeff',
+            objectUUID: '00112233-4455-6677-8899-aabbccddeeff',
+            type: vehicleType,
+            x: 1,
+            y: 65,
+            z: 1,
+            yaw: 0,
+            pitch: 0,
+            headPitch: 0,
+            velocity: { x: 0, y: 0, z: 0 },
+            metadata: []
+          })
+          c.write('set_passengers', { entityId: vehicleId, passengers: [botEntityId] })
+        })
+
+        await once(bot, 'mount')
+        assert.ok(bot.vehicle, 'bot.vehicle should be set after mount')
+        assert.strictEqual(bot.vehicle.id, vehicleId)
+        assert.ok(bot.vehicle.passengers.some((e) => e.id === bot.entity.id), 'bot should be in vehicle.passengers')
+
+        // Server dismounts the bot by re-sending the vehicle's passenger list
+        // without the bot — the vehicle still exists. This is the case the
+        // includes(bot.entity.id) check alone would miss.
+        client.write('set_passengers', { entityId: vehicleId, passengers: [] })
+        const [originalVehicle] = await once(bot, 'dismount')
+        assert.strictEqual(bot.vehicle, null, 'bot.vehicle should be cleared after dismount')
+        assert.strictEqual(bot.entity.vehicle, null, 'bot.entity.vehicle should be cleared after dismount')
+        assert.strictEqual(originalVehicle.id, vehicleId, 'dismount should report the vehicle that was left')
+      })
+
+      it('emits entityAttach/entityDetach and tracks driver order via set_passengers', async () => {
+        const vehicleId = 50
+        const riderA = 100
+        const riderB = 101
+
+        let client
+        server.on('playerJoin', (c) => {
+          client = c
+          c.write('login', bot.test.generateLoginPacket())
+          c.write(bot.registry.supportFeature('consolidatedEntitySpawnPacket') ? 'spawn_entity' : 'spawn_entity_living', {
+            entityId: vehicleId,
+            entityUUID: '00112233-4455-6677-8899-aabbccddeeff',
+            objectUUID: '00112233-4455-6677-8899-aabbccddeeff',
+            type: (bot.registry.entitiesByName.boat || bot.registry.entitiesByName.oak_boat ||
+              bot.registry.entitiesByName.minecart || bot.registry.entitiesByName.creeper).id,
+            x: 1,
+            y: 65,
+            z: 1,
+            yaw: 0,
+            pitch: 0,
+            headPitch: 0,
+            velocity: { x: 0, y: 0, z: 0 },
+            metadata: []
+          })
+        })
+        while (!bot.entities[vehicleId]) await sleep(5) // wait for the spawn packet to be processed
+        const vehicle = bot.entities[vehicleId]
+
+        // riderA (another entity, not the bot) boards: expect entityAttach.
+        let attach = once(bot, 'entityAttach')
+        client.write('set_passengers', { entityId: vehicleId, passengers: [riderA] })
+        let [entity, reportedVehicle] = await attach
+        assert.strictEqual(entity.id, riderA, 'entityAttach should report the entity that boarded')
+        assert.strictEqual(reportedVehicle.id, vehicleId, 'entityAttach should report the vehicle boarded')
+        assert.strictEqual(entity.vehicle, vehicle, 'rider.vehicle should point at the vehicle')
+        assert.deepStrictEqual(vehicle.passengers.map((e) => e.id), [riderA])
+
+        // riderB boards too: another entityAttach, riderA stays the front seat (driver).
+        attach = once(bot, 'entityAttach')
+        client.write('set_passengers', { entityId: vehicleId, passengers: [riderA, riderB] })
+        ;[entity] = await attach
+        assert.strictEqual(entity.id, riderB)
+        assert.deepStrictEqual(vehicle.passengers.map((e) => e.id), [riderA, riderB], 'order preserved, index 0 is the driver')
+
+        // The driver (riderA) leaves while riderB stays: expect entityDetach for riderA
+        // and riderB promoted to the front seat. This is the case the old loop, which
+        // only iterated the new list, dropped entirely.
+        const detach = once(bot, 'entityDetach')
+        client.write('set_passengers', { entityId: vehicleId, passengers: [riderB] })
+        const [gone, leftVehicle] = await detach
+        assert.strictEqual(gone.id, riderA, 'entityDetach should report the entity that left')
+        assert.strictEqual(leftVehicle.id, vehicleId)
+        assert.strictEqual(gone.vehicle, null, 'departed rider.vehicle should be cleared')
+        assert.deepStrictEqual(vehicle.passengers.map((e) => e.id), [riderB], 'departed rider removed, no stale entry')
+        assert.strictEqual(vehicle.passengers[0].id, riderB, 'riderB is promoted to the front seat')
+      })
+    }
     it('blockAt', (done) => {
       const pos = vec3(1, 65, 1)
       const goldId = bot.registry.blocksByName.gold_block.id

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -299,7 +299,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
             metadata: []
           })
         })
-        while (!bot.entities[vehicleId]) await sleep(5) // wait for the spawn packet to be processed
+        // bot.entities is undefined until the plugin is injected on 'inject_allowed'
+        // (fired via setTimeout after connect), so guard with ?. and wait for the spawn.
+        while (!bot.entities?.[vehicleId]) await sleep(5) // wait for injection + spawn packet
         const vehicle = bot.entities[vehicleId]
 
         // riderA (another entity, not the bot) boards: expect entityAttach.

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -9,6 +9,16 @@ const nbt = require('prismarine-nbt')
 const { once } = require('../lib/promise_utils')
 const { getPort } = require('./common/util')
 
+// A mountable vehicle entity type id that exists in every tested version. Entity
+// names were flattened to snake_case in 1.11; before that they were CamelCase
+// (e.g. Boat, Creeper, MinecartRideable), so cover both eras.
+function vehicleTypeId (registry) {
+  const n = registry.entitiesByName
+  const entity = n.boat || n.oak_boat || n.minecart || n.creeper ||
+    n.Boat || n.MinecartRideable || n.Minecart || n.Creeper
+  return entity.id
+}
+
 for (const supportedVersion of mineflayer.testedVersions) {
   const registry = require('prismarine-registry')(supportedVersion)
   const version = registry.version
@@ -232,9 +242,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('mount and dismount via set_passengers', async () => {
         const vehicleId = 50
         const botEntityId = 0 // generateLoginPacket sets the bot's entityId to 0
-        const entitiesByName = bot.registry.entitiesByName
-        const vehicleType = (entitiesByName.boat || entitiesByName.oak_boat ||
-          entitiesByName.minecart || entitiesByName.creeper).id
+        const vehicleType = vehicleTypeId(bot.registry)
 
         let client
         server.on('playerJoin', (c) => {
@@ -287,8 +295,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
             entityId: vehicleId,
             entityUUID: '00112233-4455-6677-8899-aabbccddeeff',
             objectUUID: '00112233-4455-6677-8899-aabbccddeeff',
-            type: (bot.registry.entitiesByName.boat || bot.registry.entitiesByName.oak_boat ||
-              bot.registry.entitiesByName.minecart || bot.registry.entitiesByName.creeper).id,
+            type: vehicleTypeId(bot.registry),
             x: 1,
             y: 65,
             z: 1,


### PR DESCRIPTION
Fixes #2819.

## Problem
Since 1.9, a vehicle's passenger changes arrive via the `set_passengers`
packet, which carries the vehicle's *complete* passenger list on every change.
Unlike 1.8's `attach_entity` it never sends a `-1`, and it is not resent when
the vehicle is destroyed. The existing handler didn't account for this:

- `dismount` for the bot was gated on an `entityId === -1` that never arrives,
  so it effectively never fired.
- `entityAttach` / `entityDetach` were never emitted for other entities.
- The passenger list was mutated by pushing/splicing individual entries rather
  than reconciled against the packet, so seat order (front seat = driver) and
  departures weren't tracked.

## Fix
Rewrite the `set_passengers` handler to diff the incoming list against the
vehicle's previous `vehicle.passengers` (which mineflayer already maintains):

- Entities in the old list but not the new one **left**: clear their
  `.vehicle` and emit `dismount` (bot) or `entityDetach` (others).
- Entities in the new list but not the old one **joined**: set their
  `.vehicle`, remove them from any prior vehicle whose own packet hasn't
  arrived yet, and emit `mount` (bot) or `entityAttach` (others).
- Commit the new list in server order, so `passengers[0]` is the front seat
  and a driver change is detectable.
- Bail out early if the vehicle entity is unknown.

Also emit `entityDetach` for remaining riders in the `entityGo`
passengers of a *destroyed* vehicle (which never generates a `set_passengers`) 
are detached too.

## Tests
Two in-process tests in `test/internalTest.js`, run across every tested
version except 1.8 (which uses the separate `attach_entity` pa

- mount then dismount of the bot via a re-sent passenger list
  old `-1` check missed).
- `entityAttach`/`entityDetach` for other entities, plus seat-
  a second rider boards, then the driver leaves and the remaining rider is
  promoted to the front seat.

A `vehicleTypeId(registry)` helper picks a mountable entity ty
in every tested version (entity names were CamelCase before the 1.11 flattening).