### PR TITLE
fix(inventory): don't let the trailing-sync path swallow a reused window id's early window_items

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -697,6 +697,9 @@ function inject (bot, { hideErrors }) {
         const item = Item.fromNotch(windowItems.items[i])
         window.updateSlot(i, item)
       }
+      // consume the buffer so a later window reusing this id cannot open
+      // with stale contents
+      windowItems = null
       updateHeldItem()
       extendWindow(window)
       bot.emit('windowOpen', window)
@@ -728,10 +731,19 @@ function inject (bot, { hideErrors }) {
   bot._client.on('login', () => {
     lastClosedWindow = null
     // close window when switch subserver
+    windowItems = null
+    lastClosedWindow = null
     const oldWindow = bot.currentWindow
     if (!oldWindow) return
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
+  })
+  // A respawn (death or dimension change) replaces the server-side player
+  // entity and resets its window id counter, so pending window state can
+  // never describe a post-respawn window
+  bot._client.on('respawn', () => {
+    windowItems = null
+    lastClosedWindow = null
   })
   bot._setSlot = (slotId, newItem, window = bot.inventory) => {
     // set slot
@@ -779,17 +791,23 @@ function inject (bot, { hideErrors }) {
   bot._client.on('window_items', (packet) => {
     const window = packet.windowId === 0 ? bot.inventory : bot.currentWindow
     if (!window || window.id !== packet.windowId) {
+      // Buffer even when the id matches a just-closed window: villager
+      // windows send window_items before open_window, and their id can
+      // collide with lastClosedWindow's because a respawn replaces the
+      // server-side player entity and restarts its window id counter.
+      windowItems = packet
       // Trailing sync for a window we already closed client-side — apply
-      // its player-inventory region (see the set_slot handler). Anything
-      // else is an early sync for a window we haven't opened yet.
-      if (lastClosedWindow && packet.windowId === lastClosedWindow.id) {
+      // its player-inventory region (see the set_slot handler). The item
+      // count identifies the window shape: an early sync for a different
+      // window type must not be routed through the closed window's slot
+      // mapping.
+      if (lastClosedWindow && packet.windowId === lastClosedWindow.id &&
+        packet.items.length === lastClosedWindow.slots.length) {
         for (let i = lastClosedWindow.inventoryStart; i < lastClosedWindow.inventoryEnd && i < packet.items.length; i++) {
           const invSlot = i - (lastClosedWindow.inventoryStart - bot.inventory.inventoryStart)
           bot._setSlot(invSlot, Item.fromNotch(packet.items[i]))
         }
-        return
       }
-      windowItems = packet
       return
     }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1236,6 +1236,86 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('windows', () => {
+      const Item = require('prismarine-item')(supportedVersion)
+      const pWindows = require('prismarine-windows')(supportedVersion)
+      // legacy 'minecraft:chest' has a dynamic size resolved from the packet's
+      // slotCount (container slots only); the modern equivalent is fixed
+      const chestData = pWindows.windows['minecraft:generic_9x3'] ?? { type: 'minecraft:chest', slots: 63 }
+      const merchantData = pWindows.windows['minecraft:merchant'] ?? pWindows.windows['minecraft:villager']
+      const emptyItems = (n) => Array.from({ length: n }, () => Item.toNotch(null))
+      const openWindowPacket = (windowId, winData) => ({
+        windowId,
+        inventoryType: winData.type,
+        windowTitle: chatText(''),
+        slotCount: winData.slots - 36,
+        entityId: 0
+      })
+      const windowItemsPacket = (windowId, items) => ({
+        windowId,
+        stateId: 1,
+        items,
+        carriedItem: Item.toNotch(null)
+      })
+
+      it('opens a window whose early window_items reuses the id of a closed window', (done) => {
+        const emeraldId = registry.itemsByName.emerald.id
+
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+
+          bot.once('windowOpen', () => {
+            bot.closeWindow(bot.currentWindow)
+          })
+          client.on('close_window', () => {
+            bot.once('windowOpen', (window) => {
+              assert.strictEqual(window.type, merchantData.key)
+              assert.strictEqual(window.slots[0]?.type, emeraldId)
+              done()
+            })
+            // a villager window sends its contents before open_window, and
+            // reuses the chest's id when a respawn reset the server's window
+            // id counter in between
+            const items = emptyItems(merchantData.slots)
+            items[0] = Item.toNotch(new Item(emeraldId, 3))
+            client.write('window_items', windowItemsPacket(1, items))
+            client.write('open_window', openWindowPacket(1, merchantData))
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
+        })
+      })
+
+      it('applies the player-inventory region of a trailing sync for a closed window', (done) => {
+        const stoneId = registry.itemsByName.stone.id
+        // chest slot 30 is in the window's player-inventory region and maps
+        // back to inventory slot 12
+        const chestSlot = 30
+        const invSlot = 12
+
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+
+          bot.once('windowOpen', () => {
+            bot.closeWindow(bot.currentWindow)
+          })
+          client.on('close_window', () => {
+            bot.inventory.once(`updateSlot:${invSlot}`, (oldItem, newItem) => {
+              assert.strictEqual(newItem?.type, stoneId)
+              done()
+            })
+            const items = emptyItems(chestData.slots)
+            items[chestSlot] = Item.toNotch(new Item(stoneId, 5))
+            client.write('window_items', windowItemsPacket(1, items))
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
+        })
+      })
+    })
+
     describe('tablist', () => {
       it('handles newlines in header and footer', (done) => {
         const HEADER = 'asd\ndsa'


### PR DESCRIPTION
## The bug

On 1.8, villager windows send their `window_items` **before** `open_window` — `ServerPlayerEntity.openTradingScreen` is the only opener that calls `addListener` (which syncs the contents) before sending the open packet. mineflayer handles that with the `windowItems` buffer in `prepareWindow`.

The trailing-sync path added in the 26.1 release can steal that buffer. Window ids live on the server-side player entity (`syncId % 100 + 1`), and a respawn replaces that entity (`PlayerManager.respawnPlayer`), restarting the counter. So after a respawn, a villager window can reuse the id of the last window we closed. When it does, the early `window_items` matches `lastClosedWindow`, gets applied through the *closed* window's slot mapping (writing wrong data into `bot.inventory` when the shapes differ), and is never buffered — `prepareWindow` then waits forever for `setWindowItems` and `windowOpen` never fires. The server-side window also stays open, so it remaps every subsequent inventory sync into its coordinates and poisons everything after (e.g. `bot.creative.setInventorySlot` waiting on an `updateSlot` that arrives addressed to the phantom window).

Deterministic repro in the external suite on 1.8.8: `gamemode after respawn` resets the counter, a later container test closes a window with id 1, then `trade` hangs for its full 20s timeout and `useChests` fails as collateral.

## The fix

- Buffer the packet **before** the trailing-sync check, so an `open_window` that follows with the same id can still open. Genuine trailing syncs are unaffected — no open follows, and the buffer is inert.
- Only apply the trailing sync when `packet.items.length` matches the closed window's slot count, so an early sync for a different window shape is never routed through the closed window's slot mapping.
- Consume the buffer when `prepareWindow` uses it, and drop both the buffer and `lastClosedWindow` on respawn/login — the id counter they matched against is gone.

The trailing-sync mechanism itself is kept: modern servers (`doCloseContainer` → `inventoryMenu.transferState`) carry over what they already sent through the old window id and won't resend it under windowId 0, so those packets genuinely need to be applied.

## Validation

- New internal tests (all versions): the villager id-reuse flow (times out without this fix, exactly the trade hang) and a guard that the trailing sync still applies the player-inventory region of a closed window.
- External suite on 1.8.8: previously `trade` + `useChests` failing, now 74 passing / 0 failing.
- External suite on 26.1 (the release the trailing-sync path was added for): 75 passing / 0 failing, including `creative`, `crafting`, and `playerInventory`.