### PR TITLE
test(consume): eat one bread instead of four and wait on the health event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,18 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      # the concurrent per-version test processes, which tear each other's
-      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
-      - name: Install minecraft-wrap with the concurrent download fix
-        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
+      # Unreleased upstream fixes the external tests depend on:
+      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      #   the concurrent per-version test processes, which tear each other's
+      #   writes (PrismarineJS/node-minecraft-wrap#111).
+      # - minecraft-protocol's ping never rejects when the server closes the
+      #   status connection, so the retry in externalTest.js waits out the
+      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
+      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
+        run: |
+          npm install --no-save \
+            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
+            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
+      # minecraft-wrap 1.9.0 persists the version manifest to a path shared by
+      # the concurrent per-version test processes, which tear each other's
+      # writes. Pin the fix until it is released (PrismarineJS/node-minecraft-wrap#111).
+      - name: Install minecraft-wrap with the concurrent download fix
+        run: npm install --no-save PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b
 
       - name: Start Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,18 +66,6 @@ jobs:
           java-package: jre
       - name: Install Dependencies
         run: npm install
-      # Unreleased upstream fixes the external tests depend on:
-      # - minecraft-wrap 1.9.0 persists the version manifest to a path shared by
-      #   the concurrent per-version test processes, which tear each other's
-      #   writes (PrismarineJS/node-minecraft-wrap#111).
-      # - minecraft-protocol's ping never rejects when the server closes the
-      #   status connection, so the retry in externalTest.js waits out the
-      #   whole closeTimeout per attempt (PrismarineJS/node-minecraft-protocol#1514).
-      - name: Install unreleased minecraft-wrap and minecraft-protocol fixes
-        run: |
-          npm install --no-save \
-            PrismarineJS/node-minecraft-wrap#d782f647093b21627fefebbc2b9c144429cc954b \
-            PrismarineJS/node-minecraft-protocol#0903e593a9936a5e5deffc1d4b229230de4258d8
 
       - name: Start Tests
         run: |

--- a/test/externalTests/consume.js
+++ b/test/externalTests/consume.js
@@ -1,9 +1,10 @@
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
-  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.bread.id, 5, 0))
+  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.bread.id, 1, 0))
   await bot.test.becomeSurvival()
   // Cannot consume if bot.food === 20
   await assert.rejects(bot.consume, (err) => {
@@ -17,18 +18,18 @@ module.exports = () => async (bot) => {
 
   await bot.test.becomeSurvival()
 
-  while (bot.food > 0) {
+  // Drain a little hunger so consuming is legal, waiting on the food update
+  // instead of polling on a fixed sleep. One bread is enough to show the
+  // consume state transitions; eating back to 20 re-runs the identical path.
+  while (bot.food === 20) {
     if (bot.supportFeature('effectAreNotPrefixed')) bot.test.sayEverywhere('/effect give @s hunger 1 255')
     else if (bot.supportFeature('effectAreMinecraftPrefixed')) bot.test.sayEverywhere(`/effect ${bot.username} minecraft:hunger 1 255`)
-    await bot.test.wait(500)
+    await onceWithCleanup(bot, 'health', { timeout: 5000 })
   }
 
   assert.ok(!bot.usingHeldItem)
-  while (bot.food < 20) {
-    const consume = bot.consume()
-    assert.ok(bot.usingHeldItem)
-    await consume
-    assert.ok(!bot.usingHeldItem)
-    await bot.test.wait(100)
-  }
+  const consume = bot.consume()
+  assert.ok(bot.usingHeldItem)
+  await consume
+  assert.ok(!bot.usingHeldItem)
 }


### PR DESCRIPTION
Reopened against master; originally #3994, merged into `ci/minecraft-wrap-json-fix`.

The consume test was the slowest test in the suite after fishing (~8.6-8.9s per version in the matrix), and almost all of that time re-proved things it had already asserted:

- The eat loop drained hunger to 0 and then ate 4 breads to refill to 20, but every iteration asserts the identical `usingHeldItem` true -> false transition — iterations 2-4 add ~5.1s of vanilla's fixed 32-tick eat animation without new coverage. Nothing asserts the final food level.
- The drain loop polled on a fixed `wait(500)` and ground food all the way to 0, when `consume()` only requires food < 20.

Now the drain applies the hunger effect and waits on the `health` event, stopping at the first drop below 20, and a single bread exercises the same reject-at-full-hunger check and consume transitions.

Measured: 8.86s -> 2.41s on 1.8.8, ~9s -> 3.26s on 26.1. What remains is ~70% the irreducible eat animation (1.65s) plus shared per-test reset.

Exact before/after phase timings from instrumented runs:

| Phase | Before | After |
|---|---|---|
| setup + reject-check | 0.11s | 0.11s |
| hunger drain | 1.50s (3 fixed 500ms polls, to food=0) | 0.29s (health event, stops at food=19) |
| eating | 6.79s (4 breads) | 1.65s (1 bread) |
