### PR TITLE
inventory: wait for merchant result slot to clear when a two-input trade becomes unsatisfied

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -447,13 +447,10 @@ function inject (bot, { hideErrors }) {
     const trade = window.selectedTrade
     const hasItem = !!window.slots[2]
 
-    if (hasItem !== tradeMatch(trade.inputItem1, window.slots[0])) {
-      if (trade.hasItem2) {
-        return hasItem !== tradeMatch(trade.inputItem2, window.slots[1])
-      }
-      return true
-    }
-    return false
+    // The result slot is present iff every input is satisfied.
+    const satisfied = tradeMatch(trade.inputItem1, window.slots[0]) &&
+      (!trade.hasItem2 || tradeMatch(trade.inputItem2, window.slots[1]))
+    return hasItem !== satisfied
   }
 
   async function waitForWindowUpdate (window, slot) {


### PR DESCRIPTION
`expectTradeUpdate` decides whether `clickWindow` must wait for a `set_slot` on the merchant result slot. For two-input trades it was wrong once item1 stopped matching: it returned only item2's mismatch, so taking input slot 0 below the price did not wait for the server to clear the result slot. Every following click then carried a stale `stateId`; on 1.17+ the server answers each with a full `window_items` resync, and those late snapshots roll the client's window state backwards.

Master never trips this because `transfer` only ever adds to the input slot one item at a time. #3982 does (fill to a stack, then take half back), which is how it surfaced: its `trade` test fails on 1.17.1–1.20.4 with 409 emeralds left instead of 103, and every later test cascades because the villager window is never closed. 1.16.5 passes there via transaction acks; 1.20.5+ passes because `/summon` ignores `Count` so the trade costs 1.

Verified locally on #3982 + this change: `trade` passes on 1.17.1, 1.19.2 (zero `window_items` resyncs during the trade), and 1.16.5. This PR is green on its own; #3982 rebased on it is the test that proves it.
