### PR TITLE
test(exampleBee): await the op confirmation instead of sleeping 2s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/test/externalTests/exampleBee.js
+++ b/test/externalTests/exampleBee.js
@@ -1,10 +1,17 @@
 const assert = require('assert')
 
+const { onceWithCleanup } = require('../../lib/promise_utils')
+
 module.exports = () => async (bot) => {
   await bot.test.runExample('examples/bee.js', async (name) => {
     assert.strictEqual(name, 'bee')
-    bot.chat('/op bee') // to counteract spawn protection
-    await bot.test.wait(2000)
+    // Wait for the server to confirm the op instead of sleeping a fixed 2s.
+    const opped = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (msg) => msg.includes(`Opped ${name}`) || msg.includes(`Made ${name} a server operator`)
+    })
+    bot.chat(`/op ${name}`) // to counteract spawn protection
+    await opped
     await bot.test.tellAndListen(name, 'fly', (message) => {
       if (message !== 'My flight was amazing !') {
         assert.fail(`Unexpected message: ${message}`) // error


### PR DESCRIPTION
Stacked on #3984, same pattern: the fixed 2s sleep after `/op bee` was waiting for the op — and with it the spawn-protection bypass — to apply. The server confirms exactly that with a chat message (`Opped bee` / `Made bee a server operator`), so await it instead.

Measured (instrumented runs):

| | before | after |
|---|---|---|
| op wait | 2000ms fixed | 50ms (1.8.8) / 11ms (26.1) |
| exampleBee total | 5.8s | 3.85s (1.8.8) / 4.3s (26.1) |

What remains is ~2.9s of the actual flight (11 `flyTo` hops — the behavior being demonstrated) plus ~0.9s of child-bot setup.