### PR TITLE
test(bed): wait for chunks instead of sleeping a fixed 3s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -2,8 +2,11 @@ const assert = require('assert')
 const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
-  // Wait a few seconds for chunks
-  await bot.test.wait(3000)
+  // The bed is placed relative to the bot, so the chunks around it have to be
+  // loaded before blockAt can see it. Wait on the chunks themselves rather than
+  // sleeping a fixed 3s: it is both faster and does not silently under-wait on
+  // a slow machine.
+  await bot.waitForChunksToLoad()
   const midnight = 18000
   const bedItem = bot.registry.itemsArray.find(item => item.name.endsWith('bed'))
   const bedPos1 = bot.entity.position.offset(2, 0, 0).floored()

--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -2,10 +2,8 @@ const assert = require('assert')
 const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
-  // The bed is placed relative to the bot, so the chunks around it have to be
-  // loaded before blockAt can see it. Wait on the chunks themselves rather than
-  // sleeping a fixed 3s: it is both faster and does not silently under-wait on
-  // a slow machine.
+  // The bed is placed relative to the bot; blockAt cannot see it until the
+  // surrounding chunks are loaded.
   await bot.waitForChunksToLoad()
   const midnight = 18000
   const bedItem = bot.registry.itemsArray.find(item => item.name.endsWith('bed'))


### PR DESCRIPTION
Reopened against master; originally #3977, merged into `ci/minecraft-wrap-json-fix`.

The bed test opens with:

```js
// Wait a few seconds for chunks
await bot.test.wait(3000)
```

mineflayer already ships the event-based version of exactly that wait — `bot.waitForChunksToLoad()` (`lib/plugins/blocks.js`, typed in `index.d.ts`) — so this swaps the fixed sleep for it.

It's both faster and more correct. The fixed sleep over-waits on a fast machine, where the chunks around the bot are typically already loaded, and can silently under-wait on a slow one — in which case the `blockAt` assertions a few lines down fail for a reason that has nothing to do with beds.

`waitForChunksToLoad()` checks the 5x5 chunk area around the bot and skips columns that are already loaded, so it returns promptly in the common case. The bed is placed at `bot.entity.position.offset(2, 0, 0)`, well inside that area.

### Measurements

Against a real 26.1 server, `-g "mineflayer_external 26.1v bed"`, test duration only:

| | duration |
|---|---|
| before | 10922ms |
| after | 7239ms, 6912ms |

Roughly 3–3.7s off the single most expensive non-`consume` external test, on every tested version.

### Context

`bed` is the largest instance of a broader pattern — the external tests hold about 25s of unconditional `bot.test.wait(...)` per version, which is ~11.6 minutes across the 28-version matrix. Notable remaining ones are `digWaterSpeed` (3500ms), the three `example*` tests (2000ms each), and a 1000ms tier. This PR is deliberately scoped to the one test so the approach can be reviewed before applying it more widely.

Not touched here: `bed`'s second `await bot.test.wait(1000)`, which guards `/setblock` propagation rather than chunk loading and needs a different replacement (polling `blockAt` until the bed appears). Happy to fold it in if you'd prefer them together.
