### PR TITLE
test(fishing): give the rod Lure III to cut the bite wait

### DIFF
--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -2,13 +2,13 @@ module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
   bot.test.sayEverywhere('/fill ~-10 ~-1 ~-10 ~10 ~-1 ~10 water')
-  bot.test.sayEverywhere('/weather rain') // rain shortens the vanilla bite wait; the rain test clears weather before asserting
+  bot.test.sayEverywhere('/weather rain') // rain shortens the vanilla bite wait
   await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0))
   await bot.test.awaitItemReceived('/enchant @a minecraft:lure 3')
   await bot.lookAt(bot.entity.position) // dont force the position
   bot.fish()
 
-  return new Promise((resolve, reject) => {
+  await new Promise((resolve, reject) => {
     function onPlayerCollect (collector, collected) {
       if (collected.name.toLowerCase() === 'item' || collected.type === 'object') {
         bot.test.sayEverywhere('I caught: ' + collected.displayName)
@@ -18,4 +18,6 @@ module.exports = () => async (bot) => {
     }
     bot.on('playerCollect', onPlayerCollect)
   })
+
+  bot.test.sayEverywhere('/weather clear')
 }

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -2,6 +2,7 @@ module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
   bot.test.sayEverywhere('/fill ~-10 ~-1 ~-10 ~10 ~-1 ~10 water')
+  bot.test.sayEverywhere('/weather rain') // rain shortens the vanilla bite wait; the rain test clears weather before asserting
   await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0))
   await bot.test.awaitItemReceived('/enchant @a minecraft:lure 3')
   await bot.lookAt(bot.entity.position) // dont force the position

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -3,6 +3,7 @@ module.exports = () => async (bot) => {
 
   bot.test.sayEverywhere('/fill ~-10 ~-1 ~-10 ~10 ~-1 ~10 water')
   await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0))
+  await bot.test.awaitItemReceived('/enchant @a minecraft:lure 3')
   await bot.lookAt(bot.entity.position) // dont force the position
   bot.fish()
 


### PR DESCRIPTION
The fishing test is the slowest test in the external suite: it casts an unenchanted rod and waits out the full vanilla bite delay of 5–30 seconds. Lure III takes 15 seconds off that delay, so the wait becomes 0–15 seconds.

Measured on 26.1: 33s before; 13s, 14.5s, 19s across three runs after.

`/enchant` on the held rod works on every tested version (1.8–26.1), unlike prismarine-item's `enchants` setter, which writes NBT that `set_creative_slot` no longer carries on 1.20.5+ (components). `awaitItemReceived` waits for the server's `set_slot` echo so the rod is enchanted before the cast.