### PR TITLE
test(useChests): assert the click transitions instead of clicking randomly; fix rejected quick-move clicks on 1.12–1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       # Per-test durations from the last master run of this version group, so a PR gets a
       # comment listing tests it made more than 1.5x slower (test/common/compareDurations.js).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       # Per-test durations from the last master run of this version group, so a PR gets a
       # comment listing tests it made more than 1.5x slower (test/common/compareDurations.js).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       # Per-test durations from the last master run of this version group, so a PR gets a
       # comment listing tests it made more than 1.5x slower (test/common/compareDurations.js).

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -624,7 +624,7 @@ function inject (bot, { hideErrors }) {
         action: actionId,
         mode,
         // Must match what the server's own click handling returns.
-        item: Item.toNotch((mode === 2 || mode === 4 || (mode === 1 && bot.registry.version['>=']('1.12'))) ? null : click.item)
+        item: Item.toNotch((mode === 2 || mode === 4 || (mode === 1 && bot.supportFeature('quickMoveClickSendsEmptyItem'))) ? null : click.item)
       })
     } else { // 1.17
       bot._client.write('window_click', {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -623,8 +623,8 @@ function inject (bot, { hideErrors }) {
         mouseButton,
         action: actionId,
         mode,
-        // protocol expects null even if there is an item at the slot in mode 2 and 4
-        item: Item.toNotch((mode === 2 || mode === 4) ? null : click.item)
+        // Must match what the server's own click handling returns.
+        item: Item.toNotch((mode === 2 || mode === 4 || (mode === 1 && bot.registry.version['>=']('1.12'))) ? null : click.item)
       })
     } else { // 1.17
       bot._client.write('window_click', {

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -133,19 +133,15 @@ module.exports = () => async (bot) => {
     1: ['fishing_rod', 'bow']
   }
 
-  function getRandomStackableItem () {
-    if (Math.random() < 0.75) {
-      return itemsWithStackSize[64][~~(Math.random() * itemsWithStackSize[64].length)]
-    } else {
-      if (Math.random() < 0.5) {
-        return itemsWithStackSize[16][~~(Math.random() * itemsWithStackSize[16].length)]
-      } else {
-        return itemsWithStackSize[1][~~(Math.random() * itemsWithStackSize[1].length)]
-      }
-    }
-  }
+  // The transition cases need one stack of more than 2, a second stack of a
+  // different type, and a free slot. Nothing asserts on a fuller chest.
+  const layout = [
+    { slot: 0, name: itemsWithStackSize[64][0], count: 8 },
+    { slot: 1, name: itemsWithStackSize[64][1], count: 8 },
+    { slot: 2, name: itemsWithStackSize[16][0], count: 4 }
+  ]
 
-  async function createRandomLayout (window, slotPopulationFactor) {
+  async function createLayout (window) {
     await bot.test.becomeCreative()
 
     // Wait for the given item to show up in hotbar.0. Depending on version and
@@ -180,25 +176,20 @@ module.exports = () => async (bot) => {
       throw new Error(`item ${name} never reached the hotbar`)
     }
 
-    for (let slot = 0; slot < window.inventoryStart; slot++) {
-      if (Math.random() < slotPopulationFactor) {
-        const randomItem = getRandomStackableItem()
-        const item = bot.registry.itemsByName[randomItem]
-        const count = Math.ceil(Math.random() * item.stackSize)
-        if (bot.registry.version['>=']('1.17')) {
-          // /item replace lands the item in a specific slot deterministically,
-          // so there is no race with the previous move (unlike /give, which
-          // targets the first empty slot and needs a settle delay).
-          await sendItemToHotbar(item.name, count)
-        } else {
-          bot.chat(`/give ${bot.username} ${item.name} ${count}`)
-          if (!await waitHotbarItem(item.name, 5000)) throw new Error(`item ${item.name} never reached the hotbar`)
-          await bot.test.wait(100)
-        }
-
-        // await bot.clickWindow(slot, 0, 2)
-        await bot.moveSlotItem(window.hotbarStart, slot)
+    for (const { slot, name, count } of layout) {
+      const item = bot.registry.itemsByName[name]
+      assert.ok(item, `${name} should exist on this version`)
+      if (bot.registry.version['>=']('1.17')) {
+        // /item replace lands the item in a specific slot deterministically,
+        // so there is no race with the previous move (unlike /give, which
+        // targets the first empty slot and needs a settle delay).
+        await sendItemToHotbar(item.name, count)
+      } else {
+        bot.chat(`/give ${bot.username} ${item.name} ${count}`)
+        if (!await waitHotbarItem(item.name, 5000)) throw new Error(`item ${item.name} never reached the hotbar`)
+        await bot.test.wait(100)
       }
+      await bot.moveSlotItem(window.hotbarStart, slot)
     }
 
     await bot.test.becomeSurvival()
@@ -278,33 +269,14 @@ module.exports = () => async (bot) => {
     assert.strictEqual(window.slots[move], null, 'shift click should empty the chest slot')
   }
 
-  async function testMouseClick (window, clicks) {
-    // mouseButton/mode pairs. Mode 0 alone only reaches pick up, place, merge
-    // and swap; quick move and collect-to-cursor are separate server paths.
-    // Modes 5 and 6 are assert-unimplemented in prismarine-windows, and mode 3
-    // is creative-only, so this is the reachable set from survival.
-    const ops = [
-      [0, 0], // left click: pick up / place / swap
-      [1, 0], // right click: half stack / place one
-      [0, 1] // shift click: quick move
-    ]
-    let iterations = 0
-    while (iterations++ < clicks) {
-      const [mouseButton, mode] = ops[iterations % ops.length]
-      await bot.clickWindow(~~(Math.random() * window.inventoryStart), mouseButton, mode)
-    }
-  }
-
   function clearLargeChest () {
     bot.chat(`/setblock ${largeChestLocations[0].x} ${largeChestLocations[0].y} ${largeChestLocations[0].z} chest`)
     bot.chat(`/setblock ${largeChestLocations[1].x} ${largeChestLocations[1].y} ${largeChestLocations[1].z} chest`)
   }
 
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
-  await createRandomLayout(window, 0.95)
-
+  await createLayout(window)
   await testClickTransitions(window)
-  await testMouseClick(window, 50)
 
   window.close()
   clearLargeChest()

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -219,7 +219,7 @@ module.exports = () => async (bot) => {
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
   await createRandomLayout(window, 0.95)
 
-  await testMouseClick(window, 250)
+  await testMouseClick(window, 50)
 
   window.close()
   clearLargeChest()

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -4,6 +4,8 @@ const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
+  // openContainer and placeBlock turn to face the block before acting.
+  bot.physics.yawSpeed = bot.physics.pitchSpeed = 1e3
 
   bot.test.groundY = bot.supportFeature('tallWorld') ? -60 : 4
 

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -141,58 +141,22 @@ module.exports = () => async (bot) => {
     { slot: 2, name: itemsWithStackSize[16][0], count: 4 }
   ]
 
-  async function createLayout (window) {
-    await bot.test.becomeCreative()
-
-    // Wait for the given item to show up in hotbar.0. Depending on version and
-    // which container is open, the server syncs it either through the open
-    // window or directly to the inventory, so listen on both.
-    const waitHotbarItem = (item, timeout) => new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        window.off('updateSlot', onWin)
-        bot.inventory.off('updateSlot', onInv)
-        resolve(false)
-      }, timeout)
-      const ok = newItem => newItem?.name === item
-      const onWin = (slot, oldItem, newItem) => { if (slot === window.hotbarStart && ok(newItem)) done() }
-      const onInv = (slot, oldItem, newItem) => { if (slot === 36 && ok(newItem)) done() }
-      function done () {
-        clearTimeout(timer)
-        window.off('updateSlot', onWin)
-        bot.inventory.off('updateSlot', onInv)
-        resolve(true)
-      }
-      window.on('updateSlot', onWin)
-      bot.inventory.on('updateSlot', onInv)
-    })
-
-    // The server silently drops chat commands sent too close together, so
-    // resend if the item has not arrived shortly after the command.
-    const sendItemToHotbar = async (name, count) => {
-      for (let attempt = 0; attempt < 3; attempt++) {
-        bot.chat(`/item replace entity ${bot.username} hotbar.0 with ${name} ${count}`)
-        if (await waitHotbarItem(name, 500)) return
-      }
-      throw new Error(`item ${name} never reached the hotbar`)
-    }
-
+  // Write the slots server side. Filling them by clicking leaves the result at
+  // the mercy of the client's predicted state, which from 1.17 is not confirmed
+  // per click, and a lost move is invisible until an assertion reads the slot.
+  function fillChest (pos) {
+    const at = `${pos.x} ${pos.y} ${pos.z}`
     for (const { slot, name, count } of layout) {
       const item = bot.registry.itemsByName[name]
       assert.ok(item, `${name} should exist on this version`)
       if (bot.registry.version['>=']('1.17')) {
-        // /item replace lands the item in a specific slot deterministically,
-        // so there is no race with the previous move (unlike /give, which
-        // targets the first empty slot and needs a settle delay).
-        await sendItemToHotbar(item.name, count)
+        bot.chat(`/item replace block ${at} container.${slot} with ${name} ${count}`)
+      } else if (bot.registry.version['>=']('1.13')) {
+        bot.chat(`/replaceitem block ${at} container.${slot} ${name} ${count}`)
       } else {
-        bot.chat(`/give ${bot.username} ${item.name} ${count}`)
-        if (!await waitHotbarItem(item.name, 5000)) throw new Error(`item ${item.name} never reached the hotbar`)
-        await bot.test.wait(100)
+        bot.chat(`/replaceitem block ${at} slot.container.${slot} minecraft:${name} ${count}`)
       }
-      await bot.moveSlotItem(window.hotbarStart, slot)
     }
-
-    await bot.test.becomeSurvival()
   }
 
   // Each left/right click resolves differently depending on whether the cursor
@@ -274,8 +238,12 @@ module.exports = () => async (bot) => {
     bot.chat(`/setblock ${largeChestLocations[1].x} ${largeChestLocations[1].y} ${largeChestLocations[1].z} chest`)
   }
 
+  fillChest(largeChestLocations[0])
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
-  await createLayout(window)
+  for (const { slot, name, count } of layout) {
+    assert.strictEqual(window.slots[slot]?.name, name, `expected ${name} in chest slot ${slot}`)
+    assert.strictEqual(window.slots[slot].count, count)
+  }
   await testClickTransitions(window)
 
   window.close()

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -205,9 +205,17 @@ module.exports = () => async (bot) => {
   }
 
   async function testMouseClick (window, clicks) {
+    // Modes 5 and 6 are assert-unimplemented in prismarine-windows and mode 3
+    // is creative-only, so this is the reachable set from survival.
+    const ops = [
+      [0, 0], // left click: pick up / place / swap
+      [1, 0], // right click: half stack / place one
+      [0, 1] // shift click: quick move
+    ]
     let iterations = 0
     while (iterations++ < clicks) {
-      await bot.clickWindow(~~(Math.random() * window.inventoryStart), 0, 0)
+      const [mouseButton, mode] = ops[iterations % ops.length]
+      await bot.clickWindow(~~(Math.random() * window.inventoryStart), mouseButton, mode)
     }
   }
 

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -204,8 +204,84 @@ module.exports = () => async (bot) => {
     await bot.test.becomeSurvival()
   }
 
+  // Each left/right click resolves differently depending on whether the cursor
+  // is holding something and what is in the target slot, so every case needs
+  // its own precondition rather than another random click.
+  async function testClickTransitions (window) {
+    const held = () => window.selectedItem
+    const find = (pred) => {
+      for (let i = 0; i < window.inventoryStart; i++) {
+        if (pred(window.slots[i], i)) return i
+      }
+      return -1
+    }
+
+    assert.ok(!held(), 'cursor must start empty')
+
+    // Needs more than 2 so there is still something on the cursor after placing
+    // one, and something left to merge back.
+    const a = find(s => s !== null && s.count > 2)
+    assert.notStrictEqual(a, -1, 'expected an occupied slot holding more than 2')
+    const taken = { type: window.slots[a].type, count: window.slots[a].count }
+    await bot.clickWindow(a, 0, 0)
+    assert.ok(held(), 'left click on an occupied slot should take it')
+    assert.strictEqual(held().type, taken.type)
+    assert.strictEqual(held().count, taken.count)
+    assert.strictEqual(window.slots[a], null)
+
+    // holding + empty slot, right click -> place exactly one
+    await bot.clickWindow(a, 1, 0)
+    assert.ok(window.slots[a], 'right click on an empty slot should place one')
+    assert.strictEqual(window.slots[a].count, 1)
+    assert.strictEqual(held().count, taken.count - 1)
+
+    // holding + occupied slot of the same type -> merge into it. The slot holds
+    // 1 and the cursor the rest of the same stack, so all of it fits and the
+    // cursor is left empty.
+    await bot.clickWindow(a, 0, 0)
+    assert.strictEqual(window.slots[a].type, taken.type)
+    assert.strictEqual(window.slots[a].count, taken.count, 'the whole stack should merge back')
+    assert.ok(!held(), 'a merge that fits should empty the cursor')
+
+    // holding + occupied slot of a different type -> swap
+    await bot.clickWindow(a, 0, 0)
+    assert.ok(held(), 'expected to be holding the merged stack')
+    const other = find((s, i) => s !== null && i !== a && s.type !== held().type)
+    assert.notStrictEqual(other, -1, 'expected a slot holding a different item type')
+    const there = { type: window.slots[other].type, count: window.slots[other].count }
+    const cursor = { type: held().type, count: held().count }
+    await bot.clickWindow(other, 0, 0)
+    assert.strictEqual(window.slots[other].type, cursor.type, 'swap should leave the cursor item in the slot')
+    assert.strictEqual(window.slots[other].count, cursor.count)
+    assert.strictEqual(held().type, there.type, 'swap should leave the slot item on the cursor')
+    assert.strictEqual(held().count, there.count)
+
+    // holding + empty slot -> drop the whole stack
+    await bot.clickWindow(a, 0, 0)
+    assert.ok(!held(), 'left click on an empty slot should drop the whole stack')
+    assert.strictEqual(window.slots[a].type, there.type)
+
+    // empty cursor + occupied slot, right click -> take half
+    const big = find(s => s !== null && s.count > 1)
+    assert.notStrictEqual(big, -1, 'expected a slot holding more than 1')
+    const whole = window.slots[big].count
+    await bot.clickWindow(big, 1, 0)
+    assert.ok(held(), 'right click on an occupied slot should take half')
+    assert.strictEqual(held().count + (window.slots[big]?.count ?? 0), whole, 'the halves should account for the whole stack')
+    await bot.clickWindow(big, 0, 0)
+    assert.ok(!held(), 'putting the half back should empty the cursor')
+
+    // shift click moves the stack out of the chest entirely
+    const move = find(s => s !== null)
+    assert.notStrictEqual(move, -1, 'expected an occupied slot to shift click')
+    await bot.clickWindow(move, 0, 1)
+    assert.strictEqual(window.slots[move], null, 'shift click should empty the chest slot')
+  }
+
   async function testMouseClick (window, clicks) {
-    // Modes 5 and 6 are assert-unimplemented in prismarine-windows and mode 3
+    // mouseButton/mode pairs. Mode 0 alone only reaches pick up, place, merge
+    // and swap; quick move and collect-to-cursor are separate server paths.
+    // Modes 5 and 6 are assert-unimplemented in prismarine-windows, and mode 3
     // is creative-only, so this is the reachable set from survival.
     const ops = [
       [0, 0], // left click: pick up / place / swap
@@ -227,6 +303,7 @@ module.exports = () => async (bot) => {
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
   await createRandomLayout(window, 0.95)
 
+  await testClickTransitions(window)
   await testMouseClick(window, 50)
 
   window.close()

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -151,12 +151,12 @@ module.exports = () => async (bot) => {
     for (const { slot, name, count } of layout) {
       const item = bot.registry.itemsByName[name]
       assert.ok(item, `${name} should exist on this version`)
-      if (bot.registry.version['>=']('1.17')) {
+      if (bot.supportFeature('hasItemCommand')) {
         bot.chat(`/item replace block ${at} container.${slot} with ${name} ${count}`)
-      } else if (bot.registry.version['>=']('1.13')) {
-        bot.chat(`/replaceitem block ${at} container.${slot} ${name} ${count}`)
-      } else {
+      } else if (bot.supportFeature('replaceItemSlotIsPrefixed')) {
         bot.chat(`/replaceitem block ${at} slot.container.${slot} minecraft:${name} ${count}`)
+      } else {
+        bot.chat(`/replaceitem block ${at} container.${slot} ${name} ${count}`)
       }
     }
   }

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -240,8 +240,10 @@ module.exports = () => async (bot) => {
 
   fillChest(largeChestLocations[0])
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
-  for (const { slot, name, count } of layout) {
-    assert.strictEqual(window.slots[slot]?.name, name, `expected ${name} in chest slot ${slot}`)
+  // Which half of a double chest the window lists first depends on the version.
+  for (const { name, count } of layout) {
+    const slot = window.slots.findIndex((s, i) => i < window.inventoryStart && s?.name === name)
+    assert.notStrictEqual(slot, -1, `expected ${name} in the chest`)
     assert.strictEqual(window.slots[slot].count, count)
   }
   await testClickTransitions(window)


### PR DESCRIPTION
Stacked on #3974 (`fix-26.1-crafting-desync`); the base retargets to `master` once that merges.

`useChests` made **366 window clicks**, and roughly 350 of them asserted nothing.

### What the clicks were doing

| source | clicks | asserted |
|---|---|---|
| `createRandomLayout(0.95)` — ~51 items x `moveSlotItem` | ~102–120 | nothing; pure setup |
| `testMouseClick(250)` | 250 | nothing |
| deposit/withdraw x 8 | ~14 | deposit/withdraw across chest vs trapped, single vs double |

The fuzz loop was:

```js
await bot.clickWindow(~~(Math.random() * window.inventoryStart), 0, 0)
```

Every iteration was `mouseButton = 0`, `mode = 0`, varying only the slot, and the loop had no assertions — it failed only if `clickWindow` threw. That throw lives inside `if (bot.supportFeature('transactionPacketExists'))`, so from 1.17 onward there is no accept/reject to throw on at all, only `waitForWindowUpdate`. On 19 of the 28 tested versions it verified nothing beyond "did not time out".

The random layout existed only to give that loop something to click on.

### What replaces them

A left or right click resolves differently depending on whether the cursor is holding something and what is in the target slot, so a random click only ever reaches whichever case the current state happens to allow — repeating it does not change that. `testClickTransitions` drives each case from its own precondition and asserts the resulting slot and cursor contents:

| case | asserts |
|---|---|
| empty cursor + occupied slot | cursor takes the type and count, slot emptied |
| holding + empty slot, right click | exactly one lands, cursor keeps the rest |
| holding + matching stack | slot returns to the full count, cursor emptied |
| holding + different type | contents exchanged both ways |
| holding + empty slot | whole stack dropped |
| empty cursor + stack, right click | the halves account for the whole stack |
| shift click | chest slot emptied |

That covers right click and shift-click quick move — neither of which the old mode-0 loop reached.

The layout is now three fixed items, which is what those preconditions need. They are written server side (`/item replace block` on 1.17+, `/replaceitem block` on 1.13+, `slot.container` before that) and asserted once the window opens, so a wrong command fails loudly instead of silently under-filling.

### What the new assertions surfaced

Shrinking the layout and asserting on it exposed three things the old test could not see, each fixed in its own commit:

1. **Filling by clicking lost moves on 26.1.** `/give` + `moveSlotItem` depends on the client's predicted state, and from 1.17 a click is not confirmed per transaction. On 26.1 two of the three items never arrived while the client reported all three placed; with ~51 items that margin hid it. Hence the server-side fill above.
2. **Which half of a double chest the window lists first depends on the version.** On 1.8.8 it is the lower-coordinate block; on 1.13+ it follows the chest's facing, so the filled block's slots land at 27–29 instead of 0–2. The fill assertion now searches the container instead of assuming slots 0–2.
3. **mineflayer's shift click was rejected by every 1.12–1.16 vanilla server.** For `actionIdUsed` versions the server accepts a click only if the packet's `item` matches the result of its own `slotClick`; for a quick move that is the moved stack up to 1.11 and empty from 1.12, and mineflayer always sent the clicked stack. The old loop never sent mode 1, so nothing noticed. `lib/plugins/inventory.js` now sends an empty item for mode 1 from 1.12 on. (An earlier revision of this PR drew the line at 1.9; CI on 1.9.4–1.11.2 rejected that — those servers want the stack — and the harness retries turned the error into `Event close did not fire`.)
4. **Most of the test was the bot turning its head.** `openContainer` and `placeBlock` face the block before acting, and a non-forced look turns at 3 rad/s, so each 180° swing between the small chest behind the bot and the large chest in front costs ~1.05s. On 1.8.8 that was ~8.1s of the 13.4s — ten `openContainer` calls averaging 0.8s of rotation around ~100ms of server round trip. Nothing in the test asserts on looking and turn speed is not tested anywhere (the external tests that look pass `force=true`), so the test now sets `bot.physics.yawSpeed`/`pitchSpeed` high enough that a look resolves in one physics tick.

### Measurements

Test duration only:

| version | before | click rewrite | + instant look |
|---|---|---|---|
| 1.8.8 | 38323ms | 14746ms | **3596ms** |
| 1.9.4 | | | 3499ms |
| 1.11.2 | | | 3414ms |
| 1.12.2 | | | 3418ms |
| 1.16.5 | | | 1589ms |
| 26.1 | ~13.5s (CI) | 14376ms | CI |

366 clicks to 33 on 1.8.8.

Where the 14746ms went on 1.8.8, from a `mark()` after every awaited step: `placeBlock` ×6 3.3s, chest-lid test 1.1s (`wait(500)` + one open), deposit/withdraw ×8 8.1s — of which 7.2s was the eight `openContainer` turns and 0.9s the actual clicks — fill + open 0.3s, the nine asserted clicks 0.45s at one transaction tick each. The click saving is concentrated on old versions because each `clickWindow` waits for a `transaction` that arrives on the next tick (median gap 50ms up to 1.16, 0ms from 1.17); the turning cost is the physics tick and so the same on every version.

### Verification

Run against real servers locally, all passing:

| version | covers |
|---|---|
| 1.8.8 | `slot.container` fill, quick move acknowledged with the stack |
| 1.9.4, 1.11.2 | `slot.container` fill, quick move acknowledged with the stack (1.9–1.11) |
| 1.12.2 | `slot.container` fill, quick move acknowledged empty |
| 1.16.5 | `/replaceitem block` fill |
| 26.1 | `/item replace block` fill, no transaction acknowledgement — passed locally before the instant-look commit; the box used (8 GB) can no longer keep the 26.1 server ahead of its ticks, so CI is the check on it |

CI covers the remaining tiers.
