### PR TITLE
test: serialize packet traces on a worker thread

### DIFF
--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -3,10 +3,9 @@
 //   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
 //   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
 //
-// Serialization runs on a worker thread: stringifying a chunk packet's Buffer
-// takes ~100ms+, and doing that inline for a burst of chunk packets starves the
-// bot's physics timers. `pending` counts records posted but not yet on disk so
-// process exit can wait for the worker to drain.
+// Serialization must never run on the bot's thread: a burst of chunk packets
+// would stall its event loop. `pending` is the number of records posted but not
+// yet on disk and must reach zero before the process exits.
 const fs = require('fs')
 const { Worker, isMainThread, parentPort, workerData } = require('worker_threads')
 
@@ -14,8 +13,7 @@ if (!isMainThread) {
   const { file, pending } = workerData
   const stream = fs.createWriteStream(file, { flags: 'w' })
   const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
-  // Structured clone turns Buffers into plain Uint8Arrays, which JSON.stringify
-  // would print as {"0":..}; rewrap (zero-copy) to keep Buffer's {type,data} form.
+  // Buffers arrive as plain Uint8Arrays and must still serialize in Buffer's {type,data} form.
   const rewrap = (o) => {
     if (o instanceof Uint8Array) return Buffer.from(o.buffer, o.byteOffset, o.byteLength)
     if (o && typeof o === 'object') for (const k in o) o[k] = rewrap(o[k])

--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -2,27 +2,64 @@
 //   {"ts":...,"type":"PACKET","dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
 //   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
 //   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
+//
+// Serialization runs on a worker thread: stringifying a chunk packet's Buffer
+// takes ~100ms+, and doing that inline for a burst of chunk packets starves the
+// bot's physics timers. `pending` counts records posted but not yet on disk so
+// process exit can wait for the worker to drain.
 const fs = require('fs')
+const { Worker, isMainThread, parentPort, workerData } = require('worker_threads')
 
-let stream
-const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
+if (!isMainThread) {
+  const { file, pending } = workerData
+  const stream = fs.createWriteStream(file, { flags: 'w' })
+  const bigintSafe = (k, v) => typeof v === 'bigint' ? v.toString() : v
+  // Structured clone turns Buffers into plain Uint8Arrays, which JSON.stringify
+  // would print as {"0":..}; rewrap (zero-copy) to keep Buffer's {type,data} form.
+  const rewrap = (o) => {
+    if (o instanceof Uint8Array) return Buffer.from(o.buffer, o.byteOffset, o.byteLength)
+    if (o && typeof o === 'object') for (const k in o) o[k] = rewrap(o[k])
+    return o
+  }
+  parentPort.on('message', (record) => {
+    stream.write(`${JSON.stringify(rewrap(record), bigintSafe)}\n`, () => {
+      Atomics.sub(pending, 0, 1)
+      Atomics.notify(pending, 0)
+    })
+  })
+} else {
+  let worker
+  let pending
+  const getWorker = () => {
+    if (worker) return worker
+    pending = new Int32Array(new SharedArrayBuffer(4))
+    worker = new Worker(__filename, { workerData: { file: process.env.TRACE, pending } })
+    worker.unref()
+    process.on('exit', () => {
+      let n
+      while ((n = Atomics.load(pending, 0)) > 0) Atomics.wait(pending, 0, n, 10000)
+    })
+    return worker
+  }
 
-function emit (record) {
-  if (!process.env.TRACE) return
-  stream = stream ?? fs.createWriteStream(process.env.TRACE, { flags: 'w' })
-  stream.write(`${JSON.stringify({ ts: Date.now(), ...record }, bigintSafe)}\n`)
+  function emit (record) {
+    if (!process.env.TRACE) return
+    const w = getWorker()
+    Atomics.add(pending, 0, 1)
+    w.postMessage({ ts: Date.now(), ...record })
+  }
+
+  function write (type, name, data = null) {
+    emit({ type, name, data })
+  }
+
+  function packet (dir, name, data) {
+    emit({ type: 'PACKET', dir, name, data })
+  }
+
+  function log (msg, args) {
+    emit({ type: 'LOG', msg, args })
+  }
+
+  module.exports = { write, packet, log }
 }
-
-function write (type, name, data = null) {
-  emit({ type, name, data })
-}
-
-function packet (dir, name, data) {
-  emit({ type: 'PACKET', dir, name, data })
-}
-
-function log (msg, args) {
-  emit({ type: 'LOG', msg, args })
-}
-
-module.exports = { write, packet, log }

--- a/test/traceTest.js
+++ b/test/traceTest.js
@@ -10,8 +10,7 @@ describe('packet trace', () => {
   const RECORDS = 40
   const CHUNK_BYTES = 800000
 
-  // The child mirrors what the external test harness does: emit a burst of
-  // chunk-sized packets from the main thread, then exit without waiting.
+  // Records posted before an immediate process.exit must still reach disk.
   const child = `
     const trace = require(${JSON.stringify(path.resolve(__dirname, 'common/trace.js'))})
     const data = Buffer.alloc(${CHUNK_BYTES}, 1)
@@ -27,7 +26,6 @@ describe('packet trace', () => {
     const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-')), 'trace.jsonl')
     const elapsedMs = Number(execFileSync(process.execPath, ['-e', child], { env: { ...process.env, TRACE: file } }))
 
-    // Serializing ${RECORDS} chunk packets inline takes seconds; posting them to the worker takes milliseconds.
     assert.ok(elapsedMs < 500, `emitting ${RECORDS} records blocked the caller for ${elapsedMs}ms`)
 
     const lines = fs.readFileSync(file, 'utf8').trimEnd().split('\n')

--- a/test/traceTest.js
+++ b/test/traceTest.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+describe('packet trace', () => {
+  const RECORDS = 40
+  const CHUNK_BYTES = 800000
+
+  // The child mirrors what the external test harness does: emit a burst of
+  // chunk-sized packets from the main thread, then exit without waiting.
+  const child = `
+    const trace = require(${JSON.stringify(path.resolve(__dirname, 'common/trace.js'))})
+    const data = Buffer.alloc(${CHUNK_BYTES}, 1)
+    const start = process.hrtime.bigint()
+    for (let i = 0; i < ${RECORDS}; i++) trace.packet('S2C', 'map_chunk_bulk', { i, data })
+    trace.log('done', { n: BigInt(${RECORDS}) })
+    process.stdout.write(String(Number(process.hrtime.bigint() - start) / 1e6))
+    process.exit(0)
+  `
+
+  it('does not block the caller and loses nothing on exit', function () {
+    this.timeout(60000)
+    const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'trace-')), 'trace.jsonl')
+    const elapsedMs = Number(execFileSync(process.execPath, ['-e', child], { env: { ...process.env, TRACE: file } }))
+
+    // Serializing ${RECORDS} chunk packets inline takes seconds; posting them to the worker takes milliseconds.
+    assert.ok(elapsedMs < 500, `emitting ${RECORDS} records blocked the caller for ${elapsedMs}ms`)
+
+    const lines = fs.readFileSync(file, 'utf8').trimEnd().split('\n')
+    assert.strictEqual(lines.length, RECORDS + 1)
+
+    const record = JSON.parse(lines[0])
+    assert.strictEqual(typeof record.ts, 'number')
+    delete record.ts
+    const expected = { type: 'PACKET', dir: 'S2C', name: 'map_chunk_bulk', data: { i: 0, data: Buffer.alloc(CHUNK_BYTES, 1) } }
+    assert.strictEqual(JSON.stringify(record), JSON.stringify(expected))
+
+    assert.strictEqual(lines[RECORDS].slice(lines[RECORDS].indexOf('"type"')), `"type":"LOG","msg":"done","args":{"n":"${RECORDS}"}}`)
+  })
+})


### PR DESCRIPTION
Investigating the 1.8.8 failure in #4015 (https://github.com/PrismarineJS/mineflayer/actions/runs/33038645209/job/98407102446): after the bot enters the nether, the 1.8.8 server streams ~44 `map_chunk_bulk` packets (~775KB each). The `TRACE` hook `JSON.stringify`s every packet inline on the `packet` event; `Buffer#toJSON` expands each one into a 775K-element array, ~100ms+ per packet on CI. Handled back to back that blocked the event loop for ~10s, physics timers never fired, the gradual `lookAt` inside `placeBlock` never advanced, and the nether test's 5s `signOpen` wait timed out — leaving the bot in the nether for the retries and for `rayTrace`. Mineflayer's own chunk handling is not the cost (`Chunk.load` + `setColumn` is ~28ms for all 44 packets); the tracer is.

- `trace.js` now serializes and writes on a `worker_threads` Worker. The main thread only pays `postMessage` (~3ms for 44 chunk packets vs 250ms–2.5s locally). Output format is byte-identical: Buffers come out of structured clone as `Uint8Array`, so the worker rewraps them zero-copy before stringifying to keep `{type:"Buffer",data:[...]}`.
- Mocha runs with `--exit`, so a shared pending counter lets the `exit` handler `Atomics.wait` until the worker has written every record. Public API (`write`/`packet`/`log`) is unchanged.
- `test/traceTest.js` emits a burst of chunk-sized records from a child process and exits immediately, asserting the caller wasn't blocked, nothing was lost, and the format matches inline `JSON.stringify`. It fails against the previous tracer (blocked ~2s locally).

Verified the full 1.8.8 external suite locally with `TRACE` set: 49 passing, no packet-hook stall over 30ms.