### PR TITLE
fix(anvil): use the 50 character name limit on 1.17+

### DIFF
--- a/lib/plugins/anvil.js
+++ b/lib/plugins/anvil.js
@@ -6,6 +6,8 @@ module.exports = inject
 
 function inject (bot) {
   const Item = require('prismarine-item')(bot.registry)
+  // The anvil custom name limit was raised from 35 to 50 characters in 1.17
+  const maxNameLength = bot.supportFeature('anvilNameLengthIsFifty') ? 50 : 35
 
   const matchWindowType = window => /minecraft:(?:chipped_|damaged_)?anvil/.test(window.type)
 
@@ -43,7 +45,7 @@ function inject (bot) {
     }
 
     async function combine (itemOne, itemTwo, name) {
-      if (name?.length > 35) err('Name is too long.')
+      if (name?.length > maxNameLength) err('Name is too long.')
       if (bot.supportFeature('useMCItemName')) {
         bot._client.registerChannel('MC|ItemName', 'string')
       }
@@ -70,7 +72,7 @@ function inject (bot) {
     }
 
     async function rename (item, name) {
-      if (name?.length > 35) err('Name is too long.')
+      if (name?.length > maxNameLength) err('Name is too long.')
       if (bot.supportFeature('useMCItemName')) {
         bot._client.registerChannel('MC|ItemName', 'string')
       }


### PR DESCRIPTION
Fixes #3945

## Problem
`anvil.combine` and `anvil.rename` rejected any custom name longer than **35** characters on every version. Since **1.17**, the vanilla anvil name limit is **50** characters, so valid 36–50 character names were incorrectly refused with `Name is too long.`

## Fix
minecraft-data already ships a feature flag for exactly this change — `anvilNameLengthIsFifty` (`1.17` → latest, added in PrismarineJS/minecraft-data#1207). This computes the limit once at plugin injection:

```js
const maxNameLength = bot.supportFeature('anvilNameLengthIsFifty') ? 50 : 35
```

and uses it in both `combine` and `rename`. Behavior on ≤1.16.5 is unchanged (35).

## Verified
- `supportFeature('anvilNameLengthIsFifty')` resolves to `false` on 1.8/1.12.2/1.16.5 and `true` on 1.17/1.18.2/1.20.1/1.21.1 with the installed minecraft-data (3.113.2, within the existing `^3.108.0` range — no dependency bump needed).
- `bot.supportFeature` is assigned in `loader.js` before plugins are injected, so it is available at inject time.
- `standard` lint passes on the changed file.

(The anvil integration tests in `test/externalTests/anvil.js` are excluded from CI and require a live server, so no test changes are included.)