### PR TITLE
Set test server view-distance to 8 to speed up chunk streaming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -27,6 +27,9 @@ const propOverrides = {
   'spawn-monsters': 'false',
   'generate-structures': 'false',
   'enable-command-block': 'true',
+  // 8 is the floor: nether portal travel force-generates ±128 blocks (8 chunks)
+  // regardless, and blockfinder.js findBlocks uses maxDistance 128
+  'view-distance': '8',
   'use-native-transport': 'false' // java 16 throws errors without this, https://www.spigotmc.org/threads/unable-to-access-address-of-buffer.311602
 }
 


### PR DESCRIPTION
Reopened against master; originally #3991, merged into `ci/minecraft-wrap-json-fix`.

The default `view-distance` of 10 makes each test server generate and stream a 21×21 chunk square around the bot on every dimension change and far teleport.

The dominant cost is in the nether test: 1.8's `Teleporter.placeInExistingPortal` scans ±128 blocks (a 17×17 chunk square) around the destination and force-generates every chunk it reads, synchronously, on the server thread. Chunks past that square — view-distance 9 and 10's outer rings, 152 chunks — are generated and sent purely for streaming and never read by anything.

Measured on 1.8.8 (isolated `mocha -g "1.8.8v nether"`):

| view-distance | nether test |
|---|---|
| 10 (default) | 6655ms |
| 8 | 4357ms |
| 4 | 4214ms |

8 is the floor for this suite: `examples/blockfinder.js` uses `findBlocks({maxDistance: 128})` — exactly 8 chunks — and at view-distance 4 the blockfinder + all three child-bot example tests fail. Going below 8 also buys almost nothing (~140ms) because the portal scan's ±128-block generation happens regardless.

Full 1.8.8 suite at view-distance 8 is otherwise unchanged: 71 passing / 2 pending, same as baseline; every non-nether test stays within noise since they run inside the pre-generated spawn region.
