### PR TITLE
test: wait for conditions instead of sleeping in the example tests

### DIFF
--- a/test/externalTests/exampleInventory.js
+++ b/test/externalTests/exampleInventory.js
@@ -51,19 +51,16 @@ module.exports = () => async (bot) => {
     assert.strictEqual(name, 'inventory')
     bot.chat('/op inventory') // to counteract spawn protection
     bot.chat('/clear inventory')
-    bot.chat(`/setblock 52 ${bot.test.groundY} 0 crafting_table`) // to make stone bricks stairs
+    await bot.test.setBlock({ x: 52, y: bot.test.groundY, z: 0, blockName: 'crafting_table' })
     bot.chat('/give inventory dirt 64')
     bot.chat('/give inventory stick 7')
     bot.chat('/give inventory iron_ore 64')
     bot.chat('/give inventory diamond_boots 1')
-    await bot.test.wait(2000)
     if (bot.registry.isOlderThan('1.9')) {
       tests.splice(tests.indexOf(tests.find(t => t.command.includes('off-hand'))), 2) // Delete off-hand command and the command after it as they don't work in 1.9
     }
-    const testFuncs = tests.map(test => makeTest(test.command, test.wantedMessage))
-    for (const test of testFuncs) {
-      await test()
-      await bot.test.wait(100)
+    for (const test of tests) {
+      await makeTest(test.command, test.wantedMessage)()
     }
     // cleanup
     bot.chat(`/setblock 52 ${bot.test.groundY} 0 air`)

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -239,9 +239,6 @@ function inject (bot, wrap) {
              bot.players[childBotName].entity.position.distanceTo(targetPos) > 5) {
         await sleep(100)
       }
-      // Let the child's physics engine initialize at the new position
-      // (ground detection, chunk processing) before starting the test
-      await bot.waitForTicks(60)
       bot.chat('loaded')
     }
 


### PR DESCRIPTION
`exampleInventory` took 7.9s on 1.21.1. From a packet trace, 6.1s of that was three fixed sleeps and the eleven chat round trips the test exists for took about 40ms:

| | ms |
|---|---:|
| spawn the example, log in, `player joined` | 971 |
| `/tp` + poll for the entity, then **`waitForTicks(60)`** in `runExample` | 3058 |
| **`wait(2000)`** after the `/give`s | 2001 |
| 11 commands — replies land 1–6ms after each | ~40 |
| `craft 1 ladder` → "did the recipe" (the one real wait) | 545 |
| **`wait(100)` × 11** between commands | 1100 |
| teardown | ~280 |

### `runExample`: drop the 60 ticks

Every example answers `loaded` with `await bot.waitForChunksToLoad()` before `Ready!`, so the child is ready at its new position by the time the harness hears it; the 3s on top repeated that condition. All four example tests paid it.

### `exampleInventory`: wait for the crafting table, not the clock

Removing the sleeps exposed one real ordering: **the crafting table has to reach the child before `craft`.** Sent 35ms before the craft command it sometimes had not, and the child answered "I cannot make ladder" (about 1 run in 5). `bot.test.setBlock` waits for the block update, which the child receives before any later chat.

The gives need no wait of their own — `/give` calls `broadcastChanges()` on the receiving player before it answers, so the child's inventory is synced before flatbot even sees the acknowledgement. Every other gap was already reply-driven.

### Measurements

Test duration only:

| test | version | before | after |
|---|---|---:|---:|
| exampleInventory | 1.21.1 | 7900ms | 1568–1933ms (12 runs) |
| exampleInventory | 1.8.8 | 8900ms | ~3480ms |
| exampleBee | 1.21.1 / 1.8.8 | 8703 / 9019ms | 5740 / 5811ms |
| exampleDigger | 1.21.1 / 1.8.8 | 6013 / 6493ms | 3005 / 3527ms |
| exampleBlockFinder | 1.21.1 / 1.8.8 | 5765 / 6196ms | 3154 / 3287ms |

What is left in `exampleInventory` on 1.21.1 is ~0.7–1.0s of node starting the example and logging in, ~0.2s for the teleport to be visible, ~0.1s for the child's own chunk wait, the 0.55s craft, and the teardown.

### Verification

`exampleInventory` 12/12 on 1.21.1 and 3/3 on 1.8.8 after the fix; all four example tests on 1.21.1 and 1.8.8.
