### PR TITLE
chat: on 1.19.0, wait for queued commands before sending a chat message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -143,7 +143,7 @@ function inject (bot, options) {
   })
 
   let send = (message) => bot._client.chat(message)
-  if (bot.registry.version['==']('1.19')) {
+  if (bot.supportFeature('chatCommandsQueuedToMainThread')) {
     // 1.19.0 rejects a queued command as out-of-order if a chat message overtakes
     // it; a tab_complete reply proves every earlier command has been processed.
     let sendChain = Promise.resolve()

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -142,6 +142,25 @@ function inject (bot, options) {
     if (data.positionId === 2) bot.emit('actionBar', msg, null)
   })
 
+  let send = (message) => bot._client.chat(message)
+  if (bot.registry.version['==']('1.19')) {
+    // 1.19.0 rejects a queued command as out-of-order if a chat message overtakes
+    // it; a tab_complete reply proves every earlier command has been processed.
+    let sendChain = Promise.resolve()
+    let commandPending = false
+    send = (message) => {
+      const isCommand = message.startsWith('/')
+      sendChain = sendChain.then(async () => {
+        if (!isCommand && commandPending) {
+          commandPending = false
+          await tabComplete('/', false, false).catch(() => {})
+        }
+        bot._client.chat(message)
+        if (isCommand) commandPending = true
+      })
+    }
+  }
+
   function chatWithHeader (header, message) {
     if (typeof message === 'number') message = message.toString()
     if (typeof message !== 'string') {
@@ -150,7 +169,7 @@ function inject (bot, options) {
 
     if (!header && message.startsWith('/')) {
       // Do not try and split a command without a header
-      bot._client.chat(message)
+      send(message)
       return
     }
 
@@ -161,7 +180,7 @@ function inject (bot, options) {
       let smallMsg
       for (i = 0; i < subMessage.length; i += lengthLimit) {
         smallMsg = header + subMessage.substring(i, i + lengthLimit)
-        bot._client.chat(smallMsg)
+        send(smallMsg)
       }
     })
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "minecraft-data": "^3.112.0",
+    "minecraft-data": "^3.114.0",
     "minecraft-protocol": "^1.67.0",
     "mojangson": "^2.0.4",
     "prismarine-biome": "^1.1.1",

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -90,7 +90,16 @@ function inject (bot, wrap) {
       const realY = y + bot.test.groundY - 4
       bot.chat(`/fill ~-5 ${realY} ~-5 ~5 ${realY} ~5 ` + layerNames[y])
     }
-    await bot.test.wait(100)
+    // The fills are fire-and-forget; a marker chat message on the same
+    // ordered connection confirms they have executed and their block updates
+    // have already arrived, without assuming how long a server tick takes.
+    const marker = 'superflat-reset-done'
+    const echo = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (message) => message.includes(marker)
+    })
+    bot.chat(marker)
+    await echo
   }
 
   async function placeBlock (slot, position) {


### PR DESCRIPTION
Stacked on #3996, which fails deterministically on 1.19 (and only 1.19): the bot is kicked with `multiplayer.disconnect.out_of_order_chat` on the very first reset, and every test after that fails with `Event move did not fire`.

Packet trace from the failed job:

```
C2S chat_command  fill … -56 … air        timestamp …753
C2S chat_command  fill … (×5)             timestamp …776
C2S chat_message  superflat-reset-done    timestamp …776
S2C kick_disconnect  multiplayer.disconnect.out_of_order_chat
```
Server log: `flatbot sent out-of-order chat: 'fill ~-5 -56 ~-5 ~5 -56 ~5 air'` — it rejected the *first* fill, the only packet stamped earlier than the marker.

In 1.19.0 `ServerGamePacketListenerImpl`, `handleChatCommand` calls `ensureRunningOnSameThread` (re-queues to the main thread) before `tryHandleChat`, while `handleChat` calls `tryHandleChat` straight on the netty thread. So the chat message updates `lastChatTimeStamp` before the main thread reaches the first `/fill`, whose earlier timestamp then fails `updateChatOrder`. 1.19.1+ replaced this with the ordered signed-message chain, and pre-1.19 has no timestamps, so no other version is affected.

Fix in `lib/plugins/chat.js`, gated to 1.19.0: `handleCustomCommandSuggestions` is queued to the main thread the same way and always replies, so a plain message that follows an unacknowledged command first awaits a `tab_complete` roundtrip; that reply proves every earlier command has been processed. All sends on that version go through one chain so order is preserved. Other versions are untouched, and `bot.chat` stays fire-and-forget.