### PR TITLE
fix: recompute dig time before sending block_dig.start

### DIFF
--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -24,7 +24,7 @@ function inject (bot) {
       digFace = 'auto'
     }
 
-    const waitTime = bot.digTime(block)
+    let waitTime = bot.digTime(block)
     if (waitTime === Infinity) {
       throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
     }
@@ -127,6 +127,12 @@ function inject (bot) {
     if (bot.targetDigBlock) bot.stopDigging()
 
     diggingTask = createTask()
+    // Recompute the dig time right before sending block_dig.start so the
+    // estimate reflects the current on-ground state. onGround can flip during
+    // the lookAt awaits above, and the server applies its airborne dig-speed
+    // penalty based on the bot's state when block_dig.start arrives, so an
+    // estimate computed earlier can be stale. See issue #3910.
+    waitTime = bot.digTime(block)
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,


### PR DESCRIPTION
Fixes #3910

## Problem
`bot.dig(block)` computes `waitTime = bot.digTime(block)` at the top of `dig()`, **before** the `lookAt` awaits. The `block_dig.start` packet is only sent after those awaits. If `bot.entity.onGround` flips to `false` during the awaits (e.g. the bot jumps or is knocked airborne), the estimate is stale:

- `bot.digTime` passes `!bot.entity.onGround` to `block.digTime`, which applies the 5x airborne penalty.
- The server applies its airborne dig-speed penalty based on the bot's state **when `block_dig.start` arrives**.

So the finish packet is scheduled from the old (on-ground) estimate and fires ~5x too early, while the server is still applying the airborne penalty — the block isn't broken when the client thinks it is.

## Fix
Recompute `waitTime` immediately before sending `block_dig.start`, so the scheduled finish delay reflects the on-ground state at the moment the packet is sent:

```js
diggingTask = createTask()
// Recompute the dig time right before sending block_dig.start so the
// estimate reflects the current on-ground state. onGround can flip during
// the lookAt awaits above, and the server applies its airborne dig-speed
// penalty based on the bot's state when block_dig.start arrives, so an
// estimate computed earlier can be stale. See issue #3910.
waitTime = bot.digTime(block)
bot._client.write('block_dig', { status: 0, ... })
waitTimeout = setTimeout(finishDigging, waitTime)
```

The initial `bot.digTime(block)` at the top is kept for the `Infinity` guard (so an unbreakable block still throws before any look/packet work).

## Verified
- `npx standard` passes.
- Logic probe: with a `lookAt` that flips `onGround` to `false` during the await, the scheduled `finishDigging` delay now uses the recomputed airborne value (5000ms) instead of the stale on-ground value (1000ms), matching the server's penalty at packet-send time.