### PR TITLE
placeBlock: reject an occupied target up front; nether test clears its sign spot

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1961,7 +1961,7 @@ It rejects as soon as the server refuses the placement (for example because an e
  * `faceVector` - one of the six cardinal directions, such as `new Vec3(0, 1, 0)` for the top face,
    indicating which face of the `referenceBlock` to place the block against.
 
-The new block will be placed at `referenceBlock.position.plus(faceVector)`.
+The new block will be placed at `referenceBlock.position.plus(faceVector)`. Rejects immediately if that position is already occupied by a block the new one cannot replace (anything other than air, liquids, and replaceable plants such as grass or vines).
 
 #### bot.placeEntity(referenceBlock, faceVector)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1961,7 +1961,7 @@ It rejects as soon as the server refuses the placement (for example because an e
  * `faceVector` - one of the six cardinal directions, such as `new Vec3(0, 1, 0)` for the top face,
    indicating which face of the `referenceBlock` to place the block against.
 
-The new block will be placed at `referenceBlock.position.plus(faceVector)`. Rejects immediately if that position is already occupied by a block the new one cannot replace (anything other than air, liquids, and replaceable plants such as grass or vines).
+The new block will be placed at `referenceBlock.position.plus(faceVector)`. Rejects immediately if that position is already occupied by a block the new one cannot replace, as defined by the server's `minecraft:replaceable` block tag (air, liquids, fire, snow layers and replaceable plants such as grass or vines; a built-in list is used on servers older than 1.20 that do not send the tag).
 
 #### bot.placeEntity(referenceBlock, faceVector)
 

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -2,9 +2,9 @@ const { onceWithCleanup } = require('../promise_utils')
 
 module.exports = inject
 
-// Fallback for servers that never send the minecraft:replaceable block tag
-// (pre-1.20): blocks whose Material.isReplaceable() holds, minus tall flowers,
-// whose canBeReplaced() is false from 1.13 on. Names a version lacks are skipped.
+// Servers before 1.20 send no minecraft:replaceable block tag. These are the blocks whose
+// Material.isReplaceable() holds, minus tall flowers, whose canBeReplaced() is false from
+// 1.13 on. A name the version lacks is skipped.
 const REPLACEABLE_LEGACY = ['air', 'flowing_water', 'water', 'flowing_lava', 'lava', 'tallgrass', 'deadbush', 'double_plant', 'vine', 'fire', 'snow_layer', 'structure_void']
 const REPLACEABLE_FLAT = [
   'air', 'cave_air', 'void_air', 'water', 'lava', 'bubble_column', 'structure_void', 'light',

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -2,16 +2,28 @@ const { onceWithCleanup } = require('../promise_utils')
 
 module.exports = inject
 
-// Vanilla lets a placed block overwrite these; anything else at the target
-// makes the server reject the placement and only echo the unchanged block.
-const REPLACEABLE = new Set([
+// Fallback for servers that never send the minecraft:replaceable block tag
+// (pre-1.20): blocks whose Material.isReplaceable() holds, minus tall flowers,
+// whose canBeReplaced() is false from 1.13 on. Names a version lacks are skipped.
+const REPLACEABLE_LEGACY = ['air', 'flowing_water', 'water', 'flowing_lava', 'lava', 'tallgrass', 'deadbush', 'double_plant', 'vine', 'fire', 'snow_layer', 'structure_void']
+const REPLACEABLE_FLAT = [
   'air', 'cave_air', 'void_air', 'water', 'lava', 'bubble_column', 'structure_void', 'light',
-  'grass', 'short_grass', 'tall_grass', 'fern', 'large_fern', 'dead_bush', 'seagrass', 'tall_seagrass',
-  'vine', 'glow_lichen', 'sculk_vein', 'hanging_roots', 'nether_sprouts', 'crimson_roots', 'warped_roots',
+  'grass', 'tall_grass', 'fern', 'large_fern', 'dead_bush', 'seagrass', 'tall_seagrass',
+  'vine', 'glow_lichen', 'hanging_roots', 'nether_sprouts', 'crimson_roots', 'warped_roots',
   'fire', 'soul_fire', 'snow'
-])
+]
 
 function inject (bot) {
+  const names = bot.supportFeature('blockSchemeIsFlat') ? REPLACEABLE_FLAT : REPLACEABLE_LEGACY
+  let replaceable = new Set(names.map(name => bot.registry.blocksByName[name]?.id).filter(id => id !== undefined))
+
+  // The server's tag is authoritative and reflects datapacks; it is resent on /reload.
+  bot._client.on('tags', (packet) => {
+    const blockTags = packet.tags?.find(group => group.tagType === 'minecraft:block')
+    const tag = blockTags?.tags.find(t => t.tagName === 'minecraft:replaceable')
+    if (tag) replaceable = new Set(tag.entries)
+  })
+
   // Placements in flight per destination. The server's replies carry no
   // request id, so a reply can only be attributed when a single call is
   // waiting on that destination.
@@ -20,7 +32,7 @@ function inject (bot) {
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
     const oldBlock = bot.blockAt(dest)
-    if (oldBlock && !REPLACEABLE.has(oldBlock.name)) {
+    if (oldBlock && !replaceable.has(oldBlock.type)) {
       throw new Error(`Cannot place block at ${dest}: it is occupied by ${oldBlock.name}`)
     }
     await bot._genericPlace(referenceBlock, faceVector, options)

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -2,6 +2,15 @@ const { onceWithCleanup } = require('../promise_utils')
 
 module.exports = inject
 
+// Vanilla lets a placed block overwrite these; anything else at the target
+// makes the server reject the placement and only echo the unchanged block.
+const REPLACEABLE = new Set([
+  'air', 'cave_air', 'void_air', 'water', 'lava', 'bubble_column', 'structure_void', 'light',
+  'grass', 'short_grass', 'tall_grass', 'fern', 'large_fern', 'dead_bush', 'seagrass', 'tall_seagrass',
+  'vine', 'glow_lichen', 'sculk_vein', 'hanging_roots', 'nether_sprouts', 'crimson_roots', 'warped_roots',
+  'fire', 'soul_fire', 'snow'
+])
+
 function inject (bot) {
   // Placements in flight per destination. The server's replies carry no
   // request id, so a reply can only be attributed when a single call is
@@ -11,7 +20,9 @@ function inject (bot) {
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
     const oldBlock = bot.blockAt(dest)
-
+    if (oldBlock && !REPLACEABLE.has(oldBlock.name)) {
+      throw new Error(`Cannot place block at ${dest}: it is occupied by ${oldBlock.name}`)
+    }
     await bot._genericPlace(referenceBlock, faceVector, options)
 
     // Whether or not it placed anything, the server answers block_place with a

--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -33,6 +33,14 @@ module.exports = () => async (bot) => {
     lowerBlock = bot.blockAt(bot.entity.position.offset(0, -1, 0))
   }
 
+  // Nether roof vegetation (mushrooms) can generate on the target block and
+  // the server rejects placing over it.
+  const signPos = lowerBlock.position.offset(0, 1, 0)
+  if (bot.blockAt(signPos).name !== 'air') {
+    bot.test.sayEverywhere(`/setblock ${signPos.x} ${signPos.y} ${signPos.z} air`)
+    await onceWithCleanup(bot, `blockUpdate:${signPos}`, { timeout: 5000 })
+  }
+
   await bot.lookAt(lowerBlock.position, true)
   await bot.test.setInventorySlot(36, new Item(signItem.id, 1, 0))
   const signOpen = onceWithCleanup(bot, 'signOpen', { timeout: 5000 })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -244,6 +244,22 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    it('placeBlock rejects an occupied target before sending anything', (done) => {
+      const below = vec3(1, 64, 1)
+      const target = vec3(1, 65, 1)
+      bot.on('chunkColumnLoad', () => {
+        assert.rejects(bot.placeBlock(bot.blockAt(below), vec3(0, 1, 0)), /occupied by red_mushroom/)
+          .then(done, done)
+      })
+      server.on('playerJoin', (client) => {
+        client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(below, bot.registry.blocksByName.stone.id)
+        chunk.setBlockType(target, bot.registry.blocksByName.red_mushroom.id)
+        client.write('map_chunk', generateChunkPacket(chunk))
+      })
+    })
+
     describe('digTime', () => {
       it('should use eye-level water check instead of isInWater for dig speed', (done) => {
         const blockPos = vec3(1, 65, 1)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -244,20 +244,44 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
-    it('placeBlock rejects an occupied target before sending anything', (done) => {
+    describe('placeBlock', () => {
       const below = vec3(1, 64, 1)
       const target = vec3(1, 65, 1)
-      bot.on('chunkColumnLoad', () => {
-        assert.rejects(bot.placeBlock(bot.blockAt(below), vec3(0, 1, 0)), /occupied by red_mushroom/)
-          .then(done, done)
-      })
-      server.on('playerJoin', (client) => {
+      const joinWithMushroomAt = (client) => {
         client.write('login', bot.test.generateLoginPacket())
         const chunk = bot.test.buildChunk()
         chunk.setBlockType(below, bot.registry.blocksByName.stone.id)
         chunk.setBlockType(target, bot.registry.blocksByName.red_mushroom.id)
         client.write('map_chunk', generateChunkPacket(chunk))
+      }
+
+      it('rejects an occupied target before sending anything', (done) => {
+        bot.on('chunkColumnLoad', () => {
+          assert.rejects(bot.placeBlock(bot.blockAt(below), vec3(0, 1, 0)), /occupied by red_mushroom/)
+            .then(done, done)
+        })
+        server.on('playerJoin', joinWithMushroomAt)
       })
+
+      if (registry.isNewerOrEqualTo('1.20')) {
+        it('trusts the replaceable block tag sent by the server', (done) => {
+          const Item = require('prismarine-item')(supportedVersion)
+          bot.on('chunkColumnLoad', () => {
+            bot.inventory.updateSlot(36, new Item(bot.registry.itemsByName.stone.id, 1))
+            bot._placeBlockWithOptions(bot.blockAt(below), vec3(0, 1, 0), { forceLook: true }).catch(() => {})
+          })
+          server.on('playerJoin', (client) => {
+            client.write('tags', {
+              tags: [{
+                tagType: 'minecraft:block',
+                tags: [{ tagName: 'minecraft:replaceable', entries: [bot.registry.blocksByName.red_mushroom.id] }]
+              }]
+            })
+            client.once('block_place', () => done())
+            joinWithMushroomAt(client)
+          })
+        })
+      }
     })
 
     describe('digTime', () => {


### PR DESCRIPTION
## Problem

The `nether` external test intermittently fails the whole `MC 1.21.8 … 26.1` job with

```
Error: Event blockUpdate:(0, 128, 0) did not fire within timeout of 5000ms
    at placeBlockWithOptions (lib/plugins/place_block.js:13:36)
```

From the CI packet traces of two failing runs (one 26.1, one 1.21.8): chunk (0,0) already had a `red_mushroom` / `brown_mushroom` at (0,128,0) when it loaded. Nether Wastes mushroom features use heightmap placement, which in the nether resolves to the top of the bedrock roof, so mushrooms generate at y=128 — and on some seeds exactly where the test places its sign. The server rejected the placement and re-sent both blocks unchanged (vanilla's resync after a failed use-item), so `placeBlock`'s wait for a *type change* at the target never resolved. All retries failed identically because only the overworld portal location varies per retry.

## Changes

- **`placeBlock`** checks the destination block before sending anything and rejects with `Cannot place block at (x, y, z): it is occupied by <name>` unless the block is one the server lets a placement replace. Previously this surfaced as a 5 s timeout with a misleading "event did not fire" message.
  - The replaceable set comes from the server: vanilla 1.20+ sends the `minecraft:replaceable` block tag on join (play-phase `tags` on 1.20, configuration-phase on 1.20.2+, both already parsed by nmp), which is the same property `canBeReplaced()` consults. That makes it correct for datapacks and modded servers and needs no updating as versions add blocks. Verified on real 1.20.1 and 1.21.8 servers that the entries map straight onto minecraft-data block ids.
  - Servers older than 1.20 don't have the tag, so they use a built-in list derived per version from `Material.isReplaceable()` in the decompiled sources (1.8.8 through 1.19.4), minus tall flowers, whose `canBeReplaced()` is false from 1.13 on. The list is split at the flattening because pre-1.13 `snow` is the full snow block while the layer is `snow_layer`.
- **`nether.js`** checks the sign target and, if it isn't air, clears it with `/setblock` and awaits the block update before placing. Zero cost on the common path.
- Unit tests in `internalTest.js`: the rejection on every tested version, and on 1.20+ that a tag sent by the server overrides the built-in list; docs note in `api.md`.

## Verification

- `internalTest.js`: 729 passing (41 for `placeBlock` across the 28 tested versions).
- `nether` + `sign` external tests on 1.21.8: pass.
- Forced the failure locally (`/setblock 0 128 0 red_mushroom` before the guard) on 1.21.8: guard cleared it, sign placed and text echoed, test passed without a retry.
