### PR TITLE
test(fishing): use the maximum viable Lure level per version

### DIFF
--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -3,24 +3,23 @@ module.exports = () => async (bot) => {
 
   bot.test.sayEverywhere('/fill ~-10 ~-1 ~-10 ~10 ~-1 ~10 water')
   bot.test.sayEverywhere('/weather rain') // rain shortens the vanilla bite wait
-  // The server rolls the bite wait as nextInt(100, 900) on 1.8.x and
-  // nextInt(100, 600) on 1.9+, then subtracts Lure level x100 ticks; a
-  // non-positive roll just rerolls next tick. These levels are the maximum
-  // viable: they leave only 1-100 tick waits (expected ~2.5s, hard cap 5s).
-  // One level higher and the roll can never go positive - the hook never
-  // bites. /enchant caps at Lure III, so the level is set via item NBT.
-  // From 1.20.5 the servers silently strip enchantments written by the
-  // client into a creative slot, so the rod must come from a server /give.
-  // The enchantments component lost its levels wrapper in 1.21.5.
-  if (bot.registry.version['>=']('1.21.5')) {
+  // The server rolls the bite wait as nextInt(100, fishingBiteDelayMaxTicks)
+  // then subtracts Lure level x100 ticks; a non-positive roll just rerolls
+  // next tick. This Lure level is the maximum viable: it leaves only 1-100
+  // tick waits (expected ~2.5s, hard cap 5s). One level higher and the roll
+  // can never go positive - the hook never bites. /enchant caps at Lure III.
+  // Component-era servers silently strip enchantments written by the client
+  // into a creative slot, so there the rod must come from a server /give.
+  const lure = (bot.supportFeature('fishingBiteDelayMaxTicks') - 100) / 100
+  if (bot.supportFeature('enchantmentsComponentIsFlat')) {
     await bot.test.clearInventory()
-    await bot.test.awaitItemReceived('/give @a minecraft:fishing_rod[minecraft:enchantments={"minecraft:lure":5}] 1')
-  } else if (bot.registry.version['>=']('1.20.5')) {
+    await bot.test.awaitItemReceived(`/give @a minecraft:fishing_rod[minecraft:enchantments={"minecraft:lure":${lure}}] 1`)
+  } else if (bot.supportFeature('itemsWithComponents')) {
     await bot.test.clearInventory()
-    await bot.test.awaitItemReceived('/give @a minecraft:fishing_rod[minecraft:enchantments={levels:{"minecraft:lure":5}}] 1')
+    await bot.test.awaitItemReceived(`/give @a minecraft:fishing_rod[minecraft:enchantments={levels:{"minecraft:lure":${lure}}}] 1`)
   } else {
     const rod = new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0)
-    rod.enchants = [{ name: 'lure', lvl: bot.registry.version['>=']('1.9') ? 5 : 8 }]
+    rod.enchants = [{ name: 'lure', lvl: lure }]
     await bot.test.setInventorySlot(36, rod)
   }
   await bot.lookAt(bot.entity.position) // dont force the position

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -9,9 +9,20 @@ module.exports = () => async (bot) => {
   // viable: they leave only 1-100 tick waits (expected ~2.5s, hard cap 5s).
   // One level higher and the roll can never go positive - the hook never
   // bites. /enchant caps at Lure III, so the level is set via item NBT.
-  const rod = new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0)
-  rod.enchants = [{ name: 'lure', lvl: bot.registry.version['>=']('1.9') ? 5 : 8 }]
-  await bot.test.setInventorySlot(36, rod)
+  // From 1.20.5 the servers silently strip enchantments written by the
+  // client into a creative slot, so the rod must come from a server /give.
+  // The enchantments component lost its levels wrapper in 1.21.5.
+  if (bot.registry.version['>=']('1.21.5')) {
+    await bot.test.clearInventory()
+    await bot.test.awaitItemReceived('/give @a minecraft:fishing_rod[minecraft:enchantments={"minecraft:lure":5}] 1')
+  } else if (bot.registry.version['>=']('1.20.5')) {
+    await bot.test.clearInventory()
+    await bot.test.awaitItemReceived('/give @a minecraft:fishing_rod[minecraft:enchantments={levels:{"minecraft:lure":5}}] 1')
+  } else {
+    const rod = new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0)
+    rod.enchants = [{ name: 'lure', lvl: bot.registry.version['>=']('1.9') ? 5 : 8 }]
+    await bot.test.setInventorySlot(36, rod)
+  }
   await bot.lookAt(bot.entity.position) // dont force the position
   bot.fish()
 

--- a/test/externalTests/fishing.js
+++ b/test/externalTests/fishing.js
@@ -3,8 +3,15 @@ module.exports = () => async (bot) => {
 
   bot.test.sayEverywhere('/fill ~-10 ~-1 ~-10 ~10 ~-1 ~10 water')
   bot.test.sayEverywhere('/weather rain') // rain shortens the vanilla bite wait
-  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0))
-  await bot.test.awaitItemReceived('/enchant @a minecraft:lure 3')
+  // The server rolls the bite wait as nextInt(100, 900) on 1.8.x and
+  // nextInt(100, 600) on 1.9+, then subtracts Lure level x100 ticks; a
+  // non-positive roll just rerolls next tick. These levels are the maximum
+  // viable: they leave only 1-100 tick waits (expected ~2.5s, hard cap 5s).
+  // One level higher and the roll can never go positive - the hook never
+  // bites. /enchant caps at Lure III, so the level is set via item NBT.
+  const rod = new Item(bot.registry.itemsByName.fishing_rod.id, 1, 0)
+  rod.enchants = [{ name: 'lure', lvl: bot.registry.version['>=']('1.9') ? 5 : 8 }]
+  await bot.test.setInventorySlot(36, rod)
   await bot.lookAt(bot.entity.position) // dont force the position
   bot.fish()
 


### PR DESCRIPTION
Stacked on #3989.

From reading the decompiled server code: the bite wait is rolled as `nextInt(100, 900)` on 1.8.x and `nextInt(100, 600)` on 1.9+ (verified in 1.16.5/1.21.8/26.1 sources), then reduced by Lure level × 100 ticks with **no clamp** — a non-positive roll simply rerolls next tick. That means:

- **Lure 8 on 1.8.x / Lure 5 on 1.9+** are the maximum viable levels: only rolls in the top 100 ticks survive, so the wait becomes 1–100 ticks — expected ~2.5s, **hard cap 5s** (vs 5–30s vanilla, ~15s expected under Lure III).
- One level higher and the roll can never go positive: **the hook never bites** and the test hangs — which is why the level is version-conditional and why `/enchant` (capped at III) is replaced with setting the enchant via item NBT (prismarine-item handles the per-version encoding).

The timers themselves can't be fast-forwarded directly: the 1.8.8 bobber saves no timer fields to NBT and the modern `FishingHook.addAdditionalSaveData` is empty, so `/entitydata` / `/data merge` have nothing to touch; `/tick sprint` would also sprint past the 10–30-tick catchable window.

Measured (fishing test, multiple runs):
- 1.8.8: **7.4s / 7.4s** (was 6.9–22.1s across runs tonight)
- 1.16.5: **7.3s**
- 26.1: 9.2–17.9s — modern runs still sometimes miss the first nibble and pay a second (now-capped) cycle; that reel-timing issue predates this change and is a separate fix.