### PR TITLE
Send horizontal collision state in movement packets

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -60,6 +60,11 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   // see: https://discord.com/channels/413438066984747026/519952494768685086/901948718255833158
   let timeAccumulator = 0
   let catchupTicks = 0
+
+  function getHorizontalCollision () {
+    return bot.registry.isNewerOrEqualTo('1.21.3') && !!bot.entity.isCollidedHorizontally
+  }
+
   function doPhysics () {
     const now = performance.now()
     const deltaSeconds = (now - lastPhysicsFrameTime) / 1000
@@ -98,7 +103,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     doPhysicsTimer = null
   }
 
-  function sendPacketPosition (position, onGround) {
+  function sendPacketPosition (position, onGround, hasHorizontalCollision) {
     // sends data, no logic
     if (!Number.isFinite(position.x) || !Number.isFinite(position.y) || !Number.isFinite(position.z)) return
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
@@ -106,23 +111,23 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.y = position.y
     lastSent.z = position.z
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision }
     bot._client.write('position', lastSent)
     bot.emit('move', oldPos)
   }
 
-  function sendPacketLook (yaw, pitch, onGround) {
+  function sendPacketLook (yaw, pitch, onGround, hasHorizontalCollision) {
     // sends data, no logic
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
     lastSent.yaw = yaw
     lastSent.pitch = pitch
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision }
     bot._client.write('look', lastSent)
     bot.emit('move', oldPos)
   }
 
-  function sendPacketPositionAndLook (position, yaw, pitch, onGround) {
+  function sendPacketPositionAndLook (position, yaw, pitch, onGround, hasHorizontalCollision = getHorizontalCollision()) {
     // sends data, no logic
     if (!Number.isFinite(position.x) || !Number.isFinite(position.y) || !Number.isFinite(position.z)) return
     const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
@@ -132,7 +137,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.yaw = yaw
     lastSent.pitch = pitch
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision }
     bot._client.write('position_look', lastSent)
     bot.emit('move', oldPos)
   }
@@ -173,6 +178,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const pitch = Math.fround(conv.toNotchianPitch(lastSentPitch))
     const position = bot.entity.position
     const onGround = bot.entity.onGround
+    const hasHorizontalCollision = getHorizontalCollision()
 
     // Only send a position update if necessary, select the appropriate packet
     const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z ||
@@ -182,21 +188,22 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
     if (positionUpdated && lookUpdated) {
-      sendPacketPositionAndLook(position, yaw, pitch, onGround)
+      sendPacketPositionAndLook(position, yaw, pitch, onGround, hasHorizontalCollision)
       lastSent.time = now // only reset if positionUpdated is true
     } else if (positionUpdated) {
-      sendPacketPosition(position, onGround)
+      sendPacketPosition(position, onGround, hasHorizontalCollision)
       lastSent.time = now // only reset if positionUpdated is true
     } else if (lookUpdated) {
-      sendPacketLook(yaw, pitch, onGround)
-    } else if (positionUpdateSentEveryTick || onGround !== lastSent.onGround) {
+      sendPacketLook(yaw, pitch, onGround, hasHorizontalCollision)
+    } else if (positionUpdateSentEveryTick || onGround !== lastSent.onGround || hasHorizontalCollision !== lastSent.flags.hasHorizontalCollision) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
       // For versions >= 1.12, onGround !== lastSent.onGround should be used, but it doesn't ever trigger outside of login
       bot._client.write('flying', {
-        onGround: bot.entity.onGround,
-        flags: { onGround: bot.entity.onGround, hasHorizontalCollision: undefined } // 1.21.3+
+        onGround,
+        flags: { onGround, hasHorizontalCollision }
       })
+      lastSent.flags = { onGround, hasHorizontalCollision }
     }
 
     lastSent.onGround = bot.entity.onGround // onGround is always set

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -361,14 +361,21 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
 
           bot.entity.velocity.y = -1.0 // Give bot some velocity
+          bot.entity.isCollidedHorizontally = true
 
           const p1 = once(bot, 'forcedMove')
+          const response = once(client, 'position_look')
           client.write('position', absolutePositionPacket)
           await p1
+          const [responsePacket] = await response
 
           // Assertions for absolute teleport
           assert.strictEqual(bot.entity.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
           assert.deepStrictEqual(bot.entity.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
+          if (bot.registry.isNewerOrEqualTo('1.21.3')) {
+            assert.strictEqual(responsePacket.flags.hasHorizontalCollision, true,
+              'Teleport response should preserve the current horizontal collision flag')
+          }
 
           // --- Test 2: Relative Position ---
           const relativePositionPacket = {


### PR DESCRIPTION
## Summary

- populate the 1.21.3+ `hasHorizontalCollision` movement bit from the physics state
- send a status-only movement packet when horizontal collision changes
- preserve the collision bit in immediate and delayed server-position responses

## Rationale

Vanilla includes horizontal collision in every serverbound movement packet and sends a status-only packet when that state changes. Mineflayer currently serializes it as undefined, including when acknowledging a server position correction.

The value is gated to 1.21.3+, so legacy protocols do not gain extra collision-only movement packets. This improves vanilla packet fidelity; it does not change collision resolution or claim to resolve server-side wall-contact rejection by itself.

## Tests

- StandardJS lint
- focused internal physics test on 1.8.8, 1.21.3, and 1.21.11