### PR TITLE
Expose canonical entity attribute keys

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -32,6 +32,11 @@ const entityStatusEvents = {
 
 function inject (bot) {
   const { mobs } = bot.registry
+  const attributeAliases = new Map()
+  for (const attribute of bot.registry.attributesArray ?? []) {
+    const name = attribute.resource.split(/[:.]/).pop()
+    attributeAliases.set(name, attribute.resource)
+  }
   const Entity = require('prismarine-entity')(bot.version)
   const Item = require('prismarine-item')(bot.version)
   const ChatMessage = require('prismarine-chat')(bot.registry)
@@ -577,10 +582,13 @@ function inject (bot) {
     const entity = fetchEntity(packet.entityId)
     if (!entity.attributes) entity.attributes = {}
     for (const prop of packet.properties) {
-      entity.attributes[prop.key] = {
+      const value = {
         value: prop.value,
         modifiers: prop.modifiers
       }
+      entity.attributes[prop.key] = value
+      const canonicalKey = attributeAliases.get(prop.key.split('.').pop())
+      if (canonicalKey) entity.attributes[canonicalKey] = value
     }
     bot.emit('entityAttributes', entity)
   }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -34,6 +34,7 @@ function inject (bot) {
   const { mobs } = bot.registry
   const attributeAliases = new Map()
   for (const attribute of bot.registry.attributesArray ?? []) {
+    if (!attribute.resource) continue
     const name = attribute.resource.split(/[:.]/).pop()
     attributeAliases.set(name, attribute.resource)
   }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -226,6 +226,35 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
     })
+    if (supportedVersion === '1.21.4') {
+      it('stores entity attributes under their canonical resource key', (done) => {
+        bot.once('entityAttributes', (entity) => {
+          const speed = entity.attributes['minecraft:movement_speed']
+          assert.strictEqual(speed.value, 0.1)
+          assert.deepStrictEqual(speed.modifiers, [{
+            uuid: 'minecraft:effect.speed',
+            amount: 0.4,
+            operation: 2
+          }])
+          done()
+        })
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.write('entity_update_attributes', {
+            entityId: 0,
+            properties: [{
+              key: 'generic.movement_speed',
+              value: 0.1,
+              modifiers: [{
+                uuid: 'minecraft:effect.speed',
+                amount: 0.4,
+                operation: 2
+              }]
+            }]
+          })
+        })
+      })
+    }
     it('blockAt', (done) => {
       const pos = vec3(1, 65, 1)
       const goldId = bot.registry.blocksByName.gold_block.id


### PR DESCRIPTION
## Summary
- preserve protocol-provided entity attribute keys
- expose the same values under canonical registry resource keys
- add a regression test for legacy `generic.movement_speed` becoming available as `minecraft:movement_speed`

This lets consumers such as prismarine-physics use registry-style attribute names while retaining the protocol key for compatibility.

## Validation
- `npm run lint`
- `npx mocha test/internalTest.js --grep 'stores entity attributes under their canonical resource key' --exit`