### PR TITLE
fix: send client tick end packets on 1.21.2+

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -20,7 +20,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const physics = Physics(bot.registry, world)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
-  const supportsClientTickEnd = bot.registry.version['>=']('1.21.2')
+  const supportsClientTickEnd = bot.supportFeature('sendsClientTickEndPacket')
 
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -20,6 +20,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const physics = Physics(bot.registry, world)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
+  const supportsClientTickEnd = bot.registry.version['>=']('1.21.2')
 
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown
@@ -76,15 +77,19 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function tickPhysics (now) {
-    if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
-    if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
-    if (bot.physicsEnabled && shouldUsePhysics) {
-      physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
-      bot.emit('physicsTick')
-      bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
-    }
-    if (shouldUsePhysics) {
-      updatePosition(now)
+    try {
+      if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
+      if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
+      if (bot.physicsEnabled && shouldUsePhysics) {
+        physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
+        bot.emit('physicsTick')
+        bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
+      }
+      if (shouldUsePhysics) {
+        updatePosition(now)
+      }
+    } finally {
+      if (supportsClientTickEnd) bot._client.write('tick_end', {})
     }
   }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -431,6 +431,53 @@ for (const supportedVersion of mineflayer.testedVersions) {
           })
         })
       })
+
+      it('sends client tick end after each physics tick on 1.21.2+', function (done) {
+        if (!bot.registry.version['>=']('1.21.2')) {
+          this.skip()
+          return
+        }
+
+        bot.physicsEnabled = false
+        let movementPackets = 0
+        let tickEndPackets = 0
+        let started = false
+
+        server.on('playerJoin', async (client) => {
+          client.on('packet', (data, meta) => {
+            if (['flying', 'position', 'look', 'position_look'].includes(meta.name)) {
+              if (started) movementPackets++
+            } else if (meta.name === 'tick_end') {
+              if (started) {
+                assert.ok(movementPackets <= 1, `expected at most one movement packet per tick, got ${movementPackets}`)
+              }
+              movementPackets = 0
+              started = true
+              tickEndPackets++
+            }
+          })
+
+          await client.write('login', bot.test.generateLoginPacket())
+          const chunk = bot.test.buildChunk()
+          chunk.setBlockType(pos, goldId)
+          await client.write('map_chunk', generateChunkPacket(chunk))
+          await client.write('position', {
+            x: 1.5,
+            y: 66,
+            z: 1.5,
+            pitch: 0,
+            yaw: 0,
+            flags: bot.registry.supportFeature('positionPacketHasBitflags')
+              ? { x: false, y: false, z: false, yaw: false, pitch: false }
+              : 0,
+            teleportId: 0
+          })
+
+          await sleep(300)
+          assert.ok(tickEndPackets >= 3, `expected at least three tick_end packets, got ${tickEndPackets}`)
+          done()
+        })
+      })
     })
 
     describe('world', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -433,7 +433,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
 
       it('sends client tick end after each physics tick on 1.21.2+', function (done) {
-        if (!bot.registry.version['>=']('1.21.2')) {
+        if (!bot.supportFeature('sendsClientTickEndPacket')) {
           this.skip()
           return
         }


### PR DESCRIPTION
## Summary

- Send one `tick_end` packet at the end of every Mineflayer physics tick on Minecraft 1.21.2+.
- Keep the packet emission in the internal physics loop so it also works when `physicsEnabled` is false and when no movement packet is needed.
- Use `finally` so early returns for unloaded chunks or unavailable entity state still finish the client tick.

This addresses the GrimAC `TickTimer` failure described in #3800.

## Tests

- `npm run lint`
- `npx mocha --reporter dot --exit --grep "sends client tick end"`
- `npm run mocha_test -- --grep physics` (88 passing, 20 pending)

The focused test covers protocol versions 1.21.3 through 1.21.11 and verifies movement packets are followed by `tick_end`.

Fixes #3800