### PR TITLE
Poll for the sign text echo in the nether test instead of sleeping 500ms

### DIFF
--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -13,31 +13,6 @@ module.exports = () => async (bot) => {
   }
   assert.notStrictEqual(signItem, null)
 
-  const p = new Promise((resolve, reject) => {
-    bot._client.once('open_sign_entity', (packet) => {
-      console.log('Open sign', packet)
-      const sign = bot.blockAt(new Vec3(packet.location))
-      bot.updateSign(sign, '1\n2\n3\n')
-
-      setTimeout(() => {
-        // Get updated sign
-        const sign = bot.blockAt(bot.entity.position)
-        console.log('Updated sign', sign)
-
-        assert.strictEqual(sign.signText.trimEnd(), '1\n2\n3')
-
-        if (sign.blockEntity) {
-          // Check block update
-          bot.activateBlock(sign)
-          assert.notStrictEqual(sign.blockEntity, undefined)
-        }
-
-        bot.chat(`/setblock ~ ~ ~ ${portalName}`)
-        onceWithCleanup(bot, 'spawn', { timeout: 30000 }).then(resolve).catch(reject)
-      }, 500)
-    })
-  })
-
   // A portal's link goes inert after a failed attempt at the same spot, so
   // each retry must use a fresh location or it is guaranteed to time out.
   bot.test.netherAttempts ??= 0
@@ -61,5 +36,31 @@ module.exports = () => async (bot) => {
   await bot.lookAt(lowerBlock.position, true)
   await bot.test.setInventorySlot(36, new Item(signItem.id, 1, 0))
   await bot.placeBlock(lowerBlock, new Vec3(0, 1, 0))
-  await p
+
+  // By the time placeBlock's block update echo has arrived, the server has
+  // already opened the sign editor for us, so the text can be sent right away.
+  const sign = bot.blockAt(lowerBlock.position.offset(0, 1, 0))
+  bot.updateSign(sign, '1\n2\n3\n')
+
+  // Poll for the server echoing the new text back rather than sleeping a
+  // fixed time: it usually lands within a tick, but can take longer on
+  // slow CI.
+  const deadline = Date.now() + 5000
+  let updated = bot.blockAt(sign.position)
+  while (updated.signText?.trimEnd() !== '1\n2\n3' && Date.now() < deadline) {
+    await sleep(50)
+    updated = bot.blockAt(sign.position)
+  }
+  console.log('Updated sign', updated)
+
+  assert.strictEqual(updated.signText.trimEnd(), '1\n2\n3')
+
+  if (updated.blockEntity) {
+    // Check block update
+    bot.activateBlock(updated)
+    assert.notStrictEqual(updated.blockEntity, undefined)
+  }
+
+  bot.chat(`/setblock ~ ~ ~ ${portalName}`)
+  await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
 }


### PR DESCRIPTION
After `bot.updateSign`, the nether test slept a fixed 500ms before asserting the sign text. That's a lose-lose: the server usually echoes the new text within a tick or two (so ~450ms is wasted on every version in the matrix), and on a slow CI box 500ms may not be enough and the assert fails.

This polls `blockAt(...).signText` every 50ms until it matches, capped at 5s. There's no event to await instead: the `update_sign` and `tile_entity_data` handlers write via `column.setBlock`/`setBlockEntity`, which bypasses the world's `blockUpdate` emit — #3993 (stacked on this) adds the missing events, after which this loop becomes a plain await.

It also flattens the test into a linear async flow with no raw `bot._client` listener: by the time `placeBlock`'s block update echo has arrived the server has already opened the sign editor, so the text can be sent right away — and assertion failures now reject the test naturally instead of throwing inside a callback (previously they surfaced as uncaught exceptions from a `setTimeout`).

The poll condition uses `signText?.trimEnd()` because before the echo arrives `signText` is `undefined` — a state the old fixed sleep always slept through.

Verified locally by running the nether external test against 26.1 and 1.8.8; both pass. Measured on 1.8.8: 6655ms → 6043ms.