### PR TITLE
test: record external test setup stages in the TRACE jsonl

### DIFF
--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -1,0 +1,28 @@
+// TRACE=<file> writes one JSON stream for analysis with jq afterwards:
+//   {"ts":...,"type":"PACKET","dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
+//   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
+//   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
+const fs = require('fs')
+
+let stream
+const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
+
+function emit (record) {
+  if (!process.env.TRACE) return
+  stream = stream ?? fs.createWriteStream(process.env.TRACE, { flags: 'w' })
+  stream.write(`${JSON.stringify({ ts: Date.now(), ...record }, bigintSafe)}\n`)
+}
+
+function write (type, name, data = null) {
+  emit({ type, name, data })
+}
+
+function packet (dir, name, data) {
+  emit({ type: 'PACKET', dir, name, data })
+}
+
+function log (msg, args) {
+  emit({ type: 'LOG', msg, args })
+}
+
+module.exports = { write, packet, log }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -8,6 +8,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { getPort } = require('./common/util')
+const trace = require('./common/trace')
 const { once } = require('../lib/promise_utils')
 
 // set this to false if you want to test without starting a server automatically
@@ -66,8 +67,14 @@ for (const supportedVersion of mineflayer.testedVersions) {
         bot.test.port = PORT
 
         console.log('starting bot')
+        trace.log('bot created')
+        bot._client.on('connect', () => trace.log('bot tcp connected'))
+        bot._client.on('error', err => trace.log('bot client error', { error: err?.message ?? String(err) }))
+        bot._client.on('end', reason => trace.log('bot client ended', { reason }))
+        bot.once('login', () => trace.log('bot logged in'))
         bot.once('spawn', () => {
           console.log('bot spawned, opping...')
+          trace.log('bot spawned, opping')
           wrap.writeServer('op flatbot\n')
           if (bot.supportFeature('gameRuleUsesResourceLocation')) {
             wrap.writeServer('gamerule minecraft:spawn_monsters false\n')
@@ -76,6 +83,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
           bot.once('messagestr', msg => {
             if (msg.includes('Made flatbot a server operator') || msg === '[Server: Opped flatbot]') {
+              trace.log('bot opped, setup done')
               done()
             }
           })
@@ -84,23 +92,33 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       if (START_THE_SERVER) {
         console.log('downloading and starting server')
+        trace.log('downloading server jar', { version: version.minecraftVersion, port: PORT })
         download(version.minecraftVersion, MC_SERVER_JAR, (err) => {
           if (err) {
             console.log(err)
             done(err)
             return
           }
+          trace.log('server jar downloaded, starting server')
           propOverrides['server-port'] = PORT
           wrap.startServer(propOverrides, (err) => {
             if (err) return done(err)
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
+            trace.log('server started, pinging')
             mc.ping({
               port: PORT,
               host: '127.0.0.1',
-              version: supportedVersion
+              version: supportedVersion,
+              // fail well before the mocha hook timeout (120s) so a hung ping
+              // surfaces as an ETIMEDOUT error instead of a silent hook timeout
+              closeTimeout: 30 * 1000
             }, (err, results) => {
-              if (err) return done(err)
+              if (err) {
+                trace.log('ping failed', { error: err?.message ?? String(err) })
+                return done(err)
+              }
               console.log('pong')
+              trace.log('pong', { latency: results.latency })
               assert.ok(results.latency >= 0)
               assert.ok(results.latency <= 1000)
               begin()

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -5,6 +5,7 @@ const { once } = require('../../../lib/promise_utils')
 const process = require('process')
 const assert = require('assert')
 const { sleep, onceWithCleanup } = require('../../../lib/promise_utils')
+const trace = require('../../common/trace')
 
 const timeout = 5000
 module.exports = inject
@@ -13,27 +14,18 @@ function inject (bot, wrap) {
   console.log(bot.version)
 
   bot.test = {}
-  // TRACE=<file> writes one JSON stream for analysis with jq afterwards:
-  //   {"ts":...,"dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
-  //   {"ts":...,"dir":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
-  //   {"ts":...,"dir":"MARKER","name":"### Starting <test>"}     test boundaries
-  let dumpStream
   if (process.env.TRACE) {
-    const fs = require('fs')
-    const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
-    dumpStream = fs.createWriteStream(process.env.TRACE, { flags: 'w' })
-    const write = (dir, name, data) => dumpStream.write(`${JSON.stringify({ ts: Date.now(), dir, name, data }, bigintSafe)}\n`)
-    bot._client.on('packet', (data, meta) => write('S2C', meta.name, data))
+    bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
     const oldWrite = bot._client.write
     bot._client.write = function (name, data) {
-      write('C2S', name, data)
+      trace.packet('C2S', name, data)
       oldWrite.apply(this, arguments)
     }
-    bot.test.dumpMarker = name => write('MARKER', name, null)
+    bot.test.dumpMarker = msg => trace.log(msg)
     bot.once('spawn', () => {
       const orig = bot.inventory.updateSlot.bind(bot.inventory)
       bot.inventory.updateSlot = (slot, item) => {
-        write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
+        trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
         return orig(slot, item)
       }
     })


### PR DESCRIPTION
## Problem

The external test's `before` hook chains several network operations — jar download, server boot, status ping, bot login — under one shared 120s budget. When any stage stalls, the only symptom is mocha's generic `Timeout of 120000ms exceeded`, with no indication of which stage hung or when. Worse, the TRACE jsonl is only opened at bot creation, so setup-stage failures upload **no trace at all**.

Two recent CI flakes had this identical symptom but hung in different, undiagnosable stages:

- [Run 32162701404](https://github.com/PrismarineJS/mineflayer/actions/runs/32162701404) (26.1): server booted fine and `pinging 26.1 port : 35875` printed, but `pong` never did — `mc.ping`'s `server_info` never arrived. Since `mc.ping`'s default `closeTimeout` is also 120s and the hook's clock starts earlier, mocha always wins the race and swallows the real error.
- [Run 32540840621](https://github.com/PrismarineJS/mineflayer/actions/runs/32540840621) (1.8.8): the log stops at `downloading and starting server` — the jar download itself stalled, a stage with no completion signal at all.

## Changes

- Hoist the TRACE stream into `test/common/trace.js`, shared and lazily opened, so harness events written before the bot exists land in the same file. This also fixes a latent bug: `reconnectBot` re-runs `commonTest`, which reopened the trace with `flags: 'w'` and truncated everything recorded so far.
- Record `LOG` events (`{ts, type: "LOG", msg, args}`) for each setup stage — download start/done, server start, ping sent/pong/failed, bot created, client `connect`/`error`/`end`, login, spawn, opped — alongside the packet records (`{ts, type: "PACKET", dir: "S2C"|"C2S", name, data}`), so the whole timeline is jq-able in one file. Test-boundary markers use the same `LOG` type.
- Give `mc.ping` a 30s `closeTimeout` so a hung ping fails the hook with `ETIMEDOUT` (recorded in the trace) instead of being masked by the mocha hook timeout.

Had these been in place, both runs above would have uploaded a trace pinpointing the hung stage with timestamps.

No behavior change to the tests themselves; `--retries` still doesn't cover `before` hooks, so flakes will still fail the job — they'll just say where they happened.


