### PR TITLE
test: log the server seed and allow pinning it with LEVEL_SEED

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -120,8 +120,12 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
           trace.log('server jar downloaded, starting server')
           propOverrides['server-port'] = PORT
+          if (process.env.LEVEL_SEED) propOverrides['level-seed'] = process.env.LEVEL_SEED
           wrap.startServer(propOverrides, (err) => {
             if (err) return done(err)
+            // The seed is otherwise unrecoverable from a failed run: the log never
+            // prints it and the login packet only carries a hash of it.
+            wrap.writeServer('seed\n')
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
             trace.log('server started, pinging')
             pingUntilReady(PORT, '127.0.0.1', supportedVersion).then(results => {


### PR DESCRIPTION
Follow-up to #4021. While diagnosing that failure from CI artifacts, the one thing that would have let me reproduce it locally was the world seed — and it isn't recorded anywhere: the server log never prints it, and the login/respawn packets in the trace only carry `hashedSeed` (a SHA-256 prefix, not reversible).

- After `startServer` succeeds, the harness sends `seed` to the server console; the reply (`Seed: [N]`, or `Seed: N` on 1.8) is captured by the existing line logger and ends up in `test-<version>.log`.
- `LEVEL_SEED=<n>` sets `level-seed` in `server.properties` so the run can be replayed.

Verified locally: `LEVEL_SEED=12345` on 1.21.8 logs `Seed: [12345]`; unpinned 1.8.8 logs `Seed: -7283262690086958924`; `sign` passes on both.
