### PR TITLE
fix: send player loaded before spawn on 1.21.4+

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -1,10 +1,5 @@
 module.exports = inject
 
-// Added in Java Edition 1.21.4. Mojang specifies that the client sends this
-// after the initial terrain-loading screen and again after respawn:
-// https://feedback.minecraft.net/hc/en-us/articles/32385811139085-Minecraft-Java-Edition-1-21-4-The-Garden-Awakens
-const PLAYER_LOADED_VERSION = '1.21.4'
-
 function inject (bot, options) {
   bot.isAlive = true
 
@@ -18,7 +13,7 @@ function inject (bot, options) {
       // Vanilla waits for this packet before accepting player actions. Send it
       // before exposing spawn to callers, because spawn is Mineflayer's signal
       // that they may begin interacting with the server.
-      if (bot.registry.version['>='](PLAYER_LOADED_VERSION)) {
+      if (bot.supportFeature('sendsPlayerLoadedPacket')) {
         bot._client.write('player_loaded', {})
       }
       bot.emit('spawn')
@@ -39,7 +34,7 @@ function inject (bot, options) {
       bot.respawn()
     } else if (bot.health > 0 && !bot.isAlive) {
       bot.isAlive = true
-      if (bot.registry.version['>='](PLAYER_LOADED_VERSION)) {
+      if (bot.supportFeature('sendsPlayerLoadedPacket')) {
         bot._client.write('player_loaded', {})
       }
       bot.emit('spawn')

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -1,5 +1,10 @@
 module.exports = inject
 
+// Added in Java Edition 1.21.4. Mojang specifies that the client sends this
+// after the initial terrain-loading screen and again after respawn:
+// https://feedback.minecraft.net/hc/en-us/articles/32385811139085-Minecraft-Java-Edition-1-21-4-The-Garden-Awakens
+const PLAYER_LOADED_VERSION = '1.21.4'
+
 function inject (bot, options) {
   bot.isAlive = true
 
@@ -10,6 +15,12 @@ function inject (bot, options) {
 
   bot._client.once('update_health', (packet) => {
     if (packet.health > 0) {
+      // Vanilla waits for this packet before accepting player actions. Send it
+      // before exposing spawn to callers, because spawn is Mineflayer's signal
+      // that they may begin interacting with the server.
+      if (bot.registry.version['>='](PLAYER_LOADED_VERSION)) {
+        bot._client.write('player_loaded', {})
+      }
       bot.emit('spawn')
     }
   })
@@ -28,6 +39,9 @@ function inject (bot, options) {
       bot.respawn()
     } else if (bot.health > 0 && !bot.isAlive) {
       bot.isAlive = true
+      if (bot.registry.version['>='](PLAYER_LOADED_VERSION)) {
+        bot._client.write('player_loaded', {})
+      }
       bot.emit('spawn')
     }
   })


### PR DESCRIPTION
## Summary

Since Java 1.21.4, vanilla defers initial block and item interactions until it receives `player_loaded` or its fallback expires. Mojang documents the packet after the initial loading-terrain screen and again after respawn in the [1.21.4 release notes](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-4).

Mineflayer emits `spawn` without sending the packet, so actions started immediately from a `spawn` listener can be silently ignored. This sends `player_loaded` immediately before `spawn`, including after respawn.

The behavior is gated with `bot.supportFeature('sendsPlayerLoadedPacket')`, defined by the corresponding [minecraft-data PR #1224](https://github.com/PrismarineJS/minecraft-data/pull/1224). This PR therefore depends on that feature being merged and released through `node-minecraft-data`.

## Reproduction

Run the existing 1.21.4 crafting test by itself on current Mineflayer master:

```bash
npm run mocha_test -- test/externalTest.js \
  --grep '^mineflayer_external 1\.21\.4v crafting$' \
  --retries 0
```

Before:

```text
0 passing
1 failing
Error: Event windowOpen did not fire within timeout of 20000ms
```

After:

```text
1 passing
```

## Related work

This overlaps with the 26.2 work in #3926. PR #3958 independently identified the same missing packet among broader 26.x changes; this PR isolates the lifecycle fix and applies it to every version described by the minecraft-data feature flag.

Sending `player_loaded` before `spawn` preserves Mineflayer's contract that `spawn` listeners may begin interacting with the server.

## Verification

- `npm run lint`
- Isolated 1.21.4 crafting reproduction with the minecraft-data #1224 feature applied locally: 1 passing

