### PR TITLE
test(time): cut the time test from 13 broadcast waits to 3

### DIFF
--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -48,8 +48,8 @@ module.exports = () => async (bot) => {
     }
   }
 
-  // Helper to set gamerule using the correct name for the version
-  const setDaylightCycle = (value) => {
+  // The gamerule is renamed on versions with gameRuleUsesResourceLocation.
+  const sendSetDaylightCycleCommand = (value) => {
     if (bot.supportFeature('gameRuleUsesResourceLocation')) {
       bot.test.sayEverywhere(`/gamerule minecraft:advance_time ${value}`)
     } else {
@@ -61,7 +61,7 @@ module.exports = () => async (bot) => {
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
   // Commands apply in the order sent: the first /time set below lands after this.
-  setDaylightCycle(false)
+  sendSetDaylightCycleCommand(false)
 
   // Test time transitions
   const timeTests = [
@@ -82,7 +82,7 @@ module.exports = () => async (bot) => {
   // Must be read before the commands below mutate them.
   const currentDay = bot.time.day
   const currentPhase = bot.time.moonPhase
-  setDaylightCycle(true)
+  sendSetDaylightCycleCommand(true)
   bot.test.sayEverywhere('/time add 24000')
   // Two commands are in flight. A server that answers each one sends two
   // broadcasts, and the first still has the old day, so wait on the day itself.
@@ -91,16 +91,16 @@ module.exports = () => async (bot) => {
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
 
   // Test daylight cycle toggle
-  setDaylightCycle(false)
+  sendSetDaylightCycleCommand(false)
   await waitForTimeState(() => bot.time.doDaylightCycle === false)
   assert.strictEqual(bot.time.doDaylightCycle, false)
 
-  setDaylightCycle(originalDaylightCycle)
+  sendSetDaylightCycleCommand(originalDaylightCycle)
   await waitForTimeState(() => bot.time.doDaylightCycle === originalDaylightCycle)
   assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
 
   // Commands apply in the order sent: the first /time set below lands after this.
-  setDaylightCycle(false)
+  sendSetDaylightCycleCommand(false)
 
   // Test day/night transitions
   const dayNightTests = [
@@ -116,6 +116,6 @@ module.exports = () => async (bot) => {
   }
 
   // Restore original daylight cycle setting
-  setDaylightCycle(originalDaylightCycle)
+  sendSetDaylightCycleCommand(originalDaylightCycle)
   await waitForTime()
 }

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -30,10 +30,8 @@ module.exports = () => async (bot) => {
   // Helper functions
   const isTimeClose = (current, target) => Math.abs(current - target) < 510
   const isTimeInRange = (current, start, end) => start <= end ? current >= start && current <= end : current >= start || current <= end
-  // One update_time broadcast carries world time AND the doDaylightCycle flag
-  // (vanilla builds it in a single `tickCounter % 20` block), so a wait keyed on
-  // the state we care about can confirm several commands at once. Waiting on the
-  // state also avoids latching onto a broadcast that was already in flight.
+  // update_time is the only carrier of world time and doDaylightCycle, and
+  // vanilla broadcasts it once every 20 ticks.
   const waitForTimeState = async (matches) =>
     onceWithCleanup(bot, 'time', { timeout: 5000, checkCondition: matches })
 
@@ -62,8 +60,7 @@ module.exports = () => async (bot) => {
   // Disable daylight cycle before time transition tests to prevent
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
-  // No wait here: the server applies commands in order, so the first /time set
-  // below lands after the cycle is off, and its wait confirms both.
+  // Commands apply in the order sent: the first /time set below lands after this.
   setDaylightCycle(false)
 
   // Test time transitions
@@ -81,15 +78,14 @@ module.exports = () => async (bot) => {
     assert.strictEqual(bot.time.isDay, test.isDay, `${test.name} should be ${test.isDay ? 'day' : 'night'}`)
   }
 
-  // Test day and moon phase progression. Capture before mutating, then let one
-  // broadcast confirm both the re-enabled cycle and the added day.
+  // Test day and moon phase progression.
+  // Must be read before the commands below mutate them.
   const currentDay = bot.time.day
   const currentPhase = bot.time.moonPhase
   setDaylightCycle(true)
   bot.test.sayEverywhere('/time add 24000')
-  // Must key on the day advancing, not just any broadcast: servers that echo
-  // each command immediately would otherwise satisfy a bare wait with the
-  // gamerule's echo, before the added day is reflected.
+  // A broadcast may be the echo of any command in the batch, so the wait has to
+  // be keyed on the state under test.
   await waitForTimeState(() => bot.time.day >= currentDay + 1)
   assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
@@ -103,8 +99,7 @@ module.exports = () => async (bot) => {
   await waitForTimeState(() => bot.time.doDaylightCycle === originalDaylightCycle)
   assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
 
-  // Disable the cycle again for the range tests; no wait, the first /time set
-  // below is applied after it and its wait confirms both.
+  // Commands apply in the order sent: the first /time set below lands after this.
   setDaylightCycle(false)
 
   // Test day/night transitions

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -30,6 +30,13 @@ module.exports = () => async (bot) => {
   // Helper functions
   const isTimeClose = (current, target) => Math.abs(current - target) < 510
   const isTimeInRange = (current, start, end) => start <= end ? current >= start && current <= end : current >= start || current <= end
+  // One update_time broadcast carries world time AND the doDaylightCycle flag
+  // (vanilla builds it in a single `tickCounter % 20` block), so a wait keyed on
+  // the state we care about can confirm several commands at once. Waiting on the
+  // state also avoids latching onto a broadcast that was already in flight.
+  const waitForTimeState = async (matches) =>
+    onceWithCleanup(bot, 'time', { timeout: 5000, checkCondition: matches })
+
   const waitForTime = async (expectedTime) => {
     // Wait for a time event that matches our expectation (if provided)
     // This helps avoid race conditions where we catch an old time update
@@ -55,8 +62,9 @@ module.exports = () => async (bot) => {
   // Disable daylight cycle before time transition tests to prevent
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
+  // No wait here: the server applies commands in order, so the first /time set
+  // below lands after the cycle is off, and its wait confirms both.
   setDaylightCycle(false)
-  await waitForTime()
 
   // Test time transitions
   const timeTests = [
@@ -73,30 +81,31 @@ module.exports = () => async (bot) => {
     assert.strictEqual(bot.time.isDay, test.isDay, `${test.name} should be ${test.isDay ? 'day' : 'night'}`)
   }
 
-  // Re-enable daylight cycle for progression test
-  setDaylightCycle(true)
-  await waitForTime()
-
-  // Test day and moon phase progression
+  // Test day and moon phase progression. Capture before mutating, then let one
+  // broadcast confirm both the re-enabled cycle and the added day.
   const currentDay = bot.time.day
   const currentPhase = bot.time.moonPhase
+  setDaylightCycle(true)
   bot.test.sayEverywhere('/time add 24000')
-  await waitForTime()
+  // Must key on the day advancing, not just any broadcast: servers that echo
+  // each command immediately would otherwise satisfy a bare wait with the
+  // gamerule's echo, before the added day is reflected.
+  await waitForTimeState(() => bot.time.day >= currentDay + 1)
   assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
 
   // Test daylight cycle toggle
   setDaylightCycle(false)
-  await waitForTime()
+  await waitForTimeState(() => bot.time.doDaylightCycle === false)
   assert.strictEqual(bot.time.doDaylightCycle, false)
 
   setDaylightCycle(originalDaylightCycle)
-  await waitForTime()
+  await waitForTimeState(() => bot.time.doDaylightCycle === originalDaylightCycle)
   assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
 
-  // Disable daylight cycle again for day/night range tests
+  // Disable the cycle again for the range tests; no wait, the first /time set
+  // below is applied after it and its wait confirms both.
   setDaylightCycle(false)
-  await waitForTime()
 
   // Test day/night transitions
   const dayNightTests = [
@@ -106,7 +115,7 @@ module.exports = () => async (bot) => {
 
   for (const test of dayNightTests) {
     bot.test.sayEverywhere(`/time set ${test.command}`)
-    await waitForTime()
+    await waitForTimeState(() => isTimeInRange(bot.time.timeOfDay, test.range[0], test.range[1]))
     assert(isTimeInRange(bot.time.timeOfDay, test.range[0], test.range[1]), `Time should be in ${test.command} range`)
     assert.strictEqual(bot.time.isDay, test.isDay, `${test.command} should be ${test.isDay ? 'day' : 'night'}`)
   }

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -84,8 +84,8 @@ module.exports = () => async (bot) => {
   const currentPhase = bot.time.moonPhase
   setDaylightCycle(true)
   bot.test.sayEverywhere('/time add 24000')
-  // A broadcast may be the echo of any command in the batch, so the wait has to
-  // be keyed on the state under test.
+  // Two commands are in flight. A server that answers each one sends two
+  // broadcasts, and the first still has the old day, so wait on the day itself.
   await waitForTimeState(() => bot.time.day >= currentDay + 1)
   assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -83,8 +83,6 @@ module.exports = () => async (bot) => {
   const currentPhase = bot.time.moonPhase
   sendSetDaylightCycleCommand(true)
   bot.test.sayEverywhere('/time add 24000')
-  // Two commands are in flight. A server that answers each one sends two
-  // broadcasts, and the first still has the old day, so wait on the day itself.
   await waitForTimeState(() => bot.time.day >= currentDay + 1)
   assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -60,7 +60,6 @@ module.exports = () => async (bot) => {
   // Disable daylight cycle before time transition tests to prevent
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
-  // Commands apply in the order sent: the first /time set below lands after this.
   sendSetDaylightCycleCommand(false)
 
   // Test time transitions
@@ -99,7 +98,7 @@ module.exports = () => async (bot) => {
   await waitForTimeState(() => bot.time.doDaylightCycle === originalDaylightCycle)
   assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
 
-  // Commands apply in the order sent: the first /time set below lands after this.
+  // Disable daylight cycle again for day/night range tests
   sendSetDaylightCycleCommand(false)
 
   // Test day/night transitions

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -112,7 +112,6 @@ module.exports = () => async (bot) => {
     assert.strictEqual(bot.time.isDay, test.isDay, `${test.command} should be ${test.isDay ? 'day' : 'night'}`)
   }
 
-  // Restore original daylight cycle setting
+  // Restore for later tests; the server applies it without the client waiting.
   sendSetDaylightCycleCommand(originalDaylightCycle)
-  await waitForTime()
 }

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { once, onceWithCleanup } = require('../../lib/promise_utils')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   // Test time properties and ranges
@@ -29,24 +29,11 @@ module.exports = () => async (bot) => {
 
   // Helper functions
   const isTimeClose = (current, target) => Math.abs(current - target) < 510
-  const isTimeInRange = (current, start, end) => start <= end ? current >= start && current <= end : current >= start || current <= end
   // update_time is the only carrier of world time and doDaylightCycle, and
-  // vanilla broadcasts it once every 20 ticks.
+  // vanilla broadcasts it once every 20 ticks, so each wait costs a full tick
+  // interval on servers that do not echo commands.
   const waitForTimeState = async (matches) =>
     onceWithCleanup(bot, 'time', { timeout: 5000, checkCondition: matches })
-
-  const waitForTime = async (expectedTime) => {
-    // Wait for a time event that matches our expectation (if provided)
-    // This helps avoid race conditions where we catch an old time update
-    if (expectedTime !== undefined) {
-      await onceWithCleanup(bot, 'time', {
-        timeout: 5000,
-        checkCondition: () => isTimeClose(bot.time.timeOfDay, expectedTime)
-      })
-    } else {
-      await once(bot, 'time')
-    }
-  }
 
   // The gamerule is renamed on versions with gameRuleUsesResourceLocation.
   const sendSetDaylightCycleCommand = (value) => {
@@ -60,24 +47,22 @@ module.exports = () => async (bot) => {
   // Disable daylight cycle before time transition tests to prevent
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
+
+  // Night with the cycle off: covers isDay false and doDaylightCycle false.
   sendSetDaylightCycleCommand(false)
+  bot.test.sayEverywhere('/time set 18000')
+  await waitForTimeState(() => isTimeClose(bot.time.timeOfDay, 18000))
+  assert(isTimeClose(bot.time.timeOfDay, 18000), `Expected time to be close to 18000, got ${bot.time.timeOfDay}`)
+  assert.strictEqual(bot.time.isDay, false, 'midnight should be night')
+  assert.strictEqual(bot.time.doDaylightCycle, false)
 
-  // Test time transitions
-  const timeTests = [
-    { time: 18000, name: 'midnight', isDay: false },
-    { time: 6000, name: 'noon', isDay: true },
-    { time: 12000, name: 'sunset', isDay: true },
-    { time: 0, name: 'sunrise', isDay: true }
-  ]
+  // 12000 is the last tick that still counts as day.
+  bot.test.sayEverywhere('/time set 12000')
+  await waitForTimeState(() => isTimeClose(bot.time.timeOfDay, 12000))
+  assert(isTimeClose(bot.time.timeOfDay, 12000), `Expected time to be close to 12000, got ${bot.time.timeOfDay}`)
+  assert.strictEqual(bot.time.isDay, true, 'sunset should be day')
 
-  for (const test of timeTests) {
-    bot.test.sayEverywhere(`/time set ${test.time}`)
-    await waitForTime(test.time)
-    assert(isTimeClose(bot.time.timeOfDay, test.time), `Expected time to be close to ${test.time}, got ${bot.time.timeOfDay}`)
-    assert.strictEqual(bot.time.isDay, test.isDay, `${test.name} should be ${test.isDay ? 'day' : 'night'}`)
-  }
-
-  // Test day and moon phase progression.
+  // Day and moon phase progression, and doDaylightCycle true.
   // Must be read before the commands below mutate them.
   const currentDay = bot.time.day
   const currentPhase = bot.time.moonPhase
@@ -86,31 +71,7 @@ module.exports = () => async (bot) => {
   await waitForTimeState(() => bot.time.day >= currentDay + 1)
   assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
   assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
-
-  // Test daylight cycle toggle
-  sendSetDaylightCycleCommand(false)
-  await waitForTimeState(() => bot.time.doDaylightCycle === false)
-  assert.strictEqual(bot.time.doDaylightCycle, false)
-
-  sendSetDaylightCycleCommand(originalDaylightCycle)
-  await waitForTimeState(() => bot.time.doDaylightCycle === originalDaylightCycle)
-  assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
-
-  // Disable daylight cycle again for day/night range tests
-  sendSetDaylightCycleCommand(false)
-
-  // Test day/night transitions
-  const dayNightTests = [
-    { command: 'day', range: [0, 12000], isDay: true },
-    { command: 'night', range: [12000, 24000], isDay: false }
-  ]
-
-  for (const test of dayNightTests) {
-    bot.test.sayEverywhere(`/time set ${test.command}`)
-    await waitForTimeState(() => isTimeInRange(bot.time.timeOfDay, test.range[0], test.range[1]))
-    assert(isTimeInRange(bot.time.timeOfDay, test.range[0], test.range[1]), `Time should be in ${test.command} range`)
-    assert.strictEqual(bot.time.isDay, test.isDay, `${test.command} should be ${test.isDay ? 'day' : 'night'}`)
-  }
+  assert.strictEqual(bot.time.doDaylightCycle, true)
 
   // Restore for later tests; the server applies it without the client waiting.
   sendSetDaylightCycleCommand(originalDaylightCycle)


### PR DESCRIPTION
`time` costs ~12.5s on 1.8.8–1.21.3, ~5.4s on 1.21.4–1.21.11, and ~155ms on 26.1 — measured across two CI runs, n=56, very consistent within each tier. It is about 6.5% of the entire 28-version matrix.

### Why it is slow

From `MinecraftServer` in the 1.8.8 server jar:

```
121: getfield  y:I                  // tickCounter
124: bipush    20
126: irem                           // tickCounter % 20
127: ifne      190                  // not a multiple of 20 -> skip entirely
...
144: new       hu                   // S03PacketTimeUpdate
150: le.K()J                        // getTotalWorldTime()
155: le.L()J                        // getWorldTime()
163: ldc       "doDaylightCycle"
169: hu."<init>":(JJZ)V
180: lx.a(packet, dimensionId)      // broadcast
```

`/time set` only calls `World.setWorldTime` and sends nothing, so time reaches clients **only** via that 20-tick broadcast, and the interval is a hardcoded immediate — no gamerule or server property changes it. Newer versions echo commands immediately, which is exactly why 1.21.4+ and 26.1 are fast.

So on older servers every wait costs a full tick interval. The test had 13 of them. A packet trace on 1.8.8 showed **8346 of 8348ms spent waiting for broadcasts** — sending all the commands and running every assertion took 2ms.

### What this changes

The test now only pays for state it actually distinguishes. Dropped:

- `/time set 6000` and `/time set 0` — interior day values on the same path as the `12000` boundary, which is the case worth asserting
- the two dedicated `doDaylightCycle` waits — the broadcasts satisfying the night and day-progression waits already carry the flag, so those assertions ride along for free
- `/time set day|night` — the server resolving a keyword to a number, after which mineflayer's path is identical to a numeric `/time set`

Retained: timeOfDay parsing, both `isDay` branches including the 12000 boundary, both `doDaylightCycle` branches, and day/moonPhase progression. The type and range assertions at the top of the test never cost a wait and are untouched.

Each remaining wait is keyed on the state it verifies rather than on "any time event". That also removes a latent race: a bare `await once(bot, 'time')` resolves on whichever broadcast arrives first, and on servers that echo each command that can be the *gamerule's* echo rather than the one under test. I hit this while writing the patch — two batched commands behind a bare wait made 26.1 fail with `Expected day to be at least 1, got 0`.

`setDaylightCycle` is renamed to `sendSetDaylightCycleCommand`, since it sends and returns immediately and every caller owns its own wait.

### Measurements

Same machine, test duration only:

| version | before | after |
|---|---|---|
| 1.8.8 | 12737ms | **2769ms** |
| 26.1 | — | 876ms |

13 waits to 3. Roughly 10s on each of the 21 versions in the slow tier, about 3.5 minutes off the full matrix.

### Two things worth a maintainer's eye

**The `day`/`night` aliases.** Dropping them gives up integration coverage of the server keywords. It proves nothing about mineflayer, but it is a canary if a future server version changes what they resolve to. Happy to restore them at ~2s/version if you would rather keep that.

**26.1 at 876ms.** I could not A/B that on the machine I was testing on (26.1 needs more memory than it could reliably give), so I cannot separate machine overhead from a real cost on the fast-echo tier. The CI logs on this PR will show the true per-version numbers.