### PR TITLE
test: detect and reconnect when the server stops reading the bot socket

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -9,7 +9,7 @@ const path = require('path')
 
 const { getPort } = require('./common/util')
 const trace = require('./common/trace')
-const { once } = require('../lib/promise_utils')
+const { once, onceWithCleanup, sleep } = require('../lib/promise_utils')
 
 // set this to false if you want to test without starting a server automatically
 const START_THE_SERVER = true
@@ -74,7 +74,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
     before(function (done) {
       this.timeout(1000 * 120)
+      let loginAttempts = 0
       function begin () {
+        loginAttempts++
         bot = mineflayer.createBot({
           username: 'flatbot',
           viewDistance: 'tiny',
@@ -91,6 +93,15 @@ for (const supportedVersion of mineflayer.testedVersions) {
         bot._client.on('error', err => trace.log('bot client error', { error: err?.message ?? String(err) }))
         bot._client.on('end', reason => trace.log('bot client ended', { reason }))
         bot.once('login', () => trace.log('bot logged in'))
+        // Console commands reach the bot even when the server has stopped
+        // reading its socket; the server echoing our skinParts (127) in our
+        // own entity_metadata is the only proof it is reading us.
+        let settingsAcked
+        bot._client.once('login', packet => {
+          settingsAcked = onceWithCleanup(bot._client, 'entity_metadata', {
+            checkCondition: p => p.entityId === packet.entityId && p.metadata.some(m => m.value === 127)
+          })
+        })
         bot.once('spawn', () => {
           console.log('bot spawned, opping...')
           trace.log('bot spawned, opping')
@@ -102,8 +113,18 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
           bot.once('messagestr', msg => {
             if (msg.includes('Made flatbot a server operator') || msg === '[Server: Opped flatbot]') {
-              trace.log('bot opped, setup done')
-              done()
+              Promise.race([settingsAcked, sleep(3000).then(() => { throw new Error('server is not reading the bot socket') })])
+                .then(() => {
+                  trace.log('bot opped, setup done')
+                  done()
+                }, err => {
+                  trace.log(err.message, { loginAttempts })
+                  console.log(err.message)
+                  if (loginAttempts >= 3) return done(err)
+                  wrap.writeServer('deop flatbot\n')
+                  bot.end()
+                  bot._client.once('end', begin)
+                })
             }
           })
         })

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -39,6 +39,7 @@ function inject (bot, wrap) {
   bot.test.setInventorySlot = setInventorySlot
   bot.test.placeBlock = placeBlock
   bot.test.runExample = runExample
+  bot.test.serverReads = serverReads
   bot.test.tellAndListen = tellAndListen
   bot.test.selfKill = selfKill
   bot.test.killEntity = killEntity
@@ -239,7 +240,21 @@ function inject (bot, wrap) {
     runningExample = null
   }
 
-  async function runExample (file, run) {
+  // The server echoes a bot's settings skinParts (127) in that bot's
+  // entity_metadata only once it has read the bot's socket. On <=1.20.1 a
+  // login race can leave a socket the server never reads again, and console
+  // commands still reach that bot, so this echo is the only proof of life.
+  async function serverReads (username, timeoutMs = 3000) {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const metadata = bot.players[username]?.entity?.metadata
+      if (metadata && Object.values(metadata).includes(127)) return
+      await sleep(50)
+    }
+    throw Object.assign(new Error(`server is not reading ${username}'s socket`), { serverNotReading: true })
+  }
+
+  async function runExample (file, run, attempt = 1) {
     let childBotName
     const abort = new AbortController()
     runningExample = abort
@@ -258,6 +273,7 @@ function inject (bot, wrap) {
              bot.players[childBotName].entity.position.distanceTo(targetPos) > 5) {
         await sleep(100)
       }
+      await serverReads(childBotName)
       bot.chat('loaded')
     }
 
@@ -314,6 +330,11 @@ function inject (bot, wrap) {
       await Promise.race([Promise.all([detectChildJoin(), runExampleOnReady()]), childDied])
     } catch (err) {
       console.log(err)
+      // Relaunching under the same name makes the server kick the dead session.
+      if (err.serverNotReading && attempt < 3) {
+        await closeExample()
+        return runExample(file, run, attempt + 1)
+      }
       return closeExample(err)
     }
     return closeExample()

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -245,13 +245,14 @@ function inject (bot, wrap) {
   // login race can leave a socket the server never reads again, and console
   // commands still reach that bot, so this echo is the only proof of life.
   async function serverReads (username, timeoutMs = 3000) {
-    const deadline = Date.now() + timeoutMs
-    while (Date.now() < deadline) {
-      const metadata = bot.players[username]?.entity?.metadata
-      if (metadata && Object.values(metadata).includes(127)) return
-      await sleep(50)
+    const echoed = entity => entity?.username === username && Object.values(entity.metadata).includes(127)
+    // The echo usually lands before this gate runs, so check before listening.
+    if (echoed(bot.players[username]?.entity)) return
+    try {
+      await onceWithCleanup(bot, 'entityUpdate', { timeout: timeoutMs, checkCondition: echoed })
+    } catch {
+      throw Object.assign(new Error(`server is not reading ${username}'s socket`), { serverNotReading: true })
     }
-    throw Object.assign(new Error(`server is not reading ${username}'s socket`), { serverNotReading: true })
   }
 
   async function runExample (file, run, attempt = 1) {

--- a/test/externalTests/spawnEvent.js
+++ b/test/externalTests/spawnEvent.js
@@ -1,5 +1,5 @@
 const mineflayer = require('mineflayer')
-const { once } = require('../../lib/promise_utils')
+const { once, onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   // Test spawn event on login
@@ -13,11 +13,17 @@ module.exports = () => async (bot) => {
       version: bot.version
     })
     await once(spawnBot, 'spawn')
+    // spawnbot logs in at the world spawn, possibly out of flatbot's view, so
+    // its entity metadata is no proof of life; a chat line reaching flatbot is.
+    spawnBot.chat('spawnbot-alive')
     try {
-      await bot.test.serverReads(spawnBot.username)
+      await onceWithCleanup(bot, 'chat', {
+        timeout: 3000,
+        checkCondition: (username, message) => username === spawnBot.username && message === 'spawnbot-alive'
+      })
       break
     } catch (err) {
-      if (attempt >= 3) throw err
+      if (attempt >= 3) throw new Error(`server is not reading ${spawnBot.username}'s socket`)
       spawnBot.end()
     }
   }

--- a/test/externalTests/spawnEvent.js
+++ b/test/externalTests/spawnEvent.js
@@ -3,14 +3,24 @@ const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   // Test spawn event on login
-  const spawnBot = mineflayer.createBot({
-    username: 'spawnbot',
-    viewDistance: 'tiny',
-    port: bot.test.port,
-    host: '127.0.0.1',
-    version: bot.version
-  })
-  await once(spawnBot, 'spawn')
+  let spawnBot
+  for (let attempt = 1; ; attempt++) {
+    spawnBot = mineflayer.createBot({
+      username: 'spawnbot',
+      viewDistance: 'tiny',
+      port: bot.test.port,
+      host: '127.0.0.1',
+      version: bot.version
+    })
+    await once(spawnBot, 'spawn')
+    try {
+      await bot.test.serverReads(spawnBot.username)
+      break
+    } catch (err) {
+      if (attempt >= 3) throw err
+      spawnBot.end()
+    }
+  }
   spawnBot.end()
 
   // Wait for the server to process the disconnection before killing the main bot


### PR DESCRIPTION
CI occasionally fails a whole version with 40+ `Event move did not fire` errors right after the `before` hook (e.g. 1.19.3 in https://github.com/PrismarineJS/mineflayer/actions/runs/33027267332). The server log for those runs shows zero `[flatbot: ...]` command feedback and `flatbot lost connection: Timed out` exactly 30s after login.

**Root cause** (vanilla server ≤1.20.1, not mineflayer): `Connection.sendPacket` calls `channel.config().setAutoRead(false)` on the main thread for each PLAY packet sent while the channel attr still says LOGIN (the whole `placeNewPlayer` burst), and queues `doSendPacket → setProtocol → setAutoRead(true)` on the netty IO thread. Netty re-arms `OP_READ` only on a 0→1 transition of the autoRead flag, but the queued `clearReadPending` drops it unconditionally. With ≥2 `doSendPacket` tasks pending when the main thread flips the flag, the channel ends up autoRead=true with `OP_READ` off, nothing in PLAY ever calls `read()` again, and `ReadTimeoutHandler(30)` kills the connection. Reproduced locally at ~1% of logins under CPU load (10% with `Connection` DEBUG logging); the bot's bytes sit unread in the server's kernel Recv-Q. 1.20.2+ moved the protocol switch onto the IO thread (MC-265209), so only ≤1.20.1 is affected. Nothing the client sends can re-arm the read, so the only fix is to detect it and reconnect.

**Detection**: console commands still reach the bot, so `op` succeeds. The server's first reaction to anything the bot sent is echoing its `settings` skinParts (127) in that bot's own `entity_metadata`, ~160ms after login (max 1.45s under load), never on a stalled connection.

**Where it's applied** — every bot the suite creates, since the stalls actually hit in CI were not flatbot's (the `inventory` example child on 1.17.1, `spawnbot` on 1.19.3), each burning a 90s mocha timeout:
- `before` hook: after `op` succeeds, require flatbot's own echo (3s grace), otherwise `deop`, end the bot and log in again.
- `bot.test.serverReads(username)` in `testCommon.js` polls the joined bot's entity metadata for the echo. `runExample` uses it after the child has been teleported into view; a stalled child is killed and relaunched under the same name, which makes the server kick the dead session.
- `spawnEvent`: `spawnbot` logs in at the world spawn, which on ≤1.17 superflat worlds is hundreds of blocks from flatbot, so its entity (and metadata) is never in view. It sends a chat line instead, which the server only broadcasts once it has read that socket; if flatbot doesn't get it within 3s the bot is ended and recreated. Three attempts each.

Zero cost on healthy logins (the echo normally lands before the `op` message / the child's arrival the tests already wait on).

**Validation**
- 1.19.3: 0/498 false positives on healthy logins under load; healthy suite 72/72; with `settings` deliberately dropped on the first login, the hook reconnected and the suite passed 72/72.
- `exampleBee`, `exampleInventory` on 1.16.5 and 1.21.8: pass, no gate trips.
- `spawnEvent` on 1.8.8, 1.16.5, 1.19.3, 1.21.8 (spawnbot logging in 100–400 blocks away on the first two): pass, single login each.
- Forced paths on 1.16.5: `spawnbot` chat suppressed on attempt 1 → gate tripped at 3s, attempt 2 passed; `runExample` with a forced stall on attempt 1 → child killed, relaunched, `exampleInventory` passed.

