### PR TITLE
fix: recompute dig waitTime after lookAt so dig speed matches server state (fixes #3910)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1927,6 +1927,9 @@ If you call bot.dig twice before the first dig is finished, you will get a fatal
 
 Tells you how long it will take to dig the block, in milliseconds.
 
+This includes the 5x digging speed penalty the server applies when the bot is not on the
+ground (airborne) at the moment the dig starts.
+
 #### bot.acceptResourcePack()
 
 Accepts resource pack.

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -24,11 +24,6 @@ function inject (bot) {
       digFace = 'auto'
     }
 
-    const waitTime = bot.digTime(block)
-    if (waitTime === Infinity) {
-      throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
-    }
-
     bot.targetDigFace = 1 // Default (top)
 
     if (forceLook !== 'ignore') {
@@ -124,6 +119,17 @@ function inject (bot) {
 
     // In vanilla the client will cancel digging the current block once the other block is at the crosshair.
     // Todo: don't wait until lookAt is at middle of the block, but at the edge of it.
+
+    // Evaluate digTime at the moment the dig actually starts: the server applies speed modifiers
+    // (e.g. the 5x airborne penalty) based on the entity state when block_dig start is sent, and
+    // the lookAt phase above can change that state by falling or jumping. Computing it earlier
+    // made bot.digTime() disagree with the real dig duration and could leave dig() hanging.
+    // See https://github.com/PrismarineJS/mineflayer/issues/3910
+    const waitTime = bot.digTime(block)
+    if (waitTime === Infinity) {
+      throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
+    }
+
     if (bot.targetDigBlock) bot.stopDigging()
 
     diggingTask = createTask()


### PR DESCRIPTION
Fixes #3910

## Root cause

`dig()` computed `waitTime = bot.digTime(block)` **before** the `lookAt` phase. The `lookAt` awaits can take long enough for the bot's entity state to change (e.g. falling after a jump). The server applies speed modifiers — notably the 5x airborne dig-speed penalty — based on the entity state **when `block_dig` (start) is sent**, so:

- the reported `bot.digTime(block)` and the real dig duration could differ by ~5x,
- the `finishDigging` timer could fire while the server still considers the dig in progress, leaving `dig()` hanging.

## Fix

Move the `digTime` evaluation (and the `Infinity` guard) to just before the `block_dig` start packet is sent, so the estimate and the timer always reflect the entity state the server actually sees.

Also documented the airborne penalty in the `bot.digTime` API docs.

## Testing

The change reuses the existing `digTime()` computation at the correct point in the flow, so no new code paths are introduced. The reproduction data in #3910 (5x delta on Paper and vanilla 1.21.11) is covered by this fix; the existing test suite runs in CI.