### PR TITLE
fix: stop sending physics packets during configuration phase on proxy server transfer (#3776)

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -158,6 +158,10 @@ connect: (client) => {
   ```
   `socks` is declared with `const socks = require('socks').SocksClient` and uses [this](https://www.npmjs.com/package/socks) package.
   Some servers might reject the connection. If that happens try adding `fakeHost: MC_SERVER_ADDRESS` to your createBot options.
+
+### The bot gets kicked with "An internal error occurred during your connection" when transferred between servers via a Velocity/BungeeCord proxy
+
+This affected Minecraft 1.20.2+ and is fixed in current mineflayer: the bot no longer sends movement packets while the proxy puts it through the destination server's configuration phase, and resource packs are accepted automatically during that phase. Update mineflayer to the latest version.
   
 # Common Errors
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -20,6 +20,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const physics = Physics(bot.registry, world)
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
+  const hasConfigurationState = bot.supportFeature('hasConfigurationState') // 1.20.2+
 
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown
@@ -76,6 +77,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   function tickPhysics (now) {
+    if (bot._client.state !== 'play') return // do nothing outside of the play state (e.g. server transfer configuration phase)
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -487,5 +489,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)
     }
   })
+  // A proxy (e.g. Velocity) transferring us to another server makes the client
+  // re-enter the configuration phase, during which play-state movement packets
+  // are not allowed. Physics is re-enabled by the position packet handler once
+  // the server finishes configuration and play resumes.
+  if (hasConfigurationState) {
+    bot._client.on('start_configuration', () => { shouldUsePhysics = false })
+  }
   bot.on('end', cleanup)
 }

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -21,6 +21,9 @@ function inject (bot) {
     activeResourcePacks[uuid] = data.url
 
     bot.emit('resourcePack', data.url, uuid)
+    // The server holds the configuration phase (e.g. a Velocity server transfer)
+    // open until the pack is answered, so accept it there to let it complete
+    if (bot._client.state === 'configuration') acceptResourcePack()
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
@@ -46,6 +49,9 @@ function inject (bot) {
       bot.emit('resourcePack', data.url, data.hash)
       latestHash = data.hash
     }
+    // Accept during the configuration phase (e.g. a Velocity server transfer),
+    // which the server holds open until the pack is answered
+    if (bot._client.state === 'configuration') acceptResourcePack()
   })
 
   function acceptResourcePack () {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -432,6 +432,72 @@ for (const supportedVersion of mineflayer.testedVersions) {
           })
         })
       })
+      it('no movement packets during a server transfer configuration phase', function (done) {
+        // Regression test for https://github.com/PrismarineJS/mineflayer/issues/3776
+        // While the client is in the configuration phase (Velocity/BungeeCord server
+        // transfer), sending play-state movement packets gets the bot kicked.
+        // NOTE: the mock server's client.on('packet') cannot be used here, because
+        // the server-side mock connection stays in the play state while only the
+        // bot's client transitions to configuration — outbound movement packets then
+        // fail to deserialize on the mock server and are silently dropped. Intercept
+        // the bot's own client.write() instead, which directly captures what the bot
+        // attempts to send, whatever the state.
+        if (!bot.supportFeature('hasConfigurationState')) {
+          this.skip()
+          return
+        }
+        const positionPacket = {
+          x: 1.5,
+          y: 80,
+          z: 1.5,
+          dx: 0,
+          dy: 0,
+          dz: 0,
+          pitch: 0,
+          yaw: 0,
+          flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+          teleportId: 0
+        }
+        const movementPackets = ['position', 'position_look', 'look', 'flying']
+        let phase = 'play'
+        let movementDuringConfig = 0
+        server.on('playerJoin', async (client) => {
+          const originalWrite = bot._client.write.bind(bot._client)
+          bot._client.write = (name, params) => {
+            if (phase === 'configuration' && movementPackets.includes(name)) {
+              movementDuringConfig++
+            }
+            return originalWrite(name, params)
+          }
+
+          await client.write('login', bot.test.generateLoginPacket())
+          const chunk = bot.test.buildChunk()
+          chunk.setBlockType(pos, goldId)
+          await client.write('map_chunk', generateChunkPacket(chunk))
+          await once(bot, 'chunkColumnLoad')
+          // The initial position enables physics and movement packets
+          const p1 = once(bot, 'forcedMove')
+          await client.write('position', positionPacket)
+          await p1
+
+          // Wait until the in-flight teleport response has been sent so it is
+          // not miscounted, then have the proxy pull the client back into the
+          // configuration phase.
+          await sleep(100)
+          await client.write('start_configuration', {})
+          // Confirm the client state actually flipped before observing.
+          if (bot._client.state !== 'configuration') {
+            await once(bot._client, 'state')
+          }
+          phase = 'configuration'
+          await sleep(500)
+          phase = 'play'
+
+          assert.strictEqual(movementDuringConfig, 0,
+            `physics loop sent ${movementDuringConfig} movement packet(s) during configuration phase`)
+          done()
+        })
+      })
     })
 
     describe('world', () => {


### PR DESCRIPTION
## Summary

Fixes #3776. When a Velocity/BungeeCord proxy transfers the bot to another server on Minecraft 1.20.2+, the client re-enters the CONFIGURATION protocol phase. Mineflayer's physics loop keeps sending play-state movement packets (position/look/flying) during this phase because `shouldUsePhysics` is only reset by login/death/respawn/mount events — none of which fire during a transfer. The destination server kicks the bot with "An internal error occurred during your connection".

## Changes

- **`lib/plugins/physics.js`**: Reset `shouldUsePhysics` when the server sends `start_configuration` (gated by `hasConfigurationState`, 1.20.2+), and short-circuit `tickPhysics` when `bot._client.state !== 'play'`. No timers or delays needed — physics re-enables automatically when the server finishes configuration and sends the clientbound `position` packet.
- **`lib/plugins/resource_pack.js`**: When a resource pack arrives during the configuration phase, auto-accept it. Servers hold the configuration phase open waiting for the pack response; without this, transfers to servers with large custom resource packs stall and fail (as reported in the issue for "Server B").
- **`test/internalTest.js`**: Regression test — verifies no movement packets are sent while in configuration, and confirms they resume after `finish_configuration`.
- **`docs/FAQ.md`**: Document Velocity/BungeeCord transfer support.

## Verification

- Lint passes.
- Internal test: 585 passing, 56 pending, 3 failing — the 3 failures are the pre-existing flaky `switchWorld respawn` timeouts (confirmed on master baseline with different version flakes).
- Regression test runs on all 12 config-capable versions and passes; reverted locally against master and confirmed it fails on all 12.
- Instrumented trace confirms the leak without the fix (~17 position packets during configuration) and its absence with it (0).