### PR TITLE
fix: don't let a failed external test poison the ones after it

### DIFF
--- a/lib/promise_utils.js
+++ b/lib/promise_utils.js
@@ -42,20 +42,44 @@ function createDoneTask () {
  * @param event - The name of the event you want to listen for
  * @param [timeout=0] - An amount, in milliseconds, for which to wait before considering the promise failed. <0 = none.
  * @param [checkCondition] - A function which matches the same signature of an event emitter handler, and should return something truthy if you want the event to be handled. If this is not provided, all events are handled.
+ * @param [signal] - An AbortSignal which, when aborted, removes the listener and rejects the promise with the signal's reason.
  * @returns {Promise} A promise which will either resolve to an *array* of values in the handled event, or will reject on timeout if applicable. This may never resolve if no timeout is set and the event does not fire.
  */
-function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefined } = {}) {
+function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefined, signal = undefined } = {}) {
   const task = createTask()
 
   const onEvent = (...data) => {
-    if (typeof checkCondition === 'function' && !checkCondition(...data)) {
-      return
+    if (typeof checkCondition === 'function') {
+      let matches
+      try {
+        matches = checkCondition(...data)
+      } catch (err) {
+        // checkCondition runs inside emit(), which for client events is the socket
+        // read path: throwing there unwinds it and the client silently stops
+        // receiving packets. Reject the promise instead, so the caller sees it.
+        task.cancel(err)
+        return
+      }
+      if (!matches) return
     }
 
     task.finish(data)
   }
 
   emitter.addListener(event, onEvent)
+
+  let onAbort
+  if (signal) {
+    const abortError = () => signal.reason instanceof Error
+      ? signal.reason
+      : new Error(`Waiting for event ${event} was aborted`)
+    if (signal.aborted) {
+      task.cancel(abortError())
+    } else {
+      onAbort = () => task.cancel(abortError())
+      signal.addEventListener('abort', onAbort, { once: true })
+    }
+  }
 
   if (typeof timeout === 'number' && timeout > 0) {
     // For some reason, the call stack gets lost if we don't create the error outside of the .then call
@@ -67,7 +91,10 @@ function onceWithCleanup (emitter, event, { timeout = 0, checkCondition = undefi
     })
   }
 
-  task.promise.catch(() => {}).finally(() => emitter.removeListener(event, onEvent))
+  task.promise.catch(() => {}).finally(() => {
+    emitter.removeListener(event, onEvent)
+    if (onAbort) signal.removeEventListener('abort', onAbort)
+  })
 
   return task.promise
 }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -154,6 +154,12 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    // mocha doesn't cancel a test it kills at its timeout, it just stops waiting
+    // for it: the attempt's example keeps running and its listeners keep
+    // reacting to the shared bot, so the next test (or retry) would run the
+    // example twice at once. This hook runs after every attempt, retries too.
+    afterEach(() => bot?.test?.abortRunningExample?.())
+
     async function reconnectBot () {
       console.log('  Bot disconnected, reconnecting...')
       try { bot.end() } catch (e) { /* ignore */ }

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -223,11 +223,22 @@ function inject (bot, wrap) {
     return chatMessagePromise
   }
 
+  // The example currently running, if any. Aborting it drops every listener the
+  // attempt armed on the shared bot.
+  let runningExample = null
+  bot.test.abortRunningExample = () => {
+    runningExample?.abort(new Error('a previous attempt of this example is still running'))
+    runningExample = null
+  }
+
   async function runExample (file, run) {
     let childBotName
+    const abort = new AbortController()
+    runningExample = abort
 
     const detectChildJoin = async () => {
       const [message] = await onceWithCleanup(bot, 'message', {
+        signal: abort.signal,
         checkCondition: message => message.json.translate === 'multiplayer.player.joined'
       })
       childBotName = message.json.with[0].insertion
@@ -247,6 +258,7 @@ function inject (bot, wrap) {
 
     const runExampleOnReady = async () => {
       await onceWithCleanup(bot, 'chat', {
+        signal: abort.signal,
         checkCondition: (username, message) => message === 'Ready!'
       })
       return run(childBotName)
@@ -258,16 +270,31 @@ function inject (bot, wrap) {
     child.stdout.on('data', (data) => { console.log(`${data}`) })
     child.stderr.on('data', (data) => { console.error(`${data}`) })
 
-    const closeExample = async (err) => {
-      console.log('kill process ' + child.pid)
+    // Neither wait above settles if the example process dies (an uncaught
+    // chunk-load timeout, say), so without this the attempt just hangs until
+    // mocha's timeout.
+    const childDied = onceWithCleanup(child, 'close', { signal: abort.signal })
+      .then(([code, signal]) => {
+        throw new Error(`${file} exited before the test finished (code ${code}, signal ${signal})`)
+      })
 
-      try {
-        process.kill(child.pid, 'SIGTERM')
-        const [code] = await onceWithCleanup(child, 'close', { timeout: 5000 })
-        console.log('close requested', code)
-      } catch (e) {
-        console.log(e)
-        console.log('process termination failed, process may already be closed')
+    const closeExample = async (err) => {
+      // Drop this attempt's listeners first, so a retry never inherits them.
+      abort.abort(err ?? new Error(`${file} finished`))
+      if (runningExample === abort) runningExample = null
+
+      if (child.exitCode !== null || child.signalCode !== null) {
+        console.log(`process ${child.pid} already exited (code ${child.exitCode}, signal ${child.signalCode})`)
+      } else {
+        console.log('kill process ' + child.pid)
+        try {
+          process.kill(child.pid, 'SIGTERM')
+          const [code] = await onceWithCleanup(child, 'close', { timeout: 5000 })
+          console.log('close requested', code)
+        } catch (e) {
+          console.log(e)
+          console.log('process termination failed, process may already be closed')
+        }
       }
 
       if (err) {
@@ -279,7 +306,7 @@ function inject (bot, wrap) {
     // an inner withTimeout, which was causing premature failures on
     // slow CI runners.
     try {
-      await Promise.all([detectChildJoin(), runExampleOnReady()])
+      await Promise.race([Promise.all([detectChildJoin(), runExampleOnReady()]), childDied])
     } catch (err) {
       console.log(err)
       return closeExample(err)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -6,7 +6,8 @@ const mc = require('minecraft-protocol')
 const assert = require('assert')
 const { sleep } = require('../lib/promise_utils')
 const nbt = require('prismarine-nbt')
-const { once } = require('../lib/promise_utils')
+const { once, onceWithCleanup } = require('../lib/promise_utils')
+const { EventEmitter } = require('events')
 const { getPort } = require('./common/util')
 
 for (const supportedVersion of mineflayer.testedVersions) {
@@ -1310,6 +1311,32 @@ for (const supportedVersion of mineflayer.testedVersions) {
           bot.entity.pitch = testPitch
           bot.activateItem()
         })
+      })
+    })
+
+    describe('onceWithCleanup', () => {
+      it('rejects instead of throwing out of emit when checkCondition throws', async () => {
+        // A condition that throws used to unwind whatever was emitting. For a
+        // client event that is the socket read path, which then stops delivering
+        // packets entirely and the bot dies on the next keepalive.
+        const emitter = new EventEmitter()
+        const boom = new Error('condition blew up')
+        const promise = onceWithCleanup(emitter, 'thing', {
+          checkCondition: () => { throw boom }
+        })
+        assert.doesNotThrow(() => emitter.emit('thing'))
+        await assert.rejects(promise, err => err === boom)
+        assert.strictEqual(emitter.listenerCount('thing'), 0)
+      })
+
+      it('rejects and removes the listener when the signal is aborted', async () => {
+        const emitter = new EventEmitter()
+        const abort = new AbortController()
+        const reason = new Error('no longer interested')
+        const promise = onceWithCleanup(emitter, 'thing', { signal: abort.signal })
+        abort.abort(reason)
+        await assert.rejects(promise, err => err === reason)
+        assert.strictEqual(emitter.listenerCount('thing'), 0)
       })
     })
   })


### PR DESCRIPTION
## Problem

[CI run 32586764293](https://github.com/PrismarineJS/mineflayer/actions/runs/32586764293) (1.16.5) failed two tests and killed the bot for the rest of the job. Three separate problems chained up:

- `examples/digger.js` crashed on an uncaught chunk-load timeout. Neither wait in `runExample` settles when the child dies, so the test hung until mocha's 90s timeout with its listeners still armed on the shared bot.
- The retry then ran on top of those listeners: the previous attempt's `run()` fired again on the new child's "Ready!", so every command went out twice and the example answered twice.
- The duplicate answer tripped `assert.fail('Unexpected message: ...')` inside a `checkCondition`, which runs inside the client's socket read path. The throw unwound it and the client stopped receiving packets entirely — the trace shows no S2C packet after that assertion, and the bot died 30s later on `keepAliveError`, failing everything downstream.

## Changes

- Catch a throwing `checkCondition` in `onceWithCleanup` and reject the promise instead of letting it escape into the emitter.
- Fail `runExample` as soon as the example process exits, instead of waiting for a mocha timeout that leaves listeners armed.
- Abort a still-running example before each attempt (via a new `AbortSignal` option on `onceWithCleanup`), so a retry never shares the bot with the attempt before it.

Both `onceWithCleanup` behaviors are covered by new internal tests.

