### PR TITLE
test: patch Netty's lost-read-interest race in the test server via a javaagent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-java@v1.4.3
         with:
           java-version: 25
-          java-package: jre
+          java-package: jdk
       - name: Install Dependencies
         run: npm install
 

--- a/test/common/nettyAgent.js
+++ b/test/common/nettyAgent.js
@@ -1,0 +1,34 @@
+// Builds test/netty-agent into a -javaagent jar. Needs a JDK (javac + jar);
+// returns null when there is none so the suite still runs unpatched.
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const SRC = path.join(__dirname, '..', 'netty-agent')
+let built
+
+function tool (name) {
+  const home = process.env.JAVA_HOME
+  const candidate = home && path.join(home, 'bin', name)
+  return candidate && fs.existsSync(candidate) ? candidate : name
+}
+
+function build () {
+  if (built !== undefined) return built
+  const out = fs.mkdtempSync(path.join(os.tmpdir(), 'mineflayer-netty-agent-'))
+  const jar = path.join(out, 'netty-autoread-fix.jar')
+  const sources = fs.readdirSync(SRC).filter(f => f.endsWith('.java')).map(f => path.join(SRC, f))
+  try {
+    execFileSync(tool('javac'), ['-d', out, ...sources], { stdio: 'pipe' })
+    fs.writeFileSync(path.join(out, 'MANIFEST.MF'), 'Premain-Class: NettyAutoReadFixAgent\n')
+    execFileSync(tool('jar'), ['cfm', jar, path.join(out, 'MANIFEST.MF'), '-C', out, '.'], { stdio: 'pipe' })
+    built = jar
+  } catch (err) {
+    console.log(`netty agent not built, server runs unpatched: ${err.stderr?.toString().trim() || err.message}`)
+    built = null
+  }
+  return built
+}
+
+module.exports = { build }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -9,6 +9,7 @@ const path = require('path')
 
 const { getPort } = require('./common/util')
 const trace = require('./common/trace')
+const nettyAgent = require('./common/nettyAgent')
 const { once } = require('../lib/promise_utils')
 
 // set this to false if you want to test without starting a server automatically
@@ -120,6 +121,8 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
           trace.log('server jar downloaded, starting server')
           propOverrides['server-port'] = PORT
+          const agent = nettyAgent.build()
+          if (agent) process.env.JAVA_TOOL_OPTIONS = `${process.env.JAVA_TOOL_OPTIONS ?? ''} -javaagent:${agent}`.trim()
           wrap.startServer(propOverrides, (err) => {
             if (err) return done(err)
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)

--- a/test/netty-agent/NettyAutoReadFixAgent.java
+++ b/test/netty-agent/NettyAutoReadFixAgent.java
@@ -1,0 +1,67 @@
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.Label;
+import java.lang.classfile.MethodModel;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+/**
+ * Netty 4.1.x: AbstractNioChannel.clearReadPending0() is queued onto the event
+ * loop by setAutoRead(false) and drops OP_READ unconditionally when it runs.
+ * If autoRead has been switched back on in between, the channel is left with
+ * autoRead=true and no read interest, and nothing ever re-arms it. Rewrites the
+ * method to leave OP_READ alone when autoRead is already true:
+ *
+ *   readPending = false;
+ *   if (!config().isAutoRead()) ((AbstractNioUnsafe) unsafe()).removeReadOp();
+ */
+public class NettyAutoReadFixAgent {
+  static final String TARGET = "io/netty/channel/nio/AbstractNioChannel";
+  static final ClassDesc CHANNEL = ClassDesc.ofInternalName(TARGET);
+  static final ClassDesc NIO_UNSAFE = ClassDesc.ofInternalName(TARGET + "$AbstractNioUnsafe");
+  static final ClassDesc UNSAFE = ClassDesc.ofInternalName("io/netty/channel/Channel$Unsafe");
+  static final ClassDesc CONFIG = ClassDesc.ofInternalName("io/netty/channel/ChannelConfig");
+
+  public static void premain(String args, Instrumentation inst) {
+    inst.addTransformer(new ClassFileTransformer() {
+      public byte[] transform(ClassLoader loader, String name, Class<?> cls, ProtectionDomain pd, byte[] bytes) {
+        if (!TARGET.equals(name)) return null;
+        try {
+          return patch(bytes);
+        } catch (Throwable t) {
+          System.err.println("netty-autoread-fix: leaving " + name + " unpatched: " + t);
+          return null;
+        }
+      }
+    });
+  }
+
+  static byte[] patch(byte[] bytes) {
+    ClassFile cf = ClassFile.of();
+    ClassModel cm = cf.parse(bytes);
+    boolean[] patched = { false };
+    byte[] out = cf.transformClass(cm, (cb, ce) -> {
+      if (ce instanceof MethodModel mm && mm.methodName().equalsString("clearReadPending0")) {
+        patched[0] = true;
+        cb.withMethod(mm.methodName(), mm.methodType(), mm.flags().flagsMask(), mb -> mb.withCode(code -> {
+          Label done = code.newLabel();
+          code.aload(0).iconst_0().putfield(CHANNEL, "readPending", ConstantDescs.CD_boolean)
+              .aload(0).invokevirtual(CHANNEL, "config", MethodTypeDesc.of(CONFIG))
+              .invokeinterface(CONFIG, "isAutoRead", MethodTypeDesc.of(ConstantDescs.CD_boolean))
+              .ifne(done)
+              .aload(0).invokevirtual(CHANNEL, "unsafe", MethodTypeDesc.of(UNSAFE))
+              .checkcast(NIO_UNSAFE).invokevirtual(NIO_UNSAFE, "removeReadOp", MethodTypeDesc.of(ConstantDescs.CD_void))
+              .labelBinding(done).return_();
+        }));
+      } else {
+        cb.with(ce);
+      }
+    });
+    System.err.println("netty-autoread-fix: " + (patched[0] ? "patched" : "no clearReadPending0 in") + " " + TARGET);
+    return patched[0] ? out : null;
+  }
+}


### PR DESCRIPTION
Companion to #4018. That PR detects the login stall and reconnects; this one removes it on the test server.

**The bug** (vanilla ≤1.20.1, Paper included): `Connection.sendPacket` calls `setAutoRead(false)` on the main thread for each PLAY packet sent while the channel attr still says LOGIN, and queues `setAutoRead(true)` on the netty IO thread. Netty re-arms `OP_READ` only on a 0→1 flip of the flag, but the queued `clearReadPending0` drops it unconditionally — so when `doSendPacket_i` runs between the main thread's toggles for i+1 and i+2, the channel ends up `autoRead=true` with no read interest, nothing re-arms it, and `ReadTimeoutHandler(30)` kills the connection. Reproduced deterministically on stock Netty 4.1.82 with latches, and on a real 1.19.3 server at ~1% of logins under CPU load (~10% with `Connection` DEBUG logging). Mojang rewrote protocol switching in 1.20.2 (MC-265209); Paper's archived ≤1.20.1 branches have no fix, and there is no property to toggle.

**The fix**: a `-javaagent` (`test/netty-agent/NettyAutoReadFixAgent.java`, source only) that rewrites `AbstractNioChannel.clearReadPending0` with the JDK `ClassFile` API to skip `removeReadOp()` when `autoRead` is already true. Bytecode-level, so it works on whatever Netty 4.1.x the server bundles (4.1.9–4.1.82 across 1.12–1.20.1) and is a logged no-op on 1.8.8's 4.0.23. `test/common/nettyAgent.js` compiles and jars it at test time and the harness attaches it via `JAVA_TOOL_OPTIONS`, so minecraft-wrap is untouched. If no JDK is present it logs and the suite runs unpatched.

**CI change**: `java-package: jre` → `jdk` so `javac`/`jar` exist on the runner (still Java 25).

**Validation**
- 1.19.3 (Netty 4.1.82, bundler jar): `patched`, 70/70
- 1.16.5 (Netty 4.1.25, shaded jar): `patched`, 69/69
- 1.8.8 (Netty 4.0.23): `no clearReadPending0`, 69/69
- Loaded-server login loop with DEBUG logging: 8 stalls / 60 logins unpatched → 0 / 800 patched.
