### PR TITLE
fix(inventory): don't copy unconfirmed click predictions into inventory on window close

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -422,10 +422,23 @@ function inject (bot, { hideErrors }) {
     bot.emit('windowClose', window)
   }
 
+  function setServerSlot (window, slot, item) {
+    // Track the last server-confirmed value of each slot. Optimistic click
+    // predictions update window.slots but not this copy, so a window closed
+    // before the server echoes the click still copies what the server last
+    // said — a dropped click (e.g. on a stale stateId) is never corrected
+    // by any packet, and copying the prediction leaves phantom items.
+    if (!window._serverSlots) window._serverSlots = new Array(window.slots.length).fill(null)
+    window._serverSlots[slot] = item
+  }
+
   function copyInventory (window) {
     const slotOffset = window.inventoryStart - bot.inventory.inventoryStart
+    // Prefer the server-confirmed view over window.slots, which may hold
+    // optimistic click predictions the server never echoed.
+    const slots = window._serverSlots ?? window.slots
     for (let i = window.inventoryStart; i < window.inventoryEnd; i++) {
-      const item = window.slots[i]
+      const item = slots[i]
       const slot = i - slotOffset
       if (item) {
         item.slot = slot
@@ -521,6 +534,10 @@ function inject (bot, { hideErrors }) {
       const window = windowId === 0 ? bot.inventory : bot.currentWindow
       if (!window || window.id !== click.windowId) return
       window.acceptClick(click)
+      // An accepted transaction is a server confirmation: everything in
+      // window.slots is now server truth (pre-1.17.1, predictions are only
+      // applied here, in onAccepted).
+      window._serverSlots = window.slots.slice()
       bot.emit(`confirmTransaction${click.id}`, true)
     }
 
@@ -695,6 +712,7 @@ function inject (bot, { hideErrors }) {
       for (let i = 0; i < windowItems.items.length; ++i) {
         const item = Item.fromNotch(windowItems.items[i])
         window.updateSlot(i, item)
+        setServerSlot(window, i, item)
       }
       updateHeldItem()
       extendWindow(window)
@@ -732,6 +750,7 @@ function inject (bot, { hideErrors }) {
     // set slot
     const oldItem = window.slots[slotId]
     window.updateSlot(slotId, newItem)
+    setServerSlot(window, slotId, newItem)
     updateHeldItem()
     bot.emit(`setSlot:${window.id}`, oldItem, newItem)
   }
@@ -783,6 +802,7 @@ function inject (bot, { hideErrors }) {
     for (let i = 0; i < packet.items.length; ++i) {
       const item = Item.fromNotch(packet.items[i])
       window.updateSlot(i, item)
+      setServerSlot(window, i, item)
     }
     updateHeldItem()
     bot.emit(`setWindowItems:${window.id}`)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1233,6 +1233,50 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }, 100)
         })
       })
+
+      it('does not copy unconfirmed click predictions into the inventory on window close', async () => {
+        // On 1.17.1+ clicks are applied optimistically and the server is
+        // expected to echo them with slot updates. If it never does (e.g. it
+        // silently drops a click sent with a stale stateId), the prediction
+        // must not be copied into bot.inventory when the window closes —
+        // no server correction will ever arrive for it.
+        if (!registry.supportFeature('stateIdUsed')) return
+        const Item = require('prismarine-item')(supportedVersion)
+        const windows = require('prismarine-windows')(supportedVersion)
+        const stone = new Item(registry.itemsByName.stone.id, 3)
+
+        const windowType = windows.windows['minecraft:crafting'].type
+        const titleIsNbt = registry.protocol.play.toClient.types.packet_open_window[1]
+          .some(field => field.name === 'windowTitle' && field.type === 'anonymousNbt')
+        const windowTitle = titleIsNbt
+          ? nbt.comp({ text: nbt.string('Crafting') })
+          : JSON.stringify({ text: 'Crafting' })
+
+        // Window slot 10 is the first player-inventory slot of a crafting
+        // window, which maps to bot.inventory slot 9.
+        const WINDOW_SLOT = 10
+        const INV_SLOT = 9
+        const items = Array.from({ length: 46 }, () => Item.toNotch(null))
+        items[WINDOW_SLOT] = Item.toNotch(stone)
+
+        const windowOpen = once(bot, 'windowOpen')
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.write('open_window', { windowId: 1, inventoryType: windowType, windowTitle })
+          client.write('window_items', { windowId: 1, stateId: 0, items, carriedItem: Item.toNotch(null) })
+        })
+        const [window] = await windowOpen
+        assert.strictEqual(window.slots[WINDOW_SLOT].count, 3)
+
+        // Pick the stone up and put it down one slot over; the server never
+        // echoes either click.
+        await bot.clickWindow(WINDOW_SLOT, 0, 0)
+        await bot.clickWindow(WINDOW_SLOT + 1, 0, 0)
+        bot.closeWindow(window)
+
+        assert.strictEqual(bot.inventory.slots[INV_SLOT]?.name, 'stone')
+        assert.strictEqual(bot.inventory.slots[INV_SLOT + 1], null)
+      })
     })
 
     describe('tablist', () => {


### PR DESCRIPTION
## Background

Diagnosed from the packet trace uploaded by CI run [31992963697](https://github.com/PrismarineJS/mineflayer/actions/runs/31992963697) (same commit as failing master run [31992922399](https://github.com/PrismarineJS/mineflayer/actions/runs/31992922399)): the `creative` external test failed 4/4 attempts with `10 !== 9` because `ladder x3` was stuck in inventory slot 10.

What the trace shows (26.1):

1. `crafting` test crafts ladders at a crafting table, deposits them (`window_click` slot 11) and sends `close_window` 1ms later.
2. The server never echoes the click — **zero packets mentioning the crafted item after the deposit** (no `set_slot` for the mapped inventory slot, ever).
3. `closeWindow` → `copyInventory` copied the *client-predicted* window slot into `bot.inventory`.
4. `/clear` can't fix it: the item only exists client-side, so the server never sends a correction for that slot. The phantom survives every `resetState` and fails the count assertion in `creative`.

## Fix

Track the last **server-confirmed** value of each window slot (`_serverSlots`), updated from the authoritative paths:

- `set_slot` (`bot._setSlot`)
- `window_items` (both the immediate handler and the deferred replay at open)
- accepted transactions on pre-1.17.1 (`onAccepted` — there the prediction is only applied on server acceptance, so `window.slots` is server truth)

`copyInventory` at close now copies that confirmed view instead of `window.slots`, which may hold optimistic predictions the server dropped. Trailing syncs after the client-side close (the `lastClosedWindow` handling from #3854) still apply on top as usual.

## Vanilla parity (26.1 decompile)

- Vanilla predicts clicks locally too: `MultiPlayerGameMode#handleContainerInput` snapshots, applies `containerMenu.clicked(...)`, and sends the diff as `changedSlots` + `stateId` — same shape as mineflayer's `window.acceptClick` + `window_click`.
- Server truth arrives through the same three paths this PR tracks: `handleContainerSetSlot` → `setItem`, `handleContainerContent` → `initializeContents`, `handleSetPlayerInventory` → `inventory.setItem`.
- Vanilla's `closeContainer` does no copy-back at all — its window inventory-region slots wrap the *same* `Inventory` object, so dropped-click phantoms are transient and get overwritten by the next authoritative sync. `bot.inventory` is a separate model, so closing on the confirmed view lands directly on the state vanilla would converge to.

## Testing

- New internal test `does not copy unconfirmed click predictions into the inventory on window close`: opens a crafting window, picks an item up and places it one slot over with the server never echoing, closes, and asserts the server-confirmed placement survives with no phantom. Fails on master (item vanishes into the predicted slot), passes on all `stateIdUsed` versions (1.17.1+), skipped on transaction-era versions where prediction is only applied on acceptance.
- Full internal suite: 604 passing, 0 failing. `npm run lint` clean.