### PR TITLE
Fix the intermittent 26.1 external test failure: retry the status ping until the server answers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -35,6 +35,22 @@ const download = require('minecraft-wrap').download
 
 const MC_SERVER_PATH = path.join(__dirname, 'server')
 
+// wrap's start callback fires on the server's "Done" log line, which precedes
+// the server answering status requests — by ~80ms on 26.1. That gap is version
+// dependent, so retry rather than sleep a fixed time, and keep closeTimeout well
+// under the 120s hook budget so the retries fit.
+async function pingUntilReady (port, host, version, attempts = 5) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await mc.ping({ port, host, version, closeTimeout: 5 * 1000 })
+    } catch (err) {
+      console.log(`ping attempt ${attempt} failed: ${err.message}`)
+      if (attempt === attempts) throw err
+      await new Promise(resolve => setTimeout(resolve, 250))
+    }
+  }
+}
+
 for (const supportedVersion of mineflayer.testedVersions) {
   let PORT = 25565
   const registry = require('prismarine-registry')(supportedVersion)
@@ -105,23 +121,15 @@ for (const supportedVersion of mineflayer.testedVersions) {
             if (err) return done(err)
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
             trace.log('server started, pinging')
-            mc.ping({
-              port: PORT,
-              host: '127.0.0.1',
-              version: supportedVersion,
-              // fail well before the mocha hook timeout (120s) so a hung ping
-              // surfaces as an ETIMEDOUT error instead of a silent hook timeout
-              closeTimeout: 30 * 1000
-            }, (err, results) => {
-              if (err) {
-                trace.log('ping failed', { error: err?.message ?? String(err) })
-                return done(err)
-              }
+            pingUntilReady(PORT, '127.0.0.1', supportedVersion).then(results => {
               console.log('pong')
               trace.log('pong', { latency: results.latency })
               assert.ok(results.latency >= 0)
               assert.ok(results.latency <= 1000)
               begin()
+            }).catch(err => {
+              trace.log('ping failed', { error: err?.message ?? String(err) })
+              done(err)
             })
           })
         })


### PR DESCRIPTION
Reopened against master; originally #3976, merged into `ci/minecraft-wrap-json-fix`.

## Problem

The `26.1` external tests fail intermittently in CI with nothing but a generic hook timeout:

```
pinging 26.1 port : 34199
1) mineflayer_external 26.1v
     "before all" hook for "activateItem":
   Error: Timeout of 120000ms exceeded.
```

`pong` never prints. It is the only version this happens to — scanning every failed `MC …` job from the last 40 failed CI runs (119 jobs), the "ping sent, no pong" signature shows up **4 times, all on 26.1** (2026-07-23, 08-15, 08-18, 08-22) and **0 times across the other 27 versions**.

## Root cause

The server isn't answering status yet. A server closes status connections without replying — no packet, just a FIN — until it has built the status snapshot it serves, and that doesn't happen until startup has fully finished, which is slightly *after* the `Done (…)!` line is logged.

**What makes 26.1 different:** it saves every dimension after logging `Done` and before finishing startup. That's the `Saving chunks for level 'ServerLevel[world]'/…` line that only 26.1 prints after `Done`, in 12/12 CI samples versus 0/385 for every other version — so its gap is far wider than everyone else's.

`minecraft-wrap` calls back on the `Done` line, so we ping squarely inside that gap. Probing a real server every 25 ms across a boot:

| version | closes status connections until | first successful ping |
|---|---|---|
| **26.1** | **+52 ms after `Done`** | **+77 ms** |
| 1.21.8 | −11 ms (before `Done`) | +14 ms |

And `mc.ping` can't see any of it: it settles only on `server_info`, `ping`, or a client `error` — there's no `end` handler — so a closed connection silently waits out the whole `closeTimeout` and then blames a timeout.

## Fix

Retry the ping instead of trusting the first one, with a `closeTimeout` short enough that a failed attempt is worth retrying rather than blowing the hook budget. The `latency <= 1000` assertion is unchanged; it just runs on the attempt that succeeds.

A fixed sleep after `Done` was the alternative — rejected because it's a constant tuned to today's startup sequence, would silently break the next time a version adds post-`Done` work, and would tax the 27 versions that are ready before `Done`. A retry costs nothing when the server is already answering.

[PrismarineJS/node-minecraft-protocol#1514](https://github.com/PrismarineJS/node-minecraft-protocol/pull/1514) fixes the blindness upstream; once it lands each refused attempt fails immediately instead of burning the timeout, and the retry here becomes near-free. The short `closeTimeout` still earns its keep after that, as the bound for a server that stays silent rather than closing.

## Verification

Against a real 26.1 server, `-g "26.1v activateItem"`:

- **before** — reproduces deterministically: `pinging 26.1 port : 43207`, no `pong`, `Timeout of 120000ms exceeded` after two minutes.
- **after, race hit** — the first attempts fail and are retried, then `pong`, then the bot logs in.
- **after, race not hit** — immediate `pong`, `✔ activateItem (1694ms)`.

## Follow-up (not in this PR)

`minecraft-wrap`'s `startServer` callback fires on the `Done` line, which as of 26.1 no longer means the server is ready. Waiting for a successful status ping there would fix this for every consumer.

