### PR TITLE
Fix broken features.json link in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2126,7 +2126,7 @@ All options attributes are false by default, except mode which is 2 (as to repli
 
 This can be used to check is a specific feature is available in the current Minecraft version. This is usually only required for handling version-specific functionality.
 
-The list of available features can be found inside the [./lib/features.json](https://github.com/PrismarineJS/mineflayer/blob/master/lib/features.json) file.
+The list of available features can be found inside the [features.json](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/common/features.json) file.
 
 #### bot.waitForTicks(ticks)
 

--- a/docs/br/api_br.md
+++ b/docs/br/api_br.md
@@ -1906,7 +1906,7 @@ Todas as opções têm padrão como falso, exceto modo que é 2 (para se assemel
 
 Isso pode ser usado para verificar se uma característica está disponível na versão do bot do Minecraft. Normalmente, isso é usado para lidar com funções específicas de uma versão.
 
-Você pode encontrar a lista de características em [./lib/features.json](https://github.com/PrismarineJS/mineflayer/blob/master/lib/features.json) arquivo.
+Você pode encontrar a lista de características em [features.json](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/common/features.json) arquivo.
 
 #### bot.waitForTicks(ticks)
 

--- a/docs/es/api_es.md
+++ b/docs/es/api_es.md
@@ -1917,7 +1917,7 @@ Todas las opciones tienen como predeterminado false, excepto modo que es 2 (para
 
 Esto puede usarse para ver si una característica está disponible en la versión del bot de Minecraft. Normalmente esto es solo para manejar funciones que son específicas de una versión.
 
-Puedes encontrar la lista de características en [./lib/features.json](https://github.com/PrismarineJS/mineflayer/blob/master/lib/features.json) file.
+Puedes encontrar la lista de características en [features.json](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/common/features.json) file.
 
 #### bot.waitForTicks(ticks)
 

--- a/docs/ru/api_ru.md
+++ b/docs/ru/api_ru.md
@@ -2134,7 +2134,7 @@ bot.once('login', () => {
 
 Может использоваться для проверки особой для текущей версии Майнкрафт возможности. Обычно это требуется только для обработки функций, зависящих от версии.
 
-Список возможностей можно найти в файле [./lib/features.json](https://github.com/PrismarineJS/mineflayer/blob/master/lib/features.json).
+Список возможностей можно найти в файле [features.json](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/common/features.json).
 
 #### bot.waitForTicks(ticks)
 

--- a/docs/zh/api.md
+++ b/docs/zh/api.md
@@ -2008,7 +2008,7 @@ All options attributes are false by default, except mode which is 2 (as to repli
 
 This can be used to check is a specific feature is available in the current Minecraft version. This is usually only required for handling version-specific functionality.
 
-The list of available features can be found inside the [./lib/features.json](https://github.com/PrismarineJS/mineflayer/blob/master/lib/features.json) file.
+The list of available features can be found inside the [features.json](https://github.com/PrismarineJS/minecraft-data/blob/master/data/pc/common/features.json) file.
 
 #### bot.waitForTicks(ticks)
 


### PR DESCRIPTION
The docs linked to `lib/features.json`, which no longer exists in this repo. The features list is now provided by the `minecraft-data` package (`bot.supportFeature` → `minecraftData(version).supportFeature`, see `lib/loader.js`).

Updated the link to point at the canonical file in minecraft-data (`data/pc/common/features.json`, verified reachable), across all language docs (EN, RU, ZH, PT-BR, ES).

Docs-only change, no code affected.