### PR TITLE
Fix getting stuck forever on end portal use

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -121,9 +121,18 @@ function inject (bot, options) {
     bot.emit('game')
   })
 
+  function writePerformRespawn () {
+    bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: 0 })
+  }
+
   bot._client.on('game_state_change', (packet) => {
-    if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { action: 0 })
+    // WIN_GAME: leaving the End sends value 0 (skip credits) or 1 (show credits).
+    // Vanilla always sends PERFORM_RESPAWN — value 0 immediately, value 1 after credits.
+    if (packet.reason === 4 || packet.reason === 'win_game') {
+      const value = Math.floor((packet.gameMode ?? 0) + 0.5)
+      if (value === 0 || value === 1) {
+        writePerformRespawn()
+      }
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)


### PR DESCRIPTION
fixes https://github.com/PrismarineJS/mineflayer/issues/3747

## Fix `WIN_GAME` (`game_state_change` reason 4) not sending `client_command` on End exit
### Problem
When leaving the End, vanilla sends `game_state_change` (`WIN_GAME`) with value **0** (skip credits) or **1** (show credits), then expects the client to send `client_command` (`PERFORM_RESPAWN`). The server only sends `respawn` after that — see `ClientPacketListener.handleGameEvent` and `ServerGamePacketListenerImpl.handleClientCommand`.
Mineflayer only reacted to value **1**, so value **0** (common on repeat End portal use) never triggered `client_command`. The server stayed in `wonGame` state: no `respawn`, wrong dimension, broken chat/commands.
It also used `{ action: 0 }` instead of `{ actionId: 0 }` / `{ payload: 0 }` per protocol version.

So I fixed: On `WIN_GAME` with value 0 or 1, send `client_command` using the same field names as `health.js` (`actionId` / `payload` via `respawnIsPayload`).
### Test plan (1.17.1)
- [x] Connect to a server, enter End portal, exit to overworld
- [x] Confirm `client_command` is sent on `win_game` value 0
- [x] Confirm server sends `respawn` and dimension/chunks update
- [x] Confirm chat/commands work after returning to overworld
