### PR TITLE
test: always write the packet trace, defaulting to a timestamped file in tmpdir

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -8,9 +8,16 @@ function inject (bot, options) {
     bot.emit('respawn')
   })
 
+  // 1.21.4+ servers ignore block and item interactions until the client has
+  // sent player_loaded (or 60 ticks have passed)
+  function spawn () {
+    if (bot.supportFeature('sendsPlayerLoadedPacket')) bot._client.write('player_loaded', {})
+    bot.emit('spawn')
+  }
+
   bot._client.once('update_health', (packet) => {
     if (packet.health > 0) {
-      bot.emit('spawn')
+      spawn()
     }
   })
 
@@ -28,7 +35,7 @@ function inject (bot, options) {
       bot.respawn()
     } else if (bot.health > 0 && !bot.isAlive) {
       bot.isAlive = true
-      bot.emit('spawn')
+      spawn()
     }
   })
 

--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -1,0 +1,28 @@
+// TRACE=<file> writes one JSON stream for analysis with jq afterwards:
+//   {"ts":...,"type":"PACKET","dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
+//   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
+//   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
+const fs = require('fs')
+
+let stream
+const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
+
+function emit (record) {
+  if (!process.env.TRACE) return
+  stream = stream ?? fs.createWriteStream(process.env.TRACE, { flags: 'w' })
+  stream.write(`${JSON.stringify({ ts: Date.now(), ...record }, bigintSafe)}\n`)
+}
+
+function write (type, name, data = null) {
+  emit({ type, name, data })
+}
+
+function packet (dir, name, data) {
+  emit({ type: 'PACKET', dir, name, data })
+}
+
+function log (msg, args) {
+  emit({ type: 'LOG', msg, args })
+}
+
+module.exports = { write, packet, log }

--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -1,15 +1,23 @@
-// TRACE=<file> writes one JSON stream for analysis with jq afterwards:
+// Writes one JSON stream for analysis with jq afterwards (path is printed when first opened;
+// override it with TRACE=<file>):
 //   {"ts":...,"type":"PACKET","dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
 //   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
 //   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+// pid keeps concurrent mocha processes (one per version in CI) from sharing a file
+const file = process.env.TRACE ?? path.join(os.tmpdir(), `mineflayer-trace-${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}.jsonl`)
 
 let stream
 const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
 
 function emit (record) {
-  if (!process.env.TRACE) return
-  stream = stream ?? fs.createWriteStream(process.env.TRACE, { flags: 'w' })
+  if (!stream) {
+    stream = fs.createWriteStream(file, { flags: 'w' })
+    console.log(`trace: ${file}`)
+  }
   stream.write(`${JSON.stringify({ ts: Date.now(), ...record }, bigintSafe)}\n`)
 }
 

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -27,6 +27,9 @@ const propOverrides = {
   'spawn-monsters': 'false',
   'generate-structures': 'false',
   'enable-command-block': 'true',
+  // 8 is the floor: nether portal travel force-generates ±128 blocks (8 chunks)
+  // regardless, and blockfinder.js findBlocks uses maxDistance 128
+  'view-distance': '8',
   'use-native-transport': 'false' // java 16 throws errors without this, https://www.spigotmc.org/threads/unable-to-access-address-of-buffer.311602
 }
 

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -35,6 +35,22 @@ const download = require('minecraft-wrap').download
 
 const MC_SERVER_PATH = path.join(__dirname, 'server')
 
+// wrap's start callback fires on the server's "Done" log line, which precedes
+// the server answering status requests — by ~80ms on 26.1. That gap is version
+// dependent, so retry rather than sleep a fixed time, and keep closeTimeout well
+// under the 120s hook budget so the retries fit.
+async function pingUntilReady (port, host, version, attempts = 5) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await mc.ping({ port, host, version, closeTimeout: 5 * 1000 })
+    } catch (err) {
+      console.log(`ping attempt ${attempt} failed: ${err.message}`)
+      if (attempt === attempts) throw err
+      await new Promise(resolve => setTimeout(resolve, 250))
+    }
+  }
+}
+
 for (const supportedVersion of mineflayer.testedVersions) {
   let PORT = 25565
   const registry = require('prismarine-registry')(supportedVersion)
@@ -105,23 +121,15 @@ for (const supportedVersion of mineflayer.testedVersions) {
             if (err) return done(err)
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
             trace.log('server started, pinging')
-            mc.ping({
-              port: PORT,
-              host: '127.0.0.1',
-              version: supportedVersion,
-              // fail well before the mocha hook timeout (120s) so a hung ping
-              // surfaces as an ETIMEDOUT error instead of a silent hook timeout
-              closeTimeout: 30 * 1000
-            }, (err, results) => {
-              if (err) {
-                trace.log('ping failed', { error: err?.message ?? String(err) })
-                return done(err)
-              }
+            pingUntilReady(PORT, '127.0.0.1', supportedVersion).then(results => {
               console.log('pong')
               trace.log('pong', { latency: results.latency })
               assert.ok(results.latency >= 0)
               assert.ok(results.latency <= 1000)
               begin()
+            }).catch(err => {
+              trace.log('ping failed', { error: err?.message ?? String(err) })
+              done(err)
             })
           })
         })

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -8,6 +8,7 @@ const fs = require('fs')
 const path = require('path')
 
 const { getPort } = require('./common/util')
+const trace = require('./common/trace')
 const { once } = require('../lib/promise_utils')
 
 // set this to false if you want to test without starting a server automatically
@@ -66,8 +67,14 @@ for (const supportedVersion of mineflayer.testedVersions) {
         bot.test.port = PORT
 
         console.log('starting bot')
+        trace.log('bot created')
+        bot._client.on('connect', () => trace.log('bot tcp connected'))
+        bot._client.on('error', err => trace.log('bot client error', { error: err?.message ?? String(err) }))
+        bot._client.on('end', reason => trace.log('bot client ended', { reason }))
+        bot.once('login', () => trace.log('bot logged in'))
         bot.once('spawn', () => {
           console.log('bot spawned, opping...')
+          trace.log('bot spawned, opping')
           wrap.writeServer('op flatbot\n')
           if (bot.supportFeature('gameRuleUsesResourceLocation')) {
             wrap.writeServer('gamerule minecraft:spawn_monsters false\n')
@@ -76,6 +83,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
           bot.once('messagestr', msg => {
             if (msg.includes('Made flatbot a server operator') || msg === '[Server: Opped flatbot]') {
+              trace.log('bot opped, setup done')
               done()
             }
           })
@@ -84,23 +92,33 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       if (START_THE_SERVER) {
         console.log('downloading and starting server')
+        trace.log('downloading server jar', { version: version.minecraftVersion, port: PORT })
         download(version.minecraftVersion, MC_SERVER_JAR, (err) => {
           if (err) {
             console.log(err)
             done(err)
             return
           }
+          trace.log('server jar downloaded, starting server')
           propOverrides['server-port'] = PORT
           wrap.startServer(propOverrides, (err) => {
             if (err) return done(err)
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
+            trace.log('server started, pinging')
             mc.ping({
               port: PORT,
               host: '127.0.0.1',
-              version: supportedVersion
+              version: supportedVersion,
+              // fail well before the mocha hook timeout (120s) so a hung ping
+              // surfaces as an ETIMEDOUT error instead of a silent hook timeout
+              closeTimeout: 30 * 1000
             }, (err, results) => {
-              if (err) return done(err)
+              if (err) {
+                trace.log('ping failed', { error: err?.message ?? String(err) })
+                return done(err)
+              }
               console.log('pong')
+              trace.log('pong', { latency: results.latency })
               assert.ok(results.latency >= 0)
               assert.ok(results.latency <= 1000)
               begin()

--- a/test/externalTests/consume.js
+++ b/test/externalTests/consume.js
@@ -1,9 +1,10 @@
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
-  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.bread.id, 5, 0))
+  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.bread.id, 1, 0))
   await bot.test.becomeSurvival()
   // Cannot consume if bot.food === 20
   await assert.rejects(bot.consume, (err) => {
@@ -17,18 +18,18 @@ module.exports = () => async (bot) => {
 
   await bot.test.becomeSurvival()
 
-  while (bot.food > 0) {
+  // Drain a little hunger so consuming is legal, waiting on the food update
+  // instead of polling on a fixed sleep. One bread is enough to show the
+  // consume state transitions; eating back to 20 re-runs the identical path.
+  while (bot.food === 20) {
     if (bot.supportFeature('effectAreNotPrefixed')) bot.test.sayEverywhere('/effect give @s hunger 1 255')
     else if (bot.supportFeature('effectAreMinecraftPrefixed')) bot.test.sayEverywhere(`/effect ${bot.username} minecraft:hunger 1 255`)
-    await bot.test.wait(500)
+    await onceWithCleanup(bot, 'health', { timeout: 5000 })
   }
 
   assert.ok(!bot.usingHeldItem)
-  while (bot.food < 20) {
-    const consume = bot.consume()
-    assert.ok(bot.usingHeldItem)
-    await consume
-    assert.ok(!bot.usingHeldItem)
-    await bot.test.wait(100)
-  }
+  const consume = bot.consume()
+  assert.ok(bot.usingHeldItem)
+  await consume
+  assert.ok(!bot.usingHeldItem)
 }

--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -13,31 +13,6 @@ module.exports = () => async (bot) => {
   }
   assert.notStrictEqual(signItem, null)
 
-  const p = new Promise((resolve, reject) => {
-    bot._client.once('open_sign_entity', (packet) => {
-      console.log('Open sign', packet)
-      const sign = bot.blockAt(new Vec3(packet.location))
-      bot.updateSign(sign, '1\n2\n3\n')
-
-      setTimeout(() => {
-        // Get updated sign
-        const sign = bot.blockAt(bot.entity.position)
-        console.log('Updated sign', sign)
-
-        assert.strictEqual(sign.signText.trimEnd(), '1\n2\n3')
-
-        if (sign.blockEntity) {
-          // Check block update
-          bot.activateBlock(sign)
-          assert.notStrictEqual(sign.blockEntity, undefined)
-        }
-
-        bot.chat(`/setblock ~ ~ ~ ${portalName}`)
-        onceWithCleanup(bot, 'spawn', { timeout: 30000 }).then(resolve).catch(reject)
-      }, 500)
-    })
-  })
-
   // A portal's link goes inert after a failed attempt at the same spot, so
   // each retry must use a fresh location or it is guaranteed to time out.
   bot.test.netherAttempts ??= 0
@@ -61,5 +36,31 @@ module.exports = () => async (bot) => {
   await bot.lookAt(lowerBlock.position, true)
   await bot.test.setInventorySlot(36, new Item(signItem.id, 1, 0))
   await bot.placeBlock(lowerBlock, new Vec3(0, 1, 0))
-  await p
+
+  // By the time placeBlock's block update echo has arrived, the server has
+  // already opened the sign editor for us, so the text can be sent right away.
+  const sign = bot.blockAt(lowerBlock.position.offset(0, 1, 0))
+  bot.updateSign(sign, '1\n2\n3\n')
+
+  // Poll for the server echoing the new text back rather than sleeping a
+  // fixed time: it usually lands within a tick, but can take longer on
+  // slow CI.
+  const deadline = Date.now() + 5000
+  let updated = bot.blockAt(sign.position)
+  while (updated.signText?.trimEnd() !== '1\n2\n3' && Date.now() < deadline) {
+    await sleep(50)
+    updated = bot.blockAt(sign.position)
+  }
+  console.log('Updated sign', updated)
+
+  assert.strictEqual(updated.signText.trimEnd(), '1\n2\n3')
+
+  if (updated.blockEntity) {
+    // Check block update
+    bot.activateBlock(updated)
+    assert.notStrictEqual(updated.blockEntity, undefined)
+  }
+
+  bot.chat(`/setblock ~ ~ ~ ${portalName}`)
+  await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
 }

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -14,22 +14,20 @@ function inject (bot, wrap) {
   console.log(bot.version)
 
   bot.test = {}
-  if (process.env.TRACE) {
-    bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
-    const oldWrite = bot._client.write
-    bot._client.write = function (name, data) {
-      trace.packet('C2S', name, data)
-      oldWrite.apply(this, arguments)
-    }
-    bot.test.dumpMarker = msg => trace.log(msg)
-    bot.once('spawn', () => {
-      const orig = bot.inventory.updateSlot.bind(bot.inventory)
-      bot.inventory.updateSlot = (slot, item) => {
-        trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
-        return orig(slot, item)
-      }
-    })
+  bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
+  const oldWrite = bot._client.write
+  bot._client.write = function (name, data) {
+    trace.packet('C2S', name, data)
+    oldWrite.apply(this, arguments)
   }
+  bot.test.dumpMarker = msg => trace.log(msg)
+  bot.once('spawn', () => {
+    const orig = bot.inventory.updateSlot.bind(bot.inventory)
+    bot.inventory.updateSlot = (slot, item) => {
+      trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
+      return orig(slot, item)
+    }
+  })
   bot.test.groundY = bot.supportFeature('tallWorld') ? -60 : 4
   bot.test.sayEverywhere = sayEverywhere
   bot.test.clearInventory = clearInventory

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -5,6 +5,7 @@ const { once } = require('../../../lib/promise_utils')
 const process = require('process')
 const assert = require('assert')
 const { sleep, onceWithCleanup } = require('../../../lib/promise_utils')
+const trace = require('../../common/trace')
 
 const timeout = 5000
 module.exports = inject
@@ -13,27 +14,18 @@ function inject (bot, wrap) {
   console.log(bot.version)
 
   bot.test = {}
-  // TRACE=<file> writes one JSON stream for analysis with jq afterwards:
-  //   {"ts":...,"dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
-  //   {"ts":...,"dir":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
-  //   {"ts":...,"dir":"MARKER","name":"### Starting <test>"}     test boundaries
-  let dumpStream
   if (process.env.TRACE) {
-    const fs = require('fs')
-    const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
-    dumpStream = fs.createWriteStream(process.env.TRACE, { flags: 'w' })
-    const write = (dir, name, data) => dumpStream.write(`${JSON.stringify({ ts: Date.now(), dir, name, data }, bigintSafe)}\n`)
-    bot._client.on('packet', (data, meta) => write('S2C', meta.name, data))
+    bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
     const oldWrite = bot._client.write
     bot._client.write = function (name, data) {
-      write('C2S', name, data)
+      trace.packet('C2S', name, data)
       oldWrite.apply(this, arguments)
     }
-    bot.test.dumpMarker = name => write('MARKER', name, null)
+    bot.test.dumpMarker = msg => trace.log(msg)
     bot.once('spawn', () => {
       const orig = bot.inventory.updateSlot.bind(bot.inventory)
       bot.inventory.updateSlot = (slot, item) => {
-        write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
+        trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
         return orig(slot, item)
       }
     })

--- a/test/externalTests/time.js
+++ b/test/externalTests/time.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { once, onceWithCleanup } = require('../../lib/promise_utils')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   // Test time properties and ranges
@@ -29,22 +29,14 @@ module.exports = () => async (bot) => {
 
   // Helper functions
   const isTimeClose = (current, target) => Math.abs(current - target) < 510
-  const isTimeInRange = (current, start, end) => start <= end ? current >= start && current <= end : current >= start || current <= end
-  const waitForTime = async (expectedTime) => {
-    // Wait for a time event that matches our expectation (if provided)
-    // This helps avoid race conditions where we catch an old time update
-    if (expectedTime !== undefined) {
-      await onceWithCleanup(bot, 'time', {
-        timeout: 5000,
-        checkCondition: () => isTimeClose(bot.time.timeOfDay, expectedTime)
-      })
-    } else {
-      await once(bot, 'time')
-    }
-  }
+  // update_time is the only carrier of world time and doDaylightCycle, and
+  // vanilla broadcasts it once every 20 ticks, so each wait costs a full tick
+  // interval on servers that do not echo commands.
+  const waitForTimeState = async (matches) =>
+    onceWithCleanup(bot, 'time', { timeout: 5000, checkCondition: matches })
 
-  // Helper to set gamerule using the correct name for the version
-  const setDaylightCycle = (value) => {
+  // The gamerule is renamed on versions with gameRuleUsesResourceLocation.
+  const sendSetDaylightCycleCommand = (value) => {
     if (bot.supportFeature('gameRuleUsesResourceLocation')) {
       bot.test.sayEverywhere(`/gamerule minecraft:advance_time ${value}`)
     } else {
@@ -55,63 +47,32 @@ module.exports = () => async (bot) => {
   // Disable daylight cycle before time transition tests to prevent
   // time from drifting between /time set and the assertion
   const originalDaylightCycle = bot.time.doDaylightCycle
-  setDaylightCycle(false)
-  await waitForTime()
 
-  // Test time transitions
-  const timeTests = [
-    { time: 18000, name: 'midnight', isDay: false },
-    { time: 6000, name: 'noon', isDay: true },
-    { time: 12000, name: 'sunset', isDay: true },
-    { time: 0, name: 'sunrise', isDay: true }
-  ]
-
-  for (const test of timeTests) {
-    bot.test.sayEverywhere(`/time set ${test.time}`)
-    await waitForTime(test.time)
-    assert(isTimeClose(bot.time.timeOfDay, test.time), `Expected time to be close to ${test.time}, got ${bot.time.timeOfDay}`)
-    assert.strictEqual(bot.time.isDay, test.isDay, `${test.name} should be ${test.isDay ? 'day' : 'night'}`)
-  }
-
-  // Re-enable daylight cycle for progression test
-  setDaylightCycle(true)
-  await waitForTime()
-
-  // Test day and moon phase progression
-  const currentDay = bot.time.day
-  const currentPhase = bot.time.moonPhase
-  bot.test.sayEverywhere('/time add 24000')
-  await waitForTime()
-  assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
-  assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
-
-  // Test daylight cycle toggle
-  setDaylightCycle(false)
-  await waitForTime()
+  // Night with the cycle off: covers isDay false and doDaylightCycle false.
+  sendSetDaylightCycleCommand(false)
+  bot.test.sayEverywhere('/time set 18000')
+  await waitForTimeState(() => isTimeClose(bot.time.timeOfDay, 18000))
+  assert(isTimeClose(bot.time.timeOfDay, 18000), `Expected time to be close to 18000, got ${bot.time.timeOfDay}`)
+  assert.strictEqual(bot.time.isDay, false, 'midnight should be night')
   assert.strictEqual(bot.time.doDaylightCycle, false)
 
-  setDaylightCycle(originalDaylightCycle)
-  await waitForTime()
-  assert.strictEqual(bot.time.doDaylightCycle, originalDaylightCycle)
+  // 12000 is the last tick that still counts as day.
+  bot.test.sayEverywhere('/time set 12000')
+  await waitForTimeState(() => isTimeClose(bot.time.timeOfDay, 12000))
+  assert(isTimeClose(bot.time.timeOfDay, 12000), `Expected time to be close to 12000, got ${bot.time.timeOfDay}`)
+  assert.strictEqual(bot.time.isDay, true, 'sunset should be day')
 
-  // Disable daylight cycle again for day/night range tests
-  setDaylightCycle(false)
-  await waitForTime()
+  // Day and moon phase progression, and doDaylightCycle true.
+  // Must be read before the commands below mutate them.
+  const currentDay = bot.time.day
+  const currentPhase = bot.time.moonPhase
+  sendSetDaylightCycleCommand(true)
+  bot.test.sayEverywhere('/time add 24000')
+  await waitForTimeState(() => bot.time.day >= currentDay + 1)
+  assert(bot.time.day >= currentDay + 1, `Expected day to be at least ${currentDay + 1}, got ${bot.time.day}`)
+  assert.notStrictEqual(bot.time.moonPhase, currentPhase, 'Moon phase should change after a full day')
+  assert.strictEqual(bot.time.doDaylightCycle, true)
 
-  // Test day/night transitions
-  const dayNightTests = [
-    { command: 'day', range: [0, 12000], isDay: true },
-    { command: 'night', range: [12000, 24000], isDay: false }
-  ]
-
-  for (const test of dayNightTests) {
-    bot.test.sayEverywhere(`/time set ${test.command}`)
-    await waitForTime()
-    assert(isTimeInRange(bot.time.timeOfDay, test.range[0], test.range[1]), `Time should be in ${test.command} range`)
-    assert.strictEqual(bot.time.isDay, test.isDay, `${test.command} should be ${test.isDay ? 'day' : 'night'}`)
-  }
-
-  // Restore original daylight cycle setting
-  setDaylightCycle(originalDaylightCycle)
-  await waitForTime()
+  // Restore for later tests; the server applies it without the client waiting.
+  sendSetDaylightCycleCommand(originalDaylightCycle)
 }


### PR DESCRIPTION
Stacked on #3973.

The TRACE jsonl was opt-in, so a flaky local run left nothing to look at unless you remembered to set `TRACE` beforehand — the same gap CI closed by always setting it. Recording is cheap (<1% runtime), so default it on:

- `TRACE=<file>` still overrides the path; otherwise the trace goes to `<tmpdir>/mineflayer-trace-<ISO timestamp>-<pid>.jsonl`. The pid suffix keeps concurrent mocha processes (one per version in CI) apart.
- The path is printed (`trace: /tmp/...`) when the stream first opens, i.e. right under the `mineflayer_external <v>` title.
- With no disabled state the `if (process.env.TRACE)` guards go away; `bot.test.dumpMarker` is now always defined.

CI is unchanged — it still sets `TRACE` explicitly so the artifact copy keeps working.