### PR TITLE
test: summon trade villager with the components-era count key on 1.20.5+

### DIFF
--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -2,24 +2,16 @@ const assert = require('assert')
 const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
-  function expectAmount (amount, greaterThan) {
-    // TODO: 1.20.5+ does not seem to respect "Count" NBT anymore in /summon
-    // ...as NBT was removed in favor of components that may have something to do
-    if (bot.registry.version['>=']('1.20.5')) {
-      if (amount < 1) throw new Error(`${amount} < 1`) // accept anything >=1
-    } else {
-      assert.strictEqual(amount, greaterThan)
-    }
-  }
-
   const Item = require('prismarine-item')(bot.registry)
 
   const villagerType = bot.registry.entitiesByName.villager ? 'villager' : 'Villager'
   const testFluctuations = bot.supportFeature('selectingTradeMovesItems')
+  // Item stacks are components on 1.20.5+; the NBT-era key is silently ignored.
+  const countKey = bot.registry.version['>=']('1.20.5') ? 'count' : 'Count'
 
   const summonCommand = bot.supportFeature('indexesVillagerRecipes')
-    ? `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[0:{maxUses:12,buy:{id:"minecraft:emerald",Count:2},sell:{id:"minecraft:pumpkin_pie",Count:2},uses: 1},1:{maxUses:12,buy:{id:"minecraft:emerald",Count:2},buyB:{id:"minecraft:pumpkin_pie",Count:2},sell:{id:"minecraft:wheat",Count:2}, uses:1},2:{maxUses:12,buy:{id:"minecraft:emerald",Count:1},sell:{id:"minecraft:glass",Count:4},uses: 1},3:{maxUses:12,buy:{id:"minecraft:emerald",Count:36},buyB:{id:"minecraft:book",Count:1},sell:{id:"minecraft:wooden_sword",Count:1},uses: 1}]}}`
-    : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:12,buy:{id:"minecraft:emerald",Count:2},sell:{id:"minecraft:pumpkin_pie",Count:2},${testFluctuations ? 'demand:60,priceMultiplier:0.05f,specialPrice:-4,' : ''}uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",Count:2},buyB:{id:"minecraft:pumpkin_pie",Count:2},sell:{id:"minecraft:wheat",Count:2}, uses:1},{maxUses:12,buy:{id:"minecraft:emerald",Count:1},sell:{id:"minecraft:glass",Count:4},uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",Count:36},buyB:{id:"minecraft:book",Count:1},sell:{id:"minecraft:wooden_sword",Count:1},uses: 1}]}}`
+    ? `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[0:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},uses: 1},1:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},2:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},3:{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
+    : `/summon ${villagerType} ~ ~1 ~ {NoAI:1, Offers:{Recipes:[{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},sell:{id:"minecraft:pumpkin_pie",${countKey}:2},${testFluctuations ? 'demand:60,priceMultiplier:0.05f,specialPrice:-4,' : ''}uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:2},buyB:{id:"minecraft:pumpkin_pie",${countKey}:2},sell:{id:"minecraft:wheat",${countKey}:2}, uses:1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:1},sell:{id:"minecraft:glass",${countKey}:4},uses: 1},{maxUses:12,buy:{id:"minecraft:emerald",${countKey}:36},buyB:{id:"minecraft:book",${countKey}:1},sell:{id:"minecraft:wooden_sword",${countKey}:1},uses: 1}]}}`
 
   const commandBlockPos = bot.entity.position.offset(0.5, 0, 0.5)
   const redstoneBlockPos = commandBlockPos.offset(1, 0, 0)
@@ -53,16 +45,16 @@ module.exports = () => async (bot) => {
 
     const [input] = trade.inputs
     assert.strictEqual(input.name, 'emerald')
-    expectAmount(input.count, 2)
+    assert.strictEqual(input.count, 2)
 
     const [output] = trade.outputs
     assert.strictEqual(output.name, 'pumpkin_pie')
-    expectAmount(output.count, 2)
+    assert.strictEqual(output.count, 2)
 
     await bot.trade(villager, 0, 11)
     shouldHaveEmeralds -= testFluctuations ? (2 * 2 * 11) : (2 * 11)
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 22)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 22)
   }
 
   // Handle trade #2 -- takes [2x emerald, 2x pumpkin_pie] and returns 2x wheat
@@ -73,19 +65,19 @@ module.exports = () => async (bot) => {
 
     const [input1, input2] = trade.inputs
     assert.strictEqual(input1.name, 'emerald')
-    expectAmount(input1.count, 2)
+    assert.strictEqual(input1.count, 2)
     assert.strictEqual(input2.name, 'pumpkin_pie')
-    expectAmount(input2.count, 2)
+    assert.strictEqual(input2.count, 2)
 
     const [output] = trade.outputs
     assert.strictEqual(output.name, 'wheat')
-    expectAmount(output.count, 2)
+    assert.strictEqual(output.count, 2)
 
     await bot.trade(villager, 1, 11)
     shouldHaveEmeralds -= 11 * 2
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.pumpkin_pie.id), 0)
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.wheat.id), 22)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wheat.id), 22)
   }
 
   // Handle trade #3 -- takes 1x emerald and returns 4x glass
@@ -96,16 +88,16 @@ module.exports = () => async (bot) => {
 
     const [input] = trade.inputs
     assert.strictEqual(input.name, 'emerald')
-    expectAmount(input.count, 1)
+    assert.strictEqual(input.count, 1)
 
     const [output] = trade.outputs
     assert.strictEqual(output.name, 'glass')
-    expectAmount(output.count, 4)
+    assert.strictEqual(output.count, 4)
 
     await bot.trade(villager, 2, 11)
     shouldHaveEmeralds -= 11
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.glass.id), 44)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.glass.id), 44)
   }
 
   // Handle trade #4 -- takes [36x emerald, 1x book] and returns 1x wooden sword
@@ -116,7 +108,7 @@ module.exports = () => async (bot) => {
 
     const [input1, input2] = trade.inputs
     assert.strictEqual(input1.name, 'emerald')
-    expectAmount(input1.count, 36)
+    assert.strictEqual(input1.count, 36)
     assert.strictEqual(input2.name, 'book')
     assert.strictEqual(input2.count, 1)
 
@@ -126,9 +118,9 @@ module.exports = () => async (bot) => {
 
     await bot.trade(villager, 3, 11)
     shouldHaveEmeralds -= 11 * 36
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.emerald.id), shouldHaveEmeralds)
     assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.book.id), 0)
-    expectAmount(bot.currentWindow.count(bot.registry.itemsByName.wooden_sword.id), 11)
+    assert.strictEqual(bot.currentWindow.count(bot.registry.itemsByName.wooden_sword.id), 11)
   }
 
   function verifyTrade (trade) {


### PR DESCRIPTION
Item stacks became components in 1.20.5 and the NBT-era `Count` key in `/summon` is silently ignored, so every trade in the `trade` test cost 1 on 1.20.5+ and `expectAmount` had been loosened to accept anything ≥ 1. This emits `count` on those versions and makes `expectAmount` a strict `assert.strictEqual` everywhere, so a regression in trade pricing fails instead of passing quietly.

Side effect worth knowing: the 36-emerald trade now actually costs 36 on 1.20.5+, which means the test exercises the same input-slot transitions there as on older versions. Verified locally: `trade` passes on 1.20.6, 1.21.1, 1.21.11 (log now shows `36x Emerald and 1x Book`), and 1.19.2 unchanged.
