### PR TITLE
Emit blockEntityData and signOpen events and use them in the nether test

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -215,6 +215,8 @@
       - ["playerLeft" (player)](#playerleft-player)
       - ["blockUpdate" (oldBlock, newBlock)](#blockupdate-oldblock-newblock)
       - ["blockUpdate:(x, y, z)" (oldBlock, newBlock)](#blockupdatex-y-z-oldblock-newblock)
+      - ["blockEntityData" (block)](#blockentitydata-block)
+      - ["signOpen" (block)](#signopen-block)
       - ["blockPlaced" (oldBlock, newBlock)](#blockplaced-oldblock-newblock)
       - ["chunkColumnLoad" (point)](#chunkcolumnload-point)
       - ["chunkColumnUnload" (point)](#chunkcolumnunload-point)
@@ -1376,6 +1378,14 @@ Note that `oldBlock` may be `null`.
 comparison.
 
 Note that `oldBlock` may be `null`.
+
+#### "blockEntityData" (block)
+
+Fires when the server sends new block entity data for a block, for example when a sign's text is updated. `block` is the block at that position with the fresh data (may be `null` if the block is no longer loaded).
+
+#### "signOpen" (block)
+
+Fires when the server opens the sign editor, right after the bot places a sign. `block` is the placed sign (may be `null` if it is not loaded). Respond with [bot.updateSign](#botupdatesignblock-text-back--false).
 
 #### "blockPlaced" (oldBlock, newBlock)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,8 @@ export interface BotEvents {
   playerLeft: (entity: Player) => Promise<void> | void
   blockUpdate: (oldBlock: Block | null, newBlock: Block) => Promise<void> | void
   'blockUpdate:(x, y, z)': (oldBlock: Block | null, newBlock: Block | null) => Promise<void> | void
+  blockEntityData: (block: Block | null) => Promise<void> | void
+  signOpen: (block: Block | null) => Promise<void> | void
   chunkColumnLoad: (entity: Vec3) => Promise<void> | void
   chunkColumnUnload: (entity: Vec3) => Promise<void> | void
   soundEffectHeard: (

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -441,21 +441,31 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       return JSON.parse(text)
     })
     column.setBlock(pos, blockAt)
+    bot.emit('blockEntityData', bot.blockAt(new Vec3(packet.location.x, packet.location.y, packet.location.z)))
+  })
+
+  bot._client.on('open_sign_entity', (packet) => {
+    const pos = new Vec3(packet.location.x, packet.location.y, packet.location.z)
+    bot.emit('signOpen', bot.blockAt(pos))
   })
 
   bot._client.on('tile_entity_data', (packet) => {
+    let absolutePos
     if (packet.location !== undefined) {
       const column = bot.world.getColumn(packet.location.x >> 4, packet.location.z >> 4)
       if (!column) return
       const pos = new Vec3(packet.location.x & 0xf, packet.location.y, packet.location.z & 0xf)
       column.setBlockEntity(pos, packet.nbtData)
+      absolutePos = new Vec3(packet.location.x, packet.location.y, packet.location.z)
     } else {
       const tag = packet.nbtData
       const column = bot.world.getColumn(tag.value.x.value >> 4, tag.value.z.value >> 4)
       if (!column) return
       const pos = new Vec3(tag.value.x.value & 0xf, tag.value.y.value, tag.value.z.value & 0xf)
       column.setBlockEntity(pos, tag)
+      absolutePos = new Vec3(tag.value.x.value, tag.value.y.value, tag.value.z.value)
     }
+    bot.emit('blockEntityData', bot.blockAt(absolutePos))
   })
 
   bot.updateSign = (block, text, back = false) => {

--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -35,22 +35,20 @@ module.exports = () => async (bot) => {
 
   await bot.lookAt(lowerBlock.position, true)
   await bot.test.setInventorySlot(36, new Item(signItem.id, 1, 0))
+  const signOpen = onceWithCleanup(bot, 'signOpen', { timeout: 5000 })
   await bot.placeBlock(lowerBlock, new Vec3(0, 1, 0))
 
-  // By the time placeBlock's block update echo has arrived, the server has
-  // already opened the sign editor for us, so the text can be sent right away.
-  const sign = bot.blockAt(lowerBlock.position.offset(0, 1, 0))
+  // The server opens the sign editor once the sign is placed.
+  const [sign] = await signOpen
   bot.updateSign(sign, '1\n2\n3\n')
 
-  // Poll for the server echoing the new text back rather than sleeping a
-  // fixed time: it usually lands within a tick, but can take longer on
-  // slow CI.
-  const deadline = Date.now() + 5000
-  let updated = bot.blockAt(sign.position)
-  while (updated.signText?.trimEnd() !== '1\n2\n3' && Date.now() < deadline) {
-    await sleep(50)
-    updated = bot.blockAt(sign.position)
-  }
+  // Wait for the server to echo the new text back rather than polling: it
+  // usually lands within a tick, but can take longer on slow CI.
+  await onceWithCleanup(bot, 'blockEntityData', {
+    timeout: 5000,
+    checkCondition: (block) => block?.position?.equals(sign.position) && block.signText?.trimEnd() === '1\n2\n3'
+  })
+  const updated = bot.blockAt(sign.position)
   console.log('Updated sign', updated)
 
   assert.strictEqual(updated.signText.trimEnd(), '1\n2\n3')


### PR DESCRIPTION
Stacked on #3992.

The server's block entity updates (modern `block_entity_data` and legacy `update_sign`) were stored in the world silently, and `open_sign_entity` was not surfaced at all — so consumers had to poll `bot.blockAt` or reach into `bot._client`.

- **Commit 1** adds two public events, documented in api.md + index.d.ts:
  - `blockEntityData` (block) — emitted with the updated block whenever block entity data arrives
  - `signOpen` (block) — emitted with the placed sign when the server opens the sign editor
- **Commit 2** rewrites the nether test on top of them: the sign-echo polling loop from #3992 becomes a wait for `blockEntityData`, and the placed sign is taken from `signOpen` instead of being read out of the world by position.

Verified locally by running the nether external test against 26.1 (modern packet path) and 1.8.8 (legacy `update_sign` path); both pass.