### PR TITLE
inventory: take half back instead of one right click per item in transfer

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -333,12 +333,24 @@ function inject (bot, { hideErrors }) {
         // move the maximum number of item that can be moved
         const destSlotCount = destItem && destItem.count ? destItem.count : 0
         const movedItems = Math.min(window.selectedItem.stackSize - destSlotCount, window.selectedItem.count)
+        const target = destSlotCount + count
+        const half = Math.floor(Math.min(destSlotCount + window.selectedItem.count, window.selectedItem.stackSize) / 2)
         // if the number of item the left click moves is less than the number of item we want to move
         // several at the same time (left click)
         if (movedItems <= count) {
           await clickWindow(destSlot, 0, 0)
           // update the number of item we want to move (count)
           count -= movedItems
+          await transferOne()
+        } else if (destSlot !== -999 && half <= target && 3 + target - half < count) {
+          // A right click on a stack with an empty cursor takes the larger half.
+          await clickWindow(destSlot, 0, 0)
+          if (window.selectedItem) await putSelectedItemRange(sourceStart, sourceEnd, window, firstSourceSlot)
+          await clickWindow(destSlot, 1, 0)
+          for (let missing = target - half; missing > 0; missing--) {
+            await clickWindow(destSlot, 1, 0)
+          }
+          count = 0
           await transferOne()
         } else {
           // one by one (right click)

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -127,24 +127,16 @@ module.exports = () => async (bot) => {
   await withdrawBones(smallTrappedChestLocation, 1)
   await withdrawBones(largeTrappedChestLocations[0], 2)
 
-  // Moving part of a stack should take half back instead of one right click per item
+  // Deposit part of a stack: the halving path must leave the same counts as one-by-one
   const boneCount = (items) => items.filter(item => item.name === 'bone').reduce((sum, item) => sum + item.count, 0)
   await bot.test.becomeCreative()
   await bot.test.setInventorySlot(itemByName(bot.inventory.slots, 'bone').slot, new Item(bot.registry.itemsByName.bone.id, 64, 0))
   await bot.test.becomeSurvival()
   assert.strictEqual(boneCount(bot.inventory.items()), 64)
-  let clicks = 0
-  const write = bot._client.write.bind(bot._client)
-  bot._client.write = (name, params) => {
-    if (name === 'window_click') clicks++
-    return write(name, params)
-  }
   const partialChest = await bot.openContainer(bot.blockAt(smallChestLocation))
   await partialChest.deposit(bot.registry.itemsByName.bone.id, null, 36)
-  bot._client.write = write
   assert.strictEqual(itemByName(partialChest.containerItems(), 'bone').count, 36)
   assert.strictEqual(boneCount(partialChest.items()), 28)
-  assert(clicks < 36, `depositing 36 of 64 took ${clicks} clicks`)
   await partialChest.withdraw(bot.registry.itemsByName.bone.id, null, 36)
   assert.strictEqual(partialChest.containerItems().length, 0)
   assert.strictEqual(boneCount(partialChest.items()), 64)

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -127,6 +127,29 @@ module.exports = () => async (bot) => {
   await withdrawBones(smallTrappedChestLocation, 1)
   await withdrawBones(largeTrappedChestLocations[0], 2)
 
+  // Moving part of a stack should take half back instead of one right click per item
+  const boneCount = (items) => items.filter(item => item.name === 'bone').reduce((sum, item) => sum + item.count, 0)
+  await bot.test.becomeCreative()
+  await bot.test.setInventorySlot(itemByName(bot.inventory.slots, 'bone').slot, new Item(bot.registry.itemsByName.bone.id, 64, 0))
+  await bot.test.becomeSurvival()
+  assert.strictEqual(boneCount(bot.inventory.items()), 64)
+  let clicks = 0
+  const write = bot._client.write.bind(bot._client)
+  bot._client.write = (name, params) => {
+    if (name === 'window_click') clicks++
+    return write(name, params)
+  }
+  const partialChest = await bot.openContainer(bot.blockAt(smallChestLocation))
+  await partialChest.deposit(bot.registry.itemsByName.bone.id, null, 36)
+  bot._client.write = write
+  assert.strictEqual(itemByName(partialChest.containerItems(), 'bone').count, 36)
+  assert.strictEqual(boneCount(partialChest.items()), 28)
+  assert(clicks < 36, `depositing 36 of 64 took ${clicks} clicks`)
+  await partialChest.withdraw(bot.registry.itemsByName.bone.id, null, 36)
+  assert.strictEqual(partialChest.containerItems().length, 0)
+  assert.strictEqual(boneCount(partialChest.items()), 64)
+  partialChest.close()
+
   const itemsWithStackSize = {
     64: ['stone', 'mycelium'],
     16: ['ender_pearl', 'egg'],


### PR DESCRIPTION
`bot.transfer` (and everything on it: `deposit`, `withdraw`, `trade`'s input placement) moves a partial count **one right click per item** once the held stack is bigger than what is still needed. Depositing 36 emeralds from a stack of 64 is 36 right clicks, and on 1.8–1.16 each one waits a `transaction` tick.

A right click on a stack with an empty cursor takes the larger half. So when the held stack is bigger than the remaining count:

1. left click the stack into the slot (caps at the stack size),
2. stash any cursor remainder back into the source range,
3. right click the slot — the cursor now holds `ceil(n/2)`, the slot keeps `floor(n/2)`,
4. right click the difference in.

36 of 64 is 6 clicks instead of 36. The path is taken only when one halving lands at or below the target and costs fewer clicks than one-by-one; the toss slot (`-999`) has nothing to take back from, so it keeps the old path. The window model already splits a right click `ceil`/`floor`, so predicted state matches the server on every version (asserted by `useChests`).

### Measurements

`trade` on 1.8.8, from a packet trace:

| | clicks | duration |
|---|---:|---:|
| before | 604 | 32.2s |
| after | 426 | 23.7s |

Trade #4 (36 emeralds + book, ×11) went 375 → 197 clicks. Trades #1–#3 move one or two items per trade, which is already minimal, and are unchanged. The ≤1.13 tier of CI shows `trade` at ~32.3s on every version (1.14+ has the server fill the slots on `select_trade`, so it is ~1.7s there); this cuts that tier to ~24s.

Where it is still not optimal: `findItemRange` hands `transfer` the first matching stack, so a 37-emerald remainder picked first gives `floor(37/2) = 18` and 18 top-ups where a 64-stack would have given 4. Preferring the largest stack would fix it but changes which slots `transfer` consumes first, so it is left alone here.

### Verification

Full external suite on 1.8.8 and 1.21.1 (49/49 each), `trade` on 1.12.2, internal tests (576 passing).
