### PR TITLE
health: send player_loaded on spawn so 1.21.4+ servers accept interactions immediately

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -8,9 +8,16 @@ function inject (bot, options) {
     bot.emit('respawn')
   })
 
+  // 1.21.4+ servers ignore block and item interactions until the client has
+  // sent player_loaded (or 60 ticks have passed)
+  function spawn () {
+    if (bot.supportFeature('sendsPlayerLoadedPacket')) bot._client.write('player_loaded', {})
+    bot.emit('spawn')
+  }
+
   bot._client.once('update_health', (packet) => {
     if (packet.health > 0) {
-      bot.emit('spawn')
+      spawn()
     }
   })
 
@@ -28,7 +35,7 @@ function inject (bot, options) {
       bot.respawn()
     } else if (bot.health > 0 && !bot.isAlive) {
       bot.isAlive = true
-      bot.emit('spawn')
+      spawn()
     }
   })
 


### PR DESCRIPTION
Since 1.21.4 the vanilla server ignores \`use_item\`, \`block_place\` and \`player_action\` until the client has sent \`player_loaded\` or 60 ticks have passed (\`ServerPlayer.clientLoadedTimeoutTimer\`). Mineflayer never sent it, so a bot's first 3 seconds of block/item interactions were silently dropped — e.g. \`bot.craft()\` on a freshly spawned bot hangs forever because the crafting table's \`block_place\` gets no \`open_window\` back.

This sends \`player_loaded\` right before each \`spawn\` event (login and respawn/dimension change), gated on minecraft-data's \`sendsPlayerLoadedPacket\` feature.

Found while removing the sleeps in the example tests (#3984): \`exampleInventory\` and \`exampleDigger\` only passed on 26.1 because \`testCommon\` slept exactly 60 ticks after teleporting the child bot. With this change they pass without the sleep, and on 26.1 \`exampleDigger\` goes 7.9s→3.2s, \`exampleInventory\` 6.0s→2.2s, \`fishing\` 20.8s→13.6s (its first cast was also being dropped).