### PR TITLE
Fix client-side inventory desyncs behind the 26.1 creative test failure

### DIFF
--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -21,6 +21,9 @@ function inject (bot) {
       }
 
       if (windowCraftingTable) {
+        // The last put-away click is unconfirmed; closing on a wrong model
+        // leaves items the server never placed.
+        await bot._syncWindow(windowCraftingTable)
         bot.closeWindow(windowCraftingTable)
         windowCraftingTable = undefined
       }

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -55,11 +55,14 @@ function inject (bot) {
       })
     }
 
-    await onceWithCleanup(bot.inventory, `updateSlot:${slot}`, {
-      timeout: 5000,
-      checkCondition: (oldItem, newItem) => item === null ? newItem === null : newItem?.name === item.name && newItem?.count === item.count && newItem?.metadata === item.metadata
-    })
-    creativeSlotsUpdates[slot] = false
+    try {
+      await onceWithCleanup(bot.inventory, `updateSlot:${slot}`, {
+        timeout: 5000,
+        checkCondition: (oldItem, newItem) => item === null ? newItem === null : newItem?.name === item.name && newItem?.count === item.count && newItem?.metadata === item.metadata
+      })
+    } finally {
+      creativeSlotsUpdates[slot] = false
+    }
   }
 
   async function clearInventory () {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -725,7 +725,11 @@ function inject (bot, { hideErrors }) {
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })
+  // Window ids restart with the player entity, so a later window can reuse
+  // the closed one's id and its early sync must not be taken for a trailing one.
+  bot._client.on('respawn', () => { lastClosedWindow = null })
   bot._client.on('login', () => {
+    lastClosedWindow = null
     // close window when switch subserver
     const oldWindow = bot.currentWindow
     if (!oldWindow) return

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -457,12 +457,16 @@ function inject (bot, { hideErrors }) {
   }
 
   async function waitForWindowUpdate (window, slot) {
+    // The server recomputes the crafting result slot after any click in the
+    // crafting area, including picking up the result (which consumes the
+    // ingredients). Waiting for that resync on result clicks too keeps
+    // follow-up clicks and close_window from racing ahead of the craft.
     if (window.type === 'minecraft:inventory') {
-      if (slot >= 1 && slot <= 4) {
+      if (slot >= 0 && slot <= 4) {
         await once(bot.inventory, 'updateSlot:0')
       }
     } else if (window.type === 'minecraft:crafting') {
-      if (slot >= 1 && slot <= 9) {
+      if (slot >= 0 && slot <= 9) {
         await once(bot.currentWindow, 'updateSlot:0')
       }
     } else if (window.type === 'minecraft:merchant') {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -751,11 +751,20 @@ function inject (bot, { hideErrors }) {
     const newItem = Item.fromNotch(packet.item)
     bot._setSlot(packet.slot, newItem, window)
   })
+  // set_player_inventory uses vanilla Inventory indices (0-8 hotbar, 9-35 main,
+  // 36-39 armor from feet to head, 40 offhand), not window 0 slot numbers
+  // (36-44 hotbar, 9-35 main, 5-8 armor from head to feet, 45 offhand)
+  function playerInventorySlotToWindow (slotId) {
+    if (slotId <= 8) return slotId + 36 // hotbar
+    if (slotId >= 36 && slotId <= 39) return 44 - slotId // armor
+    if (slotId === 40) return 45 // offhand
+    return slotId // main inventory
+  }
   // 1.21.9+ uses set_player_inventory for server-initiated inventory changes
   // (e.g. console /give) instead of set_slot
   bot._client.on('set_player_inventory', (packet) => {
     const newItem = Item.fromNotch(packet.contents)
-    bot._setSlot(packet.slotId, newItem)
+    bot._setSlot(playerInventorySlotToWindow(packet.slotId), newItem)
   })
   bot.inventory.on('updateSlot', (index) => {
     if (index === bot.quickBarSlot + bot.inventory.hotbarStart) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -801,9 +801,29 @@ function inject (bot, { hideErrors }) {
       const item = Item.fromNotch(packet.items[i])
       window.updateSlot(i, item)
     }
+    if (packet.carriedItem !== undefined) window.selectedItem = Item.fromNotch(packet.carriedItem)
     updateHeldItem()
     bot.emit(`setWindowItems:${window.id}`)
   })
+
+  // 1.17.1+ servers only answer a click when their record of the client is
+  // stale, so a click they ignored is never reported. A no-op click carrying
+  // an impossible stateId always gets the full window state back.
+  async function syncWindow (window) {
+    if (!bot.supportFeature('stateIdUsed')) return
+    const synced = once(bot, `setWindowItems:${window.id}`)
+    bot._client.write('window_click', {
+      windowId: window.id,
+      stateId: -1,
+      slot: -999,
+      mouseButton: 2, // end of a drag that never started
+      mode: 5,
+      changedSlots: [],
+      cursorItem: Item.toNotch(window.selectedItem)
+    })
+    await synced
+  }
+  bot._syncWindow = syncWindow
 
   /**
    * Convert a vector direction to minecraft packet number direction

--- a/test/externalTests/playerInventory.js
+++ b/test/externalTests/playerInventory.js
@@ -1,0 +1,40 @@
+const { Vec3 } = require('vec3')
+const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
+
+module.exports = () => async (bot) => {
+  // Closing a container while holding an item on the cursor makes the server
+  // return it through Inventory.placeItemBackInInventory, synced on 1.21.3+
+  // via set_player_inventory. Its slotId counts the vanilla player inventory
+  // hotbar-first (0-8), which must be translated to the inventory menu slot
+  // space. Applied raw, a return into hotbar slot 0 writes the crafting
+  // result slot 0 instead of window slot 36.
+  await bot.test.becomeCreative()
+  await bot.test.clearInventory()
+  await bot.test.wait(100)
+
+  // A stone in hotbar slot 0 to pick up on the cursor
+  const stoneId = bot.registry.itemsByName.stone.id
+  await bot.test.setInventorySlot(bot.inventory.hotbarStart, new (require('prismarine-item')(bot.registry))(stoneId, 1))
+
+  // Place a chest next to the bot and open it
+  const chestPos = new Vec3(1, bot.test.groundY, 0)
+  await bot.test.setBlock({ x: chestPos.x, y: chestPos.y, z: chestPos.z, blockName: 'chest' })
+  const chest = await bot.openContainer(bot.blockAt(chestPos))
+
+  // Pick the stone up onto the cursor (hotbar slot 0 = chest.hotbarStart)
+  await bot.clickWindow(chest.hotbarStart, 0, 0)
+  assert.ok(chest.selectedItem, 'stone should be on the cursor')
+
+  // Closing with the cursor occupied makes the server return the stone via
+  // set_player_inventory into hotbar slot 0 -> inventory slot 36
+  const returned = onceWithCleanup(bot.inventory, 'updateSlot:36', {
+    timeout: 5000,
+    checkCondition: (oldItem, newItem) => newItem?.type === stoneId
+  })
+  bot.closeWindow(chest)
+  await returned
+
+  assert.strictEqual(bot.inventory.slots[bot.inventory.hotbarStart].type, stoneId, 'returned stone should be back in hotbar slot 0')
+  assert.strictEqual(bot.inventory.slots[0], null, 'set_player_inventory slotId 0 must not write into the crafting result slot')
+}


### PR DESCRIPTION
Investigating the `creative` external test failing on 26.1 with `10 !== 9` at `creative.js:53` ([this run](https://github.com/PrismarineJS/mineflayer/actions/runs/31992963697) on #3968) turned up two client-side inventory desyncs. Replaying the uploaded packet trace showed the server held exactly 9 items at assert time — the 10th item existed only in mineflayer's state.

### 1. `set_player_inventory` slot ids were applied without mapping

The packet (1.21.2+) uses vanilla `Inventory` indices (0–8 hotbar, 9–35 main, 36–39 armor, 40 offhand), but the handler passed `packet.slotId` straight to `bot._setSlot`, which uses window-0 numbering (hotbar 36–44). The trace shows the server sending `set_player_inventory slotId=0` and `set_slot slot=36` with identical contents — mineflayer wrote the former into the crafting-result slot. Server-moved hotbar items (e.g. `/give`) became phantom items in slots the server never corrects.

### 2. `bot.craft` raced ahead of the server on the result pickup

This is what actually broke the creative test. `clickWindow` already waits for the server's recomputed result slot after every crafting-**grid** click, but not after clicking the **result** slot. The trace shows the result pickup, the deposit click, and `close_window` all sent within ~1 ms; the 26.1 server never applied the craft — it returned the 7 grid sticks on window close (and the between-test `/clear` removed 11 items: 7 sticks + 4 planks, no ladders) — while the client-side click simulation kept 3 phantom ladders in `bot.inventory.slots[10]`. Since `/clear` only corrects slots the server believes are occupied, the ghost survived every mocha retry, so `creative` (which runs right after `crafting`) always counted 9 + 1 = 10. Extending the existing result-slot wait to result clicks keeps the client in lockstep with the server.

### Verification

Against local vanilla servers, `crafting` + `creative`:
- **26.1**: both pass (previously `creative` failed every retry)
- **1.21.11** and **1.16.5** (regression check for both the client-predicted and transaction-ack click paths): both pass


---

**Update:** now includes a regression test (`test/externalTests/playerInventory.js`) covering the slot-mapping bug directly: pick an item onto the cursor in a chest, close the window, and assert the server's `set_player_inventory` return lands in inventory slot 36 (hotbar 0) and does **not** corrupt crafting-result slot 0. Verified on 1.8.8 (legacy return path) and 26.1.

Note: on 26.1 the test's chest interaction requires `player_loaded` (#3986, below this PR in the stack) — without it the server ignores the interaction indefinitely.
