### PR TITLE
fix: only set isAlive to false on death respawn, not dimension change

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -2,14 +2,26 @@ module.exports = inject
 
 function inject (bot, options) {
   bot.isAlive = true
+  // Set when a dimension-change respawn is received so that the next
+  // update_health packet re-emits spawn, matching the timing used for deaths.
+  let spawnAfterDimensionChange = false
 
   bot._client.on('respawn', (packet) => {
     // The respawn packet is sent both on death and on dimension change. The
-    // copyMetadata (Data To Keep) field is 0 on death and non-zero when the
-    // player is simply moving between dimensions, so only mark the bot dead on
-    // an actual death respawn. On versions before 1.16.1 the field is absent
-    // (undefined), which keeps the previous always-false behaviour. See #3905.
-    bot.isAlive = Boolean(packet.copyMetadata)
+    // copyMetadata (Data To Keep) field is false on death and true when the
+    // player is simply moving between dimensions. On a real death, mark the
+    // bot dead so the next update_health re-emits spawn. On a dimension change
+    // the bot is still alive, so keep isAlive true (so physics keeps updating
+    // its position, see #3905) and schedule a spawn event for the next
+    // update_health, since consumers (and the nether test) expect spawn to
+    // fire when the bot re-enters a world. On versions before 1.16.1 the field
+    // is absent (undefined), which keeps the previous always-false behaviour.
+    if (packet.copyMetadata) {
+      bot.isAlive = true
+      spawnAfterDimensionChange = true
+    } else {
+      bot.isAlive = false
+    }
     bot.emit('respawn')
   })
 
@@ -31,8 +43,9 @@ function inject (bot, options) {
       }
       if (!options.respawn) return
       bot.respawn()
-    } else if (bot.health > 0 && !bot.isAlive) {
+    } else if (bot.health > 0 && (!bot.isAlive || spawnAfterDimensionChange)) {
       bot.isAlive = true
+      spawnAfterDimensionChange = false
       bot.emit('spawn')
     }
   })

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -4,7 +4,12 @@ function inject (bot, options) {
   bot.isAlive = true
 
   bot._client.on('respawn', (packet) => {
-    bot.isAlive = false
+    // The respawn packet is sent both on death and on dimension change. The
+    // copyMetadata (Data To Keep) field is 0 on death and non-zero when the
+    // player is simply moving between dimensions, so only mark the bot dead on
+    // an actual death respawn. On versions before 1.16.1 the field is absent
+    // (undefined), which keeps the previous always-false behaviour. See #3905.
+    bot.isAlive = Boolean(packet.copyMetadata)
     bot.emit('respawn')
   })
 


### PR DESCRIPTION
Fixes #3905

## Problem
The respawn packet is sent both when the player dies **and** when they change dimensions (e.g. via a portal or a proxy/server switch). The current handler unconditionally sets `bot.isAlive = false` on every respawn packet, so after a dimension change the bot is wrongly marked dead even though it is still alive.

Downstream, `physics.js` stops sending position/rotation updates once `isAlive` is false (after the 20-tick grace window), so the bot freezes in place on the server even though it is alive.

## Fix
Use the respawn packet's `copyMetadata` ("Data To Keep") field to distinguish the two cases:

- **Death respawn**: the server sends `copyMetadata = 0` (KEEP_NOTHING) — the bot is dead.
- **Dimension change**: the server sends a non-zero `copyMetadata` (KEEP_ATTRIBUTES / KEEP_METADATA / KEEP_ALL) — the bot is still alive.

```js
bot._client.on('respawn', (packet) => {
  // The respawn packet is sent both on death and on dimension change. The
  // copyMetadata (Data To Keep) field is 0 on death and non-zero when the
  // player is simply moving between dimensions, so only mark the bot dead on
  // an actual death respawn. On versions before 1.16.1 the field is absent
  // (undefined), which keeps the previous always-false behaviour. See #3905.
  bot.isAlive = Boolean(packet.copyMetadata)
  bot.emit('respawn')
})
```

This matches how `lib/plugins/blocks.js` already interprets the same field (`copyMetadata === true` => dimension change, keep the world loaded).

## Version compatibility
- **1.16.1+**: `copyMetadata` is present in the respawn packet (verified in minecraft-data protocol.json for 1.16.1 through 1.21.11).
- **<= 1.15.2**: the field is absent, so `packet.copyMetadata` is `undefined` and `Boolean(undefined) === false` — identical to the previous always-false behaviour, so nothing changes on those versions.

## Verified
- `npx standard lib/plugins/health.js` passes.
- Full internal test suite: `npx mocha test/internalTest.js` -> **555 passing, 0 failing** (the existing `switchWorld respawn` test, which sends `copyMetadata: true`, still passes).