### PR TITLE
Fix blockAtEntityCursor returning null when yaw or pitch is 0

### DIFF
--- a/lib/plugins/ray_trace.js
+++ b/lib/plugins/ray_trace.js
@@ -55,7 +55,7 @@ module.exports = (bot) => {
   }
 
   bot.blockAtEntityCursor = (entity = bot.entity, maxDistance = 256, matcher = null) => {
-    if (!entity.position || !entity.height || !entity.pitch || !entity.yaw) return null
+    if (entity.position == null || entity.height == null || entity.pitch == null || entity.yaw == null) return null
     const { position, height, pitch, yaw } = entity
 
     const eyePosition = position.offset(0, height, 0)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1312,5 +1312,33 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
     })
+    it('blockAtEntityCursor handles zero yaw and pitch (#3935)', (done) => {
+      // Place a vertical column of gold blocks in the -Z direction from the bot,
+      // so a level (pitch=0) ray along yaw=0 is guaranteed to hit one regardless of eye height.
+      const goldId = bot.registry.blocksByName.gold_block.id
+      server.on('playerJoin', (client) => {
+        client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(vec3(0, 65, 0), goldId)
+        chunk.setBlockType(vec3(0, 66, 0), goldId)
+        chunk.setBlockType(vec3(0, 67, 0), goldId)
+        client.write('map_chunk', generateChunkPacket(chunk))
+      })
+      bot.on('chunkColumnLoad', () => {
+        // Position the bot at (0.5, 65, 5.5) looking straight north (yaw=0) and level (pitch=0)
+        bot.entity.position = vec3(0.5, 65, 5.5)
+        bot.entity.height = 1.62
+        bot.entity.yaw = 0
+        bot.entity.pitch = 0
+        const block = bot.blockAtEntityCursor(bot.entity, 256)
+        try {
+          assert.ok(block, 'blockAtEntityCursor must not return null when yaw=0 and pitch=0')
+          assert.strictEqual(block.type, goldId, 'should hit the gold block in the cursor')
+          done()
+        } catch (err) {
+          done(err)
+        }
+      })
+    })
   })
 }


### PR DESCRIPTION
## Fixes #3935

`bot.blockAtEntityCursor()` (and `blockAtCursor`) incorrectly returned `null` whenever the entity had `yaw === 0` or `pitch === 0`, because the guard used truthiness checks (`!entity.yaw` / `!entity.pitch`). A value of `0` is a perfectly valid orientation (e.g. looking level = `pitch 0`, facing north = `yaw 0`), so the ray trace was being skipped.

### Change
`lib/plugins/ray_trace.js` — replaced the truthiness guard with explicit null checks:

```js
// before
if (!entity.position || !entity.height || !entity.pitch || !entity.yaw) return null
// after
if (entity.position == null || entity.height == null || entity.pitch == null || entity.yaw == null) return null
```

### Test
Added `blockAtEntityCursor handles zero yaw and pitch (#3935)` to `test/internalTest.js`. It places a column of gold blocks in the cursor direction, sets `yaw = 0` and `pitch = 0`, and asserts the block is returned. The test fails on the old code (returns null) and passes on the fix, across all tested versions (1.21.4 – 26.1).

### Verification
Also verified against a live 1.21.11 Paper server (`intel-node2.zyphron.cloud:20013`): with the fix the ray cast is actually executed instead of early-returning.