### PR TITLE
fix: don't crash on open_window with an unrecognised window type

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -705,8 +705,16 @@ function inject (bot, { hideErrors }) {
   bot._client.on('open_window', (packet) => {
     // open window
     lastClosedWindow = null
-    bot.currentWindow = windows.createWindow(packet.windowId,
+    const window = windows.createWindow(packet.windowId,
       packet.inventoryType, packet.windowTitle, packet.slotCount)
+    if (!window) {
+      // createWindow() can only synthesise a layout for an unrecognised window type when
+      // the packet carries a slot count, and open_window stopped sending one. Any window
+      // type prismarine-windows does not know therefore lands here.
+      bot.emit('unknownWindow', packet)
+      return
+    }
+    bot.currentWindow = window
     prepareWindow(bot.currentWindow)
   })
   bot._client.on('open_horse_window', (packet) => {


### PR DESCRIPTION
Opening an unrecognised window type kills the bot outright.

`windows.createWindow()` returns `null` when it does not recognise the window type and cannot synthesise a layout — it can only synthesise one when the packet supplies a slot count, and `open_window` no longer sends `slotCount`. So any unrecognised type takes that path, and `prepareWindow()` then dereferences the null:

```
TypeError: Cannot read properties of null (reading 'id')
    at prepareWindow (lib/plugins/inventory.js:690)
    at Client.<anonymous> (lib/plugins/inventory.js:710)
```

This is reachable on any server with a mod- or plugin-registered menu, so the bot dies rather than degrading.

### Reproduction

Against a NeoForge 26.2 server running Valkyrien Skies Eureka, sneak-right-clicking a ship helm sends:

```
open_window { windowId: 1, inventoryType: 74, windowTitle: { translate: "gui.vs_eureka.ship_helm" } }
```

which reliably terminates the bot.

### Change

Emit `unknownWindow` with the raw packet and return, instead of dereferencing the null. Consumers that care about custom menus can listen for it; everyone else simply keeps a live bot. Behaviour for all recognised window types is unchanged.

After the change, the same interaction yields:

```
[unknownWindow] type=74 title="gui.vs_eureka.ship_helm"
BOT ALIVE: yes
```

`npx standard` passes on the changed file.