### PR TITLE
ci: cache server jars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      # Persist the downloaded server jars between runs. On a cache hit the tests
-      # reuse these jars and skip minecraft-wrap's download(), which avoids fetching
-      # Mojang's version_manifest.json at runtime (the main source of CI flakiness).
+      # Reuse downloaded server jars across runs. On a cache hit the tests skip
+      # download() and its runtime Mojang version-manifest fetch.
       - name: Cache Minecraft server jars
         uses: actions/cache@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      # Persist the downloaded server jars between runs. On a cache hit the tests
+      # reuse these jars and skip minecraft-wrap's download(), which avoids fetching
+      # Mojang's version_manifest.json at runtime (the main source of CI flakiness).
+      - name: Cache Minecraft server jars
+        uses: actions/cache@v4
+        with:
+          path: server_jars
+          key: server-jars-${{ hashFiles('lib/version.js') }}-${{ strategy.job-index }}
+          restore-keys: |
+            server-jars-${{ hashFiles('lib/version.js') }}-
+
       - name: Start Tests
         run: |
           exit_code=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v1.4.4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
     - run: npm i && npm run lint
@@ -24,9 +24,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v1.4.4
+      uses: actions/setup-node@v6
       with:
         node-version: 24
     - id: set-matrix
@@ -50,16 +50,16 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v1.4.4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v5
         with:
+          distribution: temurin
           java-version: 21
-          java-package: jre
       - name: Install Dependencies
         run: npm install
 
@@ -67,7 +67,7 @@ jobs:
       # reuse these jars and skip minecraft-wrap's download(), which avoids fetching
       # Mojang's version_manifest.json at runtime (the main source of CI flakiness).
       - name: Cache Minecraft server jars
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: server_jars
           key: server-jars-${{ hashFiles('lib/version.js') }}-${{ strategy.job-index }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v2
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 24
     - run: npm i && npm run lint
@@ -24,9 +24,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@v2
     - name: Use Node.js 22.x
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v1.4.4
       with:
         node-version: 24
     - id: set-matrix
@@ -50,16 +50,16 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v2
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v1.4.4
         with:
           node-version: 24
       - name: Setup Java JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v1.4.3
         with:
-          distribution: temurin
           java-version: 21
+          java-package: jre
       - name: Install Dependencies
         run: npm install
 

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -82,12 +82,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       }
 
-      // minecraft-wrap's download() refetches Mojang's version_manifest.json on
-      // every call (it is only cached in-memory per instance, never to disk), so
-      // each version's `before` hook hits the network. When Mojang is slow or
-      // unreachable this makes CI flaky. Skip the download - and thus the manifest
-      // fetch - when the server jar is already present on disk (e.g. restored from
-      // the CI cache); only reach out to the network on a cache miss.
+      // Reuse a server jar already on disk (e.g. restored from the CI cache) instead
+      // of downloading it: download() refetches Mojang's version manifest on every
+      // call, so skipping it on a cache hit keeps the run off the network.
       function ensureServerJar (cb) {
         if (fs.existsSync(MC_SERVER_JAR)) {
           console.log(`using cached server jar ${MC_SERVER_JAR}`)

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -82,9 +82,24 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       }
 
+      // minecraft-wrap's download() refetches Mojang's version_manifest.json on
+      // every call (it is only cached in-memory per instance, never to disk), so
+      // each version's `before` hook hits the network. When Mojang is slow or
+      // unreachable this makes CI flaky. Skip the download - and thus the manifest
+      // fetch - when the server jar is already present on disk (e.g. restored from
+      // the CI cache); only reach out to the network on a cache miss.
+      function ensureServerJar (cb) {
+        if (fs.existsSync(MC_SERVER_JAR)) {
+          console.log(`using cached server jar ${MC_SERVER_JAR}`)
+          return cb(null)
+        }
+        console.log('downloading server jar')
+        download(version.minecraftVersion, MC_SERVER_JAR, cb)
+      }
+
       if (START_THE_SERVER) {
-        console.log('downloading and starting server')
-        download(version.minecraftVersion, MC_SERVER_JAR, (err) => {
+        console.log('starting server')
+        ensureServerJar((err) => {
           if (err) {
             console.log(err)
             done(err)


### PR DESCRIPTION
## Cache Minecraft server jars in CI

### Why
Every external test's mocha `before` hook calls `minecraft-wrap`'s `download()`, which refetches Mojang's version manifest (`launchermeta.mojang.com/mc/game/version_manifest.json`) at runtime — on **every** run, even when the server jar is already on disk. That per-test network call is a recurring source of CI flakiness, and failures in a `before` hook aren't covered by mocha's `--retries`, so a single blip fails the whole version.

### What
Two small changes that keep runs off Mojang's network once a jar exists:

1. **`test/externalTest.js`** — new `ensureServerJar` guard: if the jar for a version is already present, skip `download()` (and its manifest fetch) and reuse the file; only download when it's actually missing.

2. **`.github/workflows/ci.yml`** — added an `actions/cache` step that persists `server_jars/` across runs, keyed by `lib/version.js`. On a cache hit the jars are restored, so `ensureServerJar` takes the skip path and no version-manifest request is made.

### Effect
First run per version list downloads and caches as before; subsequent runs restore the jars and run fully offline against Mojang. Removes the flaky runtime manifest fetch and speeds up CI.
