### PR TITLE
26.x: attack packet, use_entity shape, clockUpdates time, player_loaded

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -837,6 +837,14 @@ function inject (bot) {
   }
 
   function attack (target, swing = true) {
+    // 26.1+: dedicated attack packet (no longer reuses use_entity mouse=1)
+    if (bot.supportFeature('attackUsesOwnPacket')) {
+      if (swing) {
+        swingArm()
+      }
+      bot._client.write('attack', { entityId: target.id })
+      return
+    }
     // arm animation comes before the use_entity packet on 1.8
     if (bot.supportFeature('armAnimationBeforeUse')) {
       if (swing) {
@@ -900,6 +908,21 @@ function inject (bot) {
 
   function useEntity (target, leftClick, x, y, z) {
     const sneaking = bot.getControlState('sneak')
+    // 26.1+: use_entity shape is { target, hand, location, sneaking } (no mouse mode)
+    // Attacks use the separate attack packet via bot.attack().
+    if (bot.supportFeature('attackUsesOwnPacket')) {
+      const hand = 0 // main_hand
+      const location = (x !== undefined && y !== undefined && z !== undefined)
+        ? { x, y, z }
+        : { x: 0, y: 0, z: 0 }
+      bot._client.write('use_entity', {
+        target: target.id,
+        hand,
+        location,
+        sneaking
+      })
+      return
+    }
     if (x && y && z) {
       bot._client.write('use_entity', {
         target: target.id,

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -18,6 +18,11 @@ const parseGameMode = gameModeBits => {
 }
 
 function inject (bot, options) {
+  // 1.21.4+ / 26.x: notify server the client finished loading
+  bot.once('spawn', () => {
+    try { bot._client.write('player_loaded', {}) } catch (err) {}
+  })
+
   function getBrandCustomChannelName () {
     if (bot.supportFeature('customChannelMCPrefixed')) {
       return 'MC|Brand'

--- a/lib/plugins/time.js
+++ b/lib/plugins/time.js
@@ -13,9 +13,24 @@ function inject (bot) {
     age: null
   }
   bot._client.on('update_time', (packet) => {
-    const time = longToBigInt(packet.time)
-    const age = longToBigInt(packet.age)
-    const doDaylightCycle = packet.tickDayTime !== undefined ? !!packet.tickDayTime : time >= 0n
+    let time
+    let age
+    let doDaylightCycle
+
+    // 26.1+: { age/gameTime, clockUpdates:[{id,totalTicks,partialTick,rate}] }
+    // older: { age, time, tickDayTime? }
+    if (packet.clockUpdates) {
+      age = longToBigInt(packet.gameTime ?? packet.age ?? 0)
+      const clockId = bot.game?.dimension === 'the_end' ? 1 : 0
+      const clockUpdate = packet.clockUpdates.find(c => (c.id ?? c.clock) === clockId) ?? packet.clockUpdates[0]
+      time = longToBigInt(clockUpdate?.totalTicks ?? 0)
+      doDaylightCycle = clockUpdate ? clockUpdate.rate !== 0 : true
+    } else {
+      time = longToBigInt(packet.time)
+      age = longToBigInt(packet.age)
+      doDaylightCycle = packet.tickDayTime !== undefined ? !!packet.tickDayTime : time >= 0n
+    }
+
     // When doDaylightCycle is false, we need to take the absolute value of time
     const finalTime = doDaylightCycle ? time : (time < 0n ? -time : time)
 
@@ -34,5 +49,14 @@ function inject (bot) {
 }
 
 function longToBigInt (arr) {
-  return BigInt.asIntN(64, (BigInt(arr[0]) << 32n)) | BigInt(arr[1])
+  if (typeof arr === 'bigint') return arr
+  if (typeof arr === 'number') return BigInt(arr)
+  if (arr == null) return 0n
+  if (Array.isArray(arr)) {
+    return BigInt.asIntN(64, (BigInt(arr[0]) << 32n) | BigInt(arr[1] >>> 0))
+  }
+  if (typeof arr === 'object' && ('high' in arr || 'low' in arr)) {
+    return BigInt.asIntN(64, (BigInt(arr.high) << 32n) | BigInt(arr.low >>> 0))
+  }
+  return BigInt(arr)
 }


### PR DESCRIPTION
## Summary

Work on the `pc26_2` support branch:

1. **`bot.attack`** — when `supportFeature('attackUsesOwnPacket')` (26.1+), write the dedicated `attack` packet instead of `use_entity` with mouse=1.
2. **`useEntity`** — on those versions write `{ target, hand, location, sneaking }` (26.x shape) instead of mouse-mode fields.
3. **`update_time`** — accept 26.1+ `clockUpdates[]` (`id`, `totalTicks`, `partialTick`, `rate`) while keeping the legacy `age`/`time`/`tickDayTime` path; `longToBigInt` accepts number/bigint as well as `[hi,lo]`.
4. **`player_loaded`** — after first spawn, send the empty `player_loaded` packet so 1.21.4+/26.x servers mark the client fully loaded.

## Test plan

- [x] Live Spigot **26.2** (protocol 776) bot: login, spawn, look, walk, pathfinder `GoalNear`, inventory, entities, swingArm
- [x] Chat ping/pong via signed/native chat after login protocol fixes (depends on minecraft-data protocol field PR)
- [ ] CI against `pc26_2` once minecraft-data 26.2 data is complete

## Related

- Depends on/complements `minecraft-data` `pc_26_2` protocol field fixes (login success `sessionId`, play login `onlineMode`)
- Automated boilerplate: #3926