### PR TITLE
security(ci): prevent command injection in updator script

### DIFF
--- a/.github/helper/updator.js
+++ b/.github/helper/updator.js
@@ -7,7 +7,7 @@ const cp = require('child_process')
 const assert = require('assert')
 const github = require('gh-helpers')()
 const { join } = require('path')
-const exec = (cmd) => github.mock ? console.log('> ', cmd) : (console.log('> ', cmd), cp.execSync(cmd, { stdio: 'inherit' }))
+const exec = (cmd, args = []) => github.mock ? console.log('> ', cmd, ...args) : (console.log('> ', cmd, ...args), cp.execFileSync(cmd, args, { stdio: 'inherit' }))
 
 console.log('Starting update process...')
 // Sanitize and validate environment variables all non alpha numeric / underscore / dot
@@ -58,12 +58,12 @@ async function main () {
   }
 
   const branchName = 'pc' + newVersion.replace(/[^a-zA-Z0-9_]/g, '_')
-  exec(`git checkout -b ${branchName}`)
-  exec('git config user.name "github-actions[bot]"')
-  exec('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"')
-  exec('git add --all')
-  exec(`git commit -m "Update to version ${newVersion}"`)
-  exec(`git push origin ${branchName} --force`)
+  exec('git', ['checkout', '-b', branchName])
+  exec('git', ['config', 'user.name', 'github-actions[bot]'])
+  exec('git', ['config', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com'])
+  exec('git', ['add', '--all'])
+  exec('git', ['commit', '-m', `Update to version ${newVersion}`])
+  exec('git', ['push', 'origin', branchName, '--force'])
   //     createPullRequest(title: string, body: string, fromBranch: string, intoBranch?: string): Promise<{ number: number, url: string }>;
   const pr = await github.createPullRequest(
     `🎈 ${newVersion}`,


### PR DESCRIPTION
The `exec` helper passed concatenated strings directly to `execSync`, which inherently spawns a system shell. If any dynamically injected variables (such as `newVersion` or `branchName` pulled from environment variables) contained shell metacharacters, it could lead to arbitrary command injection during CI workflow runs.
Switching to `execFileSync` and passing arguments as an explicit array, the target executable (`git`) is invoked directly without evaluating the input through a shell, removing the security risk.