### PR TITLE
test: always write the packet trace, defaulting to a timestamped file in tmpdir

### DIFF
--- a/test/common/trace.js
+++ b/test/common/trace.js
@@ -1,4 +1,5 @@
-// TRACE=<file> writes one JSON stream for analysis with jq afterwards:
+// Writes one JSON stream for analysis with jq afterwards (path is printed when first opened;
+// override it with TRACE=<file>):
 //   {"ts":...,"type":"PACKET","dir":"S2C"|"C2S","name":<packet>,"data":{...}}   raw packets
 //   {"ts":...,"type":"MODEL","name":"updateSlot","data":{...}}  inventory model writes
 //   {"ts":...,"type":"LOG","msg":<message>,"args":{...}}        test boundaries & harness setup stages
@@ -7,7 +8,12 @@
 // would stall its event loop. `pending` is the number of records posted but not
 // yet on disk and must reach zero before the process exits.
 const fs = require('fs')
+const os = require('os')
+const path = require('path')
 const { Worker, isMainThread, parentPort, workerData } = require('worker_threads')
+
+// pid keeps concurrent mocha processes (one per version in CI) from sharing a file
+const file = process.env.TRACE ?? path.join(os.tmpdir(), `mineflayer-trace-${new Date().toISOString().replace(/[:.]/g, '-')}-${process.pid}.jsonl`)
 
 if (!isMainThread) {
   const { file, pending } = workerData
@@ -31,8 +37,9 @@ if (!isMainThread) {
   const getWorker = () => {
     if (worker) return worker
     pending = new Int32Array(new SharedArrayBuffer(4))
-    worker = new Worker(__filename, { workerData: { file: process.env.TRACE, pending } })
+    worker = new Worker(__filename, { workerData: { file, pending } })
     worker.unref()
+    console.log(`trace: ${file}`)
     process.on('exit', () => {
       let n
       while ((n = Atomics.load(pending, 0)) > 0) Atomics.wait(pending, 0, n, 10000)
@@ -41,7 +48,6 @@ if (!isMainThread) {
   }
 
   function emit (record) {
-    if (!process.env.TRACE) return
     const w = getWorker()
     Atomics.add(pending, 0, 1)
     w.postMessage({ ts: Date.now(), ...record })

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -14,22 +14,20 @@ function inject (bot, wrap) {
   console.log(bot.version)
 
   bot.test = {}
-  if (process.env.TRACE) {
-    bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
-    const oldWrite = bot._client.write
-    bot._client.write = function (name, data) {
-      trace.packet('C2S', name, data)
-      oldWrite.apply(this, arguments)
-    }
-    bot.test.dumpMarker = msg => trace.log(msg)
-    bot.once('spawn', () => {
-      const orig = bot.inventory.updateSlot.bind(bot.inventory)
-      bot.inventory.updateSlot = (slot, item) => {
-        trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
-        return orig(slot, item)
-      }
-    })
+  bot._client.on('packet', (data, meta) => trace.packet('S2C', meta.name, data))
+  const oldWrite = bot._client.write
+  bot._client.write = function (name, data) {
+    trace.packet('C2S', name, data)
+    oldWrite.apply(this, arguments)
   }
+  bot.test.dumpMarker = msg => trace.log(msg)
+  bot.once('spawn', () => {
+    const orig = bot.inventory.updateSlot.bind(bot.inventory)
+    bot.inventory.updateSlot = (slot, item) => {
+      trace.write('MODEL', 'updateSlot', { slot, item: item ? { name: item.name, count: item.count } : null })
+      return orig(slot, item)
+    }
+  })
   bot.test.groundY = bot.supportFeature('tallWorld') ? -60 : 4
   bot.test.sayEverywhere = sayEverywhere
   bot.test.clearInventory = clearInventory


### PR DESCRIPTION
The TRACE jsonl was opt-in, so a flaky local run left nothing to look at unless you remembered to set `TRACE` beforehand — the same gap CI closed by always setting it. Recording is cheap (<1% runtime), so default it on:

- `TRACE=<file>` still overrides the path; otherwise the trace goes to `<tmpdir>/mineflayer-trace-<ISO timestamp>-<pid>.jsonl`. The pid suffix keeps concurrent mocha processes (one per version in CI) apart.
- The path is printed (`trace: /tmp/...`) when the stream first opens, i.e. right under the `mineflayer_external <v>` title.
- With no disabled state the `if (process.env.TRACE)` guards go away; `bot.test.dumpMarker` is now always defined.

CI is unchanged — it still sets `TRACE` explicitly so the artifact copy keeps working.


Supersedes #3987, which GitHub closed when its already-merged base branch was deleted.
