### PR TITLE
Speed up furnace external test by fast-forwarding CookTime

### DIFF
--- a/test/externalTests/furnace.js
+++ b/test/externalTests/furnace.js
@@ -51,12 +51,11 @@ module.exports = () => async (bot) => {
   // The furnace only completes on cookTime == totalCookTime (not >=), so the
   // merged value must stay below 200.
   const { x, y, z } = furnacePos
-  if (bot.registry.version['>=']('1.21.4')) {
-    bot.chat(`/data merge block ${x} ${y} ${z} {cooking_time_spent:195s}`)
-  } else if (bot.registry.version['>=']('1.13')) {
-    bot.chat(`/data merge block ${x} ${y} ${z} {CookTime:195s}`)
+  const cookTimeKey = bot.supportFeature('furnaceNbtUsesSnakeCase') ? 'cooking_time_spent' : 'CookTime'
+  if (bot.supportFeature('hasDataCommand')) {
+    bot.chat(`/data merge block ${x} ${y} ${z} {${cookTimeKey}:195s}`)
   } else {
-    bot.chat(`/blockdata ${x} ${y} ${z} {CookTime:195s}`)
+    bot.chat(`/blockdata ${x} ${y} ${z} {${cookTimeKey}:195s}`)
   }
   // The 5 remaining ticks complete in 250-320ms on every tested version; a
   // timeout means the merge was silently ignored.

--- a/test/externalTests/furnace.js
+++ b/test/externalTests/furnace.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
@@ -47,7 +48,19 @@ module.exports = () => async (bot) => {
   assert(furnace.fuel > 0 && furnace.fuel < 1)
   assert(furnace.progress > 0 && furnace.progress < 1)
 
-  await bot.test.wait(furnace.progressSeconds * 1000 + 500)
+  // The furnace only completes on cookTime == totalCookTime (not >=), so the
+  // merged value must stay below 200.
+  const { x, y, z } = furnacePos
+  if (bot.registry.version['>=']('1.21.4')) {
+    bot.chat(`/data merge block ${x} ${y} ${z} {cooking_time_spent:195s}`)
+  } else if (bot.registry.version['>=']('1.13')) {
+    bot.chat(`/data merge block ${x} ${y} ${z} {CookTime:195s}`)
+  } else {
+    bot.chat(`/blockdata ${x} ${y} ${z} {CookTime:195s}`)
+  }
+  // The 5 remaining ticks complete in 250-320ms on every tested version; a
+  // timeout means the merge was silently ignored.
+  await onceWithCleanup(furnace, 'update', { timeout: 500, checkCondition: () => furnace.outputItem() !== null })
   assert.strictEqual(furnace.outputItem(), furnace.slots[2])
   assert.strictEqual(furnace.outputItem().type, cookedPorkchopId)
   assert.strictEqual(furnace.outputItem().count, 1)


### PR DESCRIPTION
The furnace external test spent ~10s per version waiting out a real 200-tick smelt (`getStackCookTime` is a hardcoded 200 with no gamerule or recipe hook, all the way back to 1.8.8), making it the second-slowest test in the suite (~12.4s).

This keeps the test end-to-end but skips the idle ticks: after the existing assertions that a real smelt is in progress (`0 < progress < 1`), it merges `CookTime:195s` into the furnace's block entity and waits on the furnace window's `update` event until the output slot populates, replacing the `wait(progressSeconds * 1000 + 500)` sleep. Both `/blockdata` and `/data merge block` merge into existing NBT, so the loaded input/fuel are untouched, and the output is still produced by the vanilla `tick()` → `craftRecipe()` path — input decremented, fuel consumed — so every assertion is unchanged.

Version details, verified empirically against real servers on all 28 tested versions:
- Completion checks `cookTime == totalCookTime` exactly (not `>=`), so the merged value must stay below 200 — overshooting would cook forever.
- `/blockdata` became `/data merge block` in 1.13, and `CookTime` was renamed `cooking_time_spent` in 1.21.4 (1.21.3 still accepts `CookTime`; 1.21.4 does not).
- On 1.21.4+ the placement step needs #3986 or #3960 (send player loaded before spawn); without it the test fails at `placeBlock` on master today, with or without this change.

The remaining 5 ticks complete in 250–320ms on every tested version, so the await uses a tight 500ms timeout as a guard: if a future version renames the field or command again, the merge is silently ignored and the test fails fast instead of sitting out the real 10s smelt.

Timing across the matrix: ~12s → ~3s per version (the cook await itself is 249–319ms on all 28 versions), roughly 4.5 minutes saved per full-matrix run.