### PR TITLE
fix: write client_command's actual field name (actionId, not action)

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -123,7 +123,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { action: 0 })
+      bot._client.write('client_command', { actionId: 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -123,7 +123,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { actionId: 0 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)


### PR DESCRIPTION
The `win_game` handler in `lib/plugins/game.js` builds the packet with `action`, but the field is `actionId` in every protocol version's `client_command` definition. The intended value is therefore never written.

**This is currently harmless rather than broken**, and I want to be upfront about that: the missing field serialises as `undefined`, protodef writes that as `0`, and `0` is exactly the value that was intended (`perform_respawn`). The packet has always come out correct by coincidence.

It is still wrong, and it is fragile — it only holds while the intended action is `0` and while `undefined` keeps coinciding with it. Worth writing the documented field name.

Verified the emitted bytes are unchanged on 26.1:

```
{ action: 0 }   -> 0c00
{ actionId: 0 } -> 0c00
```

So this is a no-op at the wire level today and purely a correctness fix. `npx standard` passes.