### PR TITLE
test: skip reset roundtrips that are provably no-ops

### DIFF
--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -108,17 +108,32 @@ function inject (bot, wrap) {
     return bot.placeBlock(referenceBlock, new Vec3(0, 1, 0))
   }
 
+  // Any block change since the last superflat repair marks the world dirty;
+  // resetState uses it to skip the /fill roundtrips after read-only tests.
+  // Fills themselves fire blockUpdate, so the flag is cleared after they
+  // settle; a late-arriving update just makes the next reset conservative.
+  let worldDirty = true
+  bot.on('blockUpdate', () => { worldDirty = true })
+
   // always leaves you in creative mode
   async function resetState () {
     await becomeCreative()
     bot.creative.startFlying()
-    await teleport(new Vec3(0, bot.test.groundY, 0))
-    await bot.waitForChunksToLoad()
-    await resetBlocksToSuperflat()
+    const origin = new Vec3(0, bot.test.groundY, 0)
+    if (bot.entity.position.distanceTo(origin) >= 0.9) {
+      await teleport(origin)
+      await bot.waitForChunksToLoad()
+    }
+    if (worldDirty) {
+      await resetBlocksToSuperflat()
+      worldDirty = false
+    }
     // Clear after the fills: they destroy the previous test's containers,
     // and those deferred closes return items into the inventory — the clear's
     // give-retry converges over those late returns.
-    await clearInventory()
+    if (bot.inventory.slots.some((slot) => slot != null) || bot.inventory.selectedItem) {
+      await clearInventory()
+    }
   }
 
   async function becomeCreative () {


### PR DESCRIPTION
resetState is the isolation barrier before every external test, and it stays that way — but it paid ~6 server roundtrips (~300ms) unconditionally, even after read-only tests like `bossBar` or the chat tests that touched nothing.

This keeps the universal pre-test reset and makes each step conditional on evidence it's needed:

- **teleport + `waitForChunksToLoad`** — only when the bot has actually moved away from the origin
- **the six superflat `/fill` repairs** — only when a `blockUpdate` fired since the last repair (a dirty flag; the fills' own updates settle before the flag clears, and a late-arriving update just makes the next reset conservative)
- **`clearInventory`** — only when a slot or the cursor item is non-empty

The world-pristine guarantee before each test is unchanged — steps are skipped only when their postcondition already provably holds.

Measured on 1.8.8 (instrumented `resetState`, full suite):

| | before | after |
|---|---|---|
| resets | 50 × 301ms mean (231–449ms) | 50 × 89ms mean, median 0ms |
| total reset time | 15.0s | 4.5s |
| suite wall time | ~2m | ~1m |

27 of 50 resets become near-zero (the read-only tests). All tests pass identically before/after.