### PR TITLE
test: confirm superflat fills via chat echo instead of sleeping 100ms

### DIFF
--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -142,6 +142,25 @@ function inject (bot, options) {
     if (data.positionId === 2) bot.emit('actionBar', msg, null)
   })
 
+  let send = (message) => bot._client.chat(message)
+  if (bot.supportFeature('chatCommandsQueuedToMainThread')) {
+    // 1.19.0 rejects a queued command as out-of-order if a chat message overtakes
+    // it; a tab_complete reply proves every earlier command has been processed.
+    let sendChain = Promise.resolve()
+    let commandPending = false
+    send = (message) => {
+      const isCommand = message.startsWith('/')
+      sendChain = sendChain.then(async () => {
+        if (!isCommand && commandPending) {
+          commandPending = false
+          await tabComplete('/', false, false).catch(() => {})
+        }
+        bot._client.chat(message)
+        if (isCommand) commandPending = true
+      })
+    }
+  }
+
   function chatWithHeader (header, message) {
     if (typeof message === 'number') message = message.toString()
     if (typeof message !== 'string') {
@@ -150,7 +169,7 @@ function inject (bot, options) {
 
     if (!header && message.startsWith('/')) {
       // Do not try and split a command without a header
-      bot._client.chat(message)
+      send(message)
       return
     }
 
@@ -161,7 +180,7 @@ function inject (bot, options) {
       let smallMsg
       for (i = 0; i < subMessage.length; i += lengthLimit) {
         smallMsg = header + subMessage.substring(i, i + lengthLimit)
-        bot._client.chat(smallMsg)
+        send(smallMsg)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "minecraft-data": "^3.112.0",
+    "minecraft-data": "^3.114.0",
     "minecraft-protocol": "^1.67.0",
     "mojangson": "^2.0.4",
     "prismarine-biome": "^1.1.1",

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -90,7 +90,16 @@ function inject (bot, wrap) {
       const realY = y + bot.test.groundY - 4
       bot.chat(`/fill ~-5 ${realY} ~-5 ~5 ${realY} ~5 ` + layerNames[y])
     }
-    await bot.test.wait(100)
+    // The fills are fire-and-forget; a marker chat message on the same
+    // ordered connection confirms they have executed and their block updates
+    // have already arrived, without assuming how long a server tick takes.
+    const marker = 'superflat-reset-done'
+    const echo = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (message) => message.includes(marker)
+    })
+    bot.chat(marker)
+    await echo
   }
 
   async function placeBlock (slot, position) {


### PR DESCRIPTION
The six `/fill` repairs in `resetBlocksToSuperflat` are fire-and-forget chat commands, synchronized only by a fixed `wait(100)` — an assumption that a slow CI tick can exceed (and that fast ticks waste).

A marker chat message sent on the same ordered connection is only echoed back after the fills have executed server-side, and the fills' `multi_block_change` packets sit earlier in the same ordered stream — so by the time the echo arrives, the client's world is provably up to date.

Measured on 1.8.8 (instrumented reset, full suite): the fills step went from ~102ms avg to ~47ms avg (min 4ms, max 66ms), all tests passing identically. Combined with #3995 this puts the whole pre-test reset around ~3.5s per version, mostly the /clear-confirm roundtrips.