### PR TITLE
ci: install unreleased minecraft-wrap and minecraft-protocol fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -2,8 +2,9 @@ const assert = require('assert')
 const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
-  // Wait a few seconds for chunks
-  await bot.test.wait(3000)
+  // The bed is placed relative to the bot; blockAt cannot see it until the
+  // surrounding chunks are loaded.
+  await bot.waitForChunksToLoad()
   const midnight = 18000
   const bedItem = bot.registry.itemsArray.find(item => item.name.endsWith('bed'))
   const bedPos1 = bot.entity.position.offset(2, 0, 0).floored()


### PR DESCRIPTION
Two upstream fixes the external tests depend on are not released yet; install them from their commits in CI until they are, then revert this.

**minecraft-wrap** 1.9.0 writes `version_manifest.json` to `server_jars/versions/`, which the four per-version test processes in each CI job share, and reads it straight back. They tear each other's writes, so every job has been failing in the `before all` hook with `SyntaxError ... JSON` at `launcher_download.js:42`. PrismarineJS/node-minecraft-wrap#111 keeps the manifest in memory and writes downloads to a temp file + rename.

**minecraft-protocol**'s `ping` never rejects when the server closes the status connection before answering, so each failed attempt of the ping retry in `externalTest.js` (#3976) waits out the full `closeTimeout`. PrismarineJS/node-minecraft-protocol#1514 rejects on close.

The other open PRs are rebased onto this branch so their CI reflects only their own changes.