### PR TITLE
Fix inventory desync when the server force-closes a window.

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -709,6 +709,7 @@ function inject (bot, { hideErrors }) {
   bot._client.on('close_window', (packet) => {
     // close window
     const oldWindow = bot.currentWindow
+    if (oldWindow) copyInventory(oldWindow) // sync player inventory slots, same as closeWindow()
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })


### PR DESCRIPTION
**Issue:**
When the server  closes a window (`close_window` packet), the handler discards the window without calling `copyInventory()`, so any changes in the player-inventory section of that window are lost and `bot.inventory` is left stale. The client-initiated path (`bot.closeWindow()`) already calls `copyInventory()` before discarding  but if the server initiates close it doesn't.

**When this is needed:**
Any time the server force-closes a container the bot is using: shop/GUI plugins that close the window after a click, containers closed on teleport, anti-cheat closing windows, etc. After such a close, `bot.inventory.items()` reports the pre-window contents even though the bot's actual inventory changed while the window was open.

Fixed by using `copyInventory(oldWindow)` in the `close_window` packet handler, mirroring what `closeWindow()` does.


**Example:**
Bot puts items in a [SafeTrade ](https://www.spigotmc.org/resources/safetrade.13885/) plugin window and both players accept the trade. After the trade succeeds the items are gone from the bot's actual inventory, but logging bot.inventory still shows the old items until the bot opens and closes any random container. With this fix it gets synced properly.