### PR TITLE
test(trade): two trades per offer, and shift click in putAway

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -657,10 +657,19 @@ function inject (bot, { hideErrors }) {
   async function putAway (slot) {
     const window = bot.currentWindow || bot.inventory
     const promisePutAway = once(window, `updateSlot:${slot}`)
-    await clickWindow(slot, 0, 0)
     const start = window.inventoryStart
     const end = window.inventoryEnd
-    await putSelectedItemRange(start, end, window, null)
+    const item = window.slots[slot]
+    // A shift click on a result slot repeats the craft or trade while the
+    // inputs cover it, and does nothing when the inventory has no room.
+    const resultSlot = slot === window.craftingResultSlot || (window.type === 'minecraft:merchant' && slot === 2)
+    const room = item && (window.findItemRange(start, end, item.type, item.metadata, true, item.nbt) || window.firstEmptySlotRange(start, end) !== null)
+    if (room && !resultSlot) {
+      await clickWindow(slot, 0, 1)
+    } else {
+      await clickWindow(slot, 0, 0)
+      await putSelectedItemRange(start, end, window, null)
+    }
     await promisePutAway
   }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -623,8 +623,8 @@ function inject (bot, { hideErrors }) {
         mouseButton,
         action: actionId,
         mode,
-        // protocol expects null even if there is an item at the slot in mode 2 and 4
-        item: Item.toNotch((mode === 2 || mode === 4) ? null : click.item)
+        // Must match what the server's own click handling returns.
+        item: Item.toNotch((mode === 2 || mode === 4 || (mode === 1 && bot.supportFeature('quickMoveClickSendsEmptyItem'))) ? null : click.item)
       })
     } else { // 1.17
       bot._client.write('window_click', {

--- a/lib/plugins/villager.js
+++ b/lib/plugins/villager.js
@@ -189,7 +189,12 @@ function inject (bot, { version }) {
         }
       }
 
-      await bot.putAway(2)
+      if (bot.supportFeature('selectingTradeMovesItems')) {
+        await bot.putAway(2)
+      } else {
+        // A shift click on the output trades again while the inputs still cover the price.
+        await bot.clickWindow(2, 0, 1)
+      }
     }
 
     for (const i of [0, 1]) {

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -4,24 +4,27 @@ const { once } = require('../../lib/promise_utils')
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
+  const maxUses = 3
+  const trades = maxUses - 1 // each trade starts with one use spent
+
   const villagerType = bot.registry.entitiesByName.villager ? 'villager' : 'Villager'
   const testFluctuations = bot.supportFeature('selectingTradeMovesItems')
   // Item stacks are components on 1.20.5+; the NBT-era key is silently ignored.
   const countKey = bot.registry.version['>=']('1.20.5') ? 'count' : 'Count'
 
   const summonCommand = bot.supportFeature('indexesVillagerRecipes')
-    ? `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[0:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},uses: 1},1:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},2:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},3:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
-    : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},${testFluctuations ? 'demand:60,priceMultiplier:0.05f,specialPrice:-4,' : ''}uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
+    ? `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[0:{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},uses: 1},1:{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},2:{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},3:{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
+    : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},${testFluctuations ? 'demand:60,priceMultiplier:0.05f,specialPrice:-4,' : ''}uses: 1},{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},{maxUses:${maxUses},buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
 
   const commandBlockPos = bot.entity.position.offset(0.5, 0, 0.5)
   const redstoneBlockPos = commandBlockPos.offset(1, 0, 0)
 
   let shouldHaveEmeralds = 0
-  for (let slot = 9; slot <= 17; slot += 1) {
+  for (let slot = 9; slot <= 10; slot += 1) {
     await bot.test.setInventorySlot(slot, new Item(bot.registry.itemsByName.emerald.id, 64, 0))
     shouldHaveEmeralds += 64
   }
-  await bot.test.setInventorySlot(18, new Item(bot.registry.itemsByName.book.id, 11, 0))
+  await bot.test.setInventorySlot(18, new Item(bot.registry.itemsByName.book.id, trades, 0))
 
   // A command block is needed to spawn the villager due to the chat's character limit in some versions
   bot.test.sayEverywhere(`/setblock ${commandBlockPos.toArray().join(' ')} command_block`)
@@ -51,10 +54,10 @@ module.exports = () => async (bot) => {
     assert.strictEqual(output.name, 'pumpkin_pie')
     assert.strictEqual(output.count, 2)
 
-    await bot.trade(villager, 0, 11)
-    shouldHaveEmeralds -= testFluctuations ? (2 * 2 * 11) : (2 * 11)
+    await bot.trade(villager, 0, trades)
+    shouldHaveEmeralds -= testFluctuations ? (2 * 2 * trades) : (2 * trades)
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
-    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 22)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 2 * trades)
   }
 
   // Handle trade #2 -- takes [2x emerald, 2x pumpkin_pie] and returns 2x wheat
@@ -73,11 +76,11 @@ module.exports = () => async (bot) => {
     assert.strictEqual(output.name, 'wheat')
     assert.strictEqual(output.count, 2)
 
-    await bot.trade(villager, 1, 11)
-    shouldHaveEmeralds -= 11 * 2
+    await bot.trade(villager, 1, trades)
+    shouldHaveEmeralds -= trades * 2
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 0)
-    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wheat.id), 22)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wheat.id), 2 * trades)
   }
 
   // Handle trade #3 -- takes 1x emerald and returns 4x glass
@@ -94,10 +97,10 @@ module.exports = () => async (bot) => {
     assert.strictEqual(output.name, 'glass')
     assert.strictEqual(output.count, 4)
 
-    await bot.trade(villager, 2, 11)
-    shouldHaveEmeralds -= 11
+    await bot.trade(villager, 2, trades)
+    shouldHaveEmeralds -= trades
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
-    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.glass.id), 44)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.glass.id), 4 * trades)
   }
 
   // Handle trade #4 -- takes [36x emerald, 1x book] and returns 1x wooden sword
@@ -116,16 +119,16 @@ module.exports = () => async (bot) => {
     assert.strictEqual(output.name, 'wooden_sword')
     assert.strictEqual(output.count, 1)
 
-    await bot.trade(villager, 3, 11)
-    shouldHaveEmeralds -= 11 * 36
+    await bot.trade(villager, 3, trades)
+    shouldHaveEmeralds -= trades * 36
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.book.id), 0)
-    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wooden_sword.id), 11)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wooden_sword.id), trades)
   }
 
   function verifyTrade (trade) {
     assert.strictEqual(trade.nbTradeUses, 1)
-    assert.strictEqual(trade.maximumNbTradeUses, 12)
+    assert.strictEqual(trade.maximumNbTradeUses, maxUses)
     assert.strictEqual(trade.tradeDisabled, false)
 
     const printCountInv = function (item) {


### PR DESCRIPTION
Carries #3979's 2-line `inventory.js` fix as its first commit (identical patch, so git drops it when either lands): the shift click below needs the right mode-1 `item` on 1.12–1.16, gated on minecraft-data 3.115.0's `quickMoveClickSendsEmptyItem` feature, which master's `^3.114.0` already resolves to.

`trade` took ~32s on every version up to 1.13 and ~1.7s from 1.14. A packet trace on 1.8.8 put 21.3s of the 23.2s at exactly **one transaction tick per `clickWindow`** — 426 clicks × 50ms — and 1.9s in setup; there are no other waits in it. From 1.14 the server fills the input slots on `select_trade`, so the click loop never runs there.

Three changes, one commit each, after the carried fix:

**`putAway`: shift click** instead of pick-up-and-drop — the same move in one click, for every caller (furnace, enchantment table, anvil, the crafting-grid cleanup, `disrobe`, villager's input leftovers). Two carve-outs keep the old path: result slots, where a shift click repeats the craft or trade while the inputs cover it (`craftingResultSlot`, merchant slot 2), and a full inventory, where a shift click does nothing and the old path tosses the stack. Sending the right `item` for a mode-1 click on 1.12–1.16 is #3979's `inventory.js` fix, carried here as the first commit.

**`villager`: shift click the output** on <1.14, where `trade` deposits exactly the price per iteration so the repeat cannot happen; from 1.14 the server pre-fills whole stacks and it stays on `putAway`. This is the one place that knows the inputs hold a single trade, which is why it is not folded into `putAway`.

**`test(trade)`: two trades per offer instead of eleven.** The test checks `nbTradeUses`, `maximumNbTradeUses`, the item arithmetic after trading, and that an exhausted offer is refused; none of that needs eleven rounds. `maxUses: 3` with one use already spent gives two, and the refusal at the end still fires. Two emerald stacks cover the 86 needed, so eight of the ten `setInventorySlot` calls go too (each is 400ms on 1.21.3+).

### Measurements

1.8.8, test duration only, from the traces:

| | clicks | duration |
|---|---:|---:|
| before | 604 | 32.2s |
| after | 101 | 7.1s |

Where the 6.6s traced goes now: 101 clicks 5.05s (trade #4 alone 67 — its 36-emerald deposit is still one right click per item; #3982 halves that independently), command block `wait(500)` ×2 1.04s, redstone → `entitySpawn` 0.35s, `setInventorySlot` ×3 0.14s.

### Verification

`trade` on 1.8.8 (7113ms), 1.9.4 (6856ms), 1.12.2 (7173ms), 1.16.5 (1909ms), 1.21.1 (1690ms) — the stack-ack tier, the empty-ack tier, the 1.14–1.16 `putAway` tier, and the no-ack tier. With the `putAway` change: full external suite on 1.8.8 and 1.21.1 (49/49 each), `trade`/`furnace`/`crafting` on 1.12.2, internal tests.

After rebasing on master: `trade` on 1.8.8, 1.12.2, 1.16.5, 1.21.4; `furnace` and `crafting` on 1.12.2.
