### PR TITLE
entities: apply spawn_entity velocity; test activateItem via the snowball it throws

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -230,6 +230,10 @@ function inject (bot) {
     const entity = entityData?.type === 'player'
       ? addNewPlayer(packet.entityId, packet.objectUUID, packet)
       : addNewNonPlayer(packet.entityId, packet.objectUUID, packet.type, packet)
+    // 1.8 omits velocity when objectData is 0
+    if (packet.velocity) {
+      entity.velocity.update(conv.fromNotchVelocity(new Vec3(packet.velocity.x, packet.velocity.y, packet.velocity.z)))
+    }
     bot.emit('entitySpawn', entity)
   })
 

--- a/test/externalTests/activateItem.js
+++ b/test/externalTests/activateItem.js
@@ -1,75 +1,34 @@
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
 
-  // Test that activateItem sends the bot's actual rotation (PR #3840).
-  // Only applies to versions that use the 'use_item' packet with rotation.
-  if (!bot.supportFeature('useItemWithOwnPacket')) return
-
   await bot.test.becomeCreative()
   await bot.test.clearInventory()
-
-  const snowballItem = bot.registry.itemsByName.snowball
-  if (!snowballItem) return
-
-  // Give the bot a snowball and switch to survival to throw it
-  await bot.test.setInventorySlot(36, new Item(snowballItem.id, 16, 0))
+  await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.snowball.id, 16, 0))
   await bot.test.becomeSurvival()
   await bot.test.wait(250)
 
-  // Look south (+Z direction): yaw = PI, pitch = 0
-  await bot.look(Math.PI, 0, true)
-  await bot.test.wait(250)
-
-  // Intercept the outgoing use_item packet to verify rotation
-  const sentPacket = await new Promise((resolve) => {
-    const origWrite = bot._client.write
-    bot._client.write = function (name, data) {
-      origWrite.apply(bot._client, arguments)
-      if (name === 'use_item') {
-        bot._client.write = origWrite
-        resolve(data)
-      }
-    }
+  // Throw a snowball and return the velocity the server spawned it with.
+  async function throwTowards (yaw) {
+    await bot.look(yaw, 0, true)
+    await bot.test.wait(250)
+    const spawned = onceWithCleanup(bot, 'entitySpawn', { checkCondition: e => /snowball/i.test(e.name), timeout: 5000 })
     bot.activateItem()
-  })
+    const [snowball] = await spawned
+    // The velocity can arrive in its own packet right after the spawn.
+    for (let i = 0; i < 40 && snowball.velocity.norm() === 0; i++) await bot.test.wait(50)
+    return snowball.velocity
+  }
 
-  // Verify the rotation was sent (not zeros)
-  assert(sentPacket.rotation, 'use_item packet should have rotation field')
-  const { x: sentYaw, y: sentPitch } = sentPacket.rotation
+  // yaw PI is notchian 0 (south, +z): the direction a server uses if rotation is dropped.
+  const south = await throwTowards(Math.PI)
+  assert(south.z > 0 && Math.abs(south.x) < Math.abs(south.z), `expected a southward throw, got ${south}`)
 
-  // With pitch = 0, the notchian pitch should be ~0
-  assert(Math.abs(sentPitch) < 1, `Pitch should be near 0 for level look, got ${sentPitch}`)
-
-  // With yaw = PI (south), the notchian yaw should be ~0 (due to toNotchianYaw = degrees(PI - yaw))
-  // toNotchianYaw(PI) = degrees(PI - PI) = 0
-  assert(Math.abs(sentYaw) < 1, `Yaw should be near 0 for south-facing look, got ${sentYaw}`)
-
-  // Now test a different direction: look east (yaw = PI/2 in mineflayer)
-  await bot.look(Math.PI * 3 / 2, -0.5, true)
-  await bot.test.wait(250)
-
-  const sentPacket2 = await new Promise((resolve) => {
-    const origWrite = bot._client.write
-    bot._client.write = function (name, data) {
-      origWrite.apply(bot._client, arguments)
-      if (name === 'use_item') {
-        bot._client.write = origWrite
-        resolve(data)
-      }
-    }
-    bot.activateItem()
-  })
-
-  const { x: sentYaw2, y: sentPitch2 } = sentPacket2.rotation
-
-  // toNotchianYaw(3*PI/2) = degrees(PI - 3*PI/2) = degrees(-PI/2) = -90
-  assert(Math.abs(sentYaw2 - (-90)) < 1, `Yaw should be near -90 for east-facing look, got ${sentYaw2}`)
-
-  // toNotchianPitch(-0.5) = degrees(0.5) ≈ 28.65
-  const expectedPitch = (0.5 * 180) / Math.PI
-  assert(Math.abs(sentPitch2 - expectedPitch) < 1, `Pitch should be near ${expectedPitch}, got ${sentPitch2}`)
+  // yaw 3PI/2 is notchian -90 (east, +x), so this only passes if the bot's rotation reached the server.
+  const east = await throwTowards(Math.PI * 3 / 2)
+  assert(east.x > 0 && Math.abs(east.z) < Math.abs(east.x), `expected an eastward throw, got ${east}`)
 
   await bot.test.becomeCreative()
   await bot.test.clearInventory()


### PR DESCRIPTION
The `activateItem` external test returned early on any version without `useItemWithOwnPacket`, so it never ran on 1.8, and it verified rotation by monkey-patching `bot._client.write` to inspect the outgoing packet. It now only looks at what the server does: throw a snowball south (notchian yaw 0, which is also what a server would do if the rotation were dropped), then east, and check the velocity the server spawns each snowball with points that way.

That surfaced a library gap: `spawn_entity` carries a velocity, but the handler ignored it, so `entity.velocity` at `entitySpawn` was zero on 1.21.6+ where the server no longer follows up with a separate `entity_velocity`. The handler now applies it, guarded for 1.8 where the field is omitted when `objectData` is 0.

Ran `mocha -g "<v>v activateItem"` locally on all 28 tested versions: 27 pass. 1.19.0 fails intermittently in `resetState` with `Out-of-order chat packet received` before the test body runs, at the same rate with the unmodified test, so it's the pre-existing 1.19.0 chat kick rather than this change.
