### PR TITLE
fix(anvil): use 50-char name limit on 1.17+

### DIFF
--- a/lib/plugins/anvil.js
+++ b/lib/plugins/anvil.js
@@ -15,6 +15,9 @@ function inject (bot) {
       throw new Error('Not a anvil-like window: ' + JSON.stringify(anvil))
     }
 
+    // 1.17+ raised the anvil custom-name limit from 35 to 50 characters
+    const nameLengthLimit = bot.supportFeature('anvilNameLengthIsFifty') ? 50 : 35
+
     function err (name) {
       anvil.close()
       throw new Error(name)
@@ -43,7 +46,7 @@ function inject (bot) {
     }
 
     async function combine (itemOne, itemTwo, name) {
-      if (name?.length > 35) err('Name is too long.')
+      if (name?.length > nameLengthLimit) err('Name is too long.')
       if (bot.supportFeature('useMCItemName')) {
         bot._client.registerChannel('MC|ItemName', 'string')
       }
@@ -70,7 +73,7 @@ function inject (bot) {
     }
 
     async function rename (item, name) {
-      if (name?.length > 35) err('Name is too long.')
+      if (name?.length > nameLengthLimit) err('Name is too long.')
       if (bot.supportFeature('useMCItemName')) {
         bot._client.registerChannel('MC|ItemName', 'string')
       }

--- a/test/externalTests/anvil.js
+++ b/test/externalTests/anvil.js
@@ -132,5 +132,27 @@ module.exports = () => {
     await bot.test.wait(1000)
   })
 
+  addTest('rename with 40-char name on 1.17+', async (b, renameCost, renameName, Item, bot, makeBook, makeItem) => { // the name limit was raised to 50 in 1.17 (#3945)
+    if (!bot.supportFeature('anvilNameLengthIsFifty')) return // 1.16 and below: limit is still 35
+
+    bot.chat(`/clear ${bot.username}`)
+    await bot.test.becomeCreative()
+
+    await bot.test.setInventorySlot(36, makeItem({ type: bot.registry.itemsByName.diamond_sword.id }))
+
+    await bot.test.becomeSurvival()
+
+    const anvil = await bot.openAnvil(b)
+
+    const sword = anvil.findInventoryItem(bot.registry.itemsByName.diamond_sword.id)
+    const longName = 'a'.repeat(40)
+    await anvil.rename(sword, longName)
+    // test result
+    assert.strictEqual(anvil.slots[3].repairCost, renameCost())
+    assert.deepStrictEqual(anvil.slots[3].customName, renameName(longName))
+    anvil.close()
+    await bot.test.wait(1000)
+  })
+
   return tests
 }


### PR DESCRIPTION
Fixes #3945.

## Problem

Minecraft 1.17 raised the anvil custom-name limit from 35 to 50 characters, but `openAnvil` still rejected names longer than 35 characters on every version, breaking bots that need to rename items with names between 36 and 50 characters.

## Change

`lib/plugins/anvil.js`: compute the limit once per opened anvil from the `anvilNameLengthIsFifty` minecraft-data feature (`bot.supportFeature`):

- 1.17+ → 50 characters
- 1.16 and below → 35 characters (unchanged)

Applies to both `anvil.combine` and `anvil.rename`.

## Tests

`test/externalTests/anvil.js`: version-gated test that renames an item with a 40-character name (skipped on versions where the limit is still 35). The existing rename tests keep covering the short-name path on every version.

## Verification

- `standard` lint clean on both changed files.
- The new external test runs in the per-version CI matrix on 1.17+; on older versions it early-returns (35-char limit is preserved).
