### PR TITLE
inventory: sync the server's inventory bookkeeping after closing a window on pre-1.17

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -484,6 +484,8 @@ This function returns a `Promise`, with `void` as its argument when done withdra
 
 #### window.close()
 
+Close the `window`; returns the `Promise` from [bot.closeWindow(window)](#botclosewindowwindow).
+
 ### Recipe
 
 See [prismarine-recipe](https://github.com/PrismarineJS/prismarine-recipe)

--- a/docs/api.md
+++ b/docs/api.md
@@ -2186,7 +2186,9 @@ Put the item at `slot` in the inventory.
 
 #### bot.closeWindow(window)
 
-Close the `window`.
+This function returns a `Promise`, with `void` as its argument once the server has acknowledged the close.
+
+Close the `window`. On 1.16.5 and below the server only learns which inventory slots the window changed on its next tick, so await this before anything else (a command, another player) touches those slots.
 
 #### bot.transfer(options)
 

--- a/examples/anvil.js
+++ b/examples/anvil.js
@@ -120,7 +120,7 @@ async function rename (bot, itemName, name) {
   } catch (err) {
     bot.chat(err.message)
   }
-  anvil.close()
+  await anvil.close()
 }
 
 async function combine (bot, itemName1, itemName2, name) {
@@ -135,7 +135,7 @@ async function combine (bot, itemName1, itemName2, name) {
   } catch (err) {
     bot.chat(err.message)
   }
-  anvil.close()
+  await anvil.close()
 }
 
 bot.on('error', console.log)

--- a/examples/trader.js
+++ b/examples/trader.js
@@ -73,7 +73,7 @@ async function showTrades (id) {
       break
     default: {
       const villager = await bot.openVillager(e)
-      villager.close()
+      await villager.close()
       stringifyTrades(villager.trades).forEach((trade, i) => {
         bot.chat(`${i + 1}: ${trade}`)
       })
@@ -99,7 +99,7 @@ async function trade (id, index, count) {
       count = count || trade.maximumNbTradeUses - trade.nbTradeUses
       switch (true) {
         case !trade:
-          villager.close()
+          await villager.close()
           bot.chat('trade not found')
           break
         case trade.disabled:
@@ -123,7 +123,7 @@ async function trade (id, index, count) {
             bot.chat('an error occurred while trying to trade')
             console.log(err)
           }
-          villager.close()
+          await villager.close()
       }
     }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -408,7 +408,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   putAway: (slot: number) => Promise<void>
 
-  closeWindow: (window: Window) => void
+  closeWindow: (window: Window) => Promise<void>
 
   transfer: (options: TransferOptions) => Promise<void>
 
@@ -667,7 +667,7 @@ interface ConditionalStorageEvents extends StorageEvents {
 export class Chest extends Window<StorageEvents> {
   constructor ();
 
-  close (): void;
+  close (): Promise<void>;
 
   deposit (
     itemType: number,
@@ -688,7 +688,7 @@ export class Furnace extends Window<FurnaceEvents> {
 
   constructor ();
 
-  close (): void;
+  close (): Promise<void>;
 
   takeInput (): Promise<Item>;
 
@@ -718,7 +718,7 @@ export class Furnace extends Window<FurnaceEvents> {
 export class Dispenser extends Window<StorageEvents> {
   constructor ();
 
-  close (): void;
+  close (): Promise<void>;
 
   deposit (
     itemType: number,
@@ -738,7 +738,7 @@ export class EnchantmentTable extends Window<ConditionalStorageEvents> {
 
   constructor ();
 
-  close (): void;
+  close (): Promise<void>;
 
   targetItem (): Item;
 
@@ -768,7 +768,7 @@ export class Villager extends Window<ConditionalStorageEvents> {
 
   constructor ();
 
-  close (): void;
+  close (): Promise<void>;
 }
 
 export interface VillagerTrade {

--- a/lib/plugins/craft.js
+++ b/lib/plugins/craft.js
@@ -24,7 +24,7 @@ function inject (bot) {
         // The last put-away click is unconfirmed; closing on a wrong model
         // leaves items the server never placed.
         await bot._syncWindow(windowCraftingTable)
-        bot.closeWindow(windowCraftingTable)
+        await bot.closeWindow(windowCraftingTable)
         windowCraftingTable = undefined
       }
     } catch (err) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -352,8 +352,9 @@ function inject (bot, { hideErrors }) {
 
   function extendWindow (window) {
     window.close = () => {
-      closeWindow(window)
+      const closed = closeWindow(window)
       window.emit('close')
+      return closed
     }
 
     window.withdraw = async (itemType, metadata, count, nbt) => {
@@ -412,6 +413,11 @@ function inject (bot, { hideErrors }) {
     bot.emit('heldItemChanged', bot.heldItem)
   }
 
+  // Pre-1.17 servers keep the player inventory's slot bookkeeping from before
+  // the container opened until their next tick or an accepted click on it;
+  // until then a change to a slot the container touched (e.g. by /clear) is
+  // never sent. A rejected click already carries the full inventory, so the
+  // sync click's outcome is not an error.
   function closeWindow (window) {
     bot._client.write('close_window', {
       windowId: window.id
@@ -420,6 +426,8 @@ function inject (bot, { hideErrors }) {
     lastClosedWindow = window
     bot.currentWindow = null
     bot.emit('windowClose', window)
+    if (bot.supportFeature('stateIdUsed')) return Promise.resolve()
+    return clickWindow(-999, 0, 0).catch(() => {})
   }
 
   function copyInventory (window) {

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -23,7 +23,7 @@ function inject (bot) {
     assert.ok(item)
     await bot.clickWindow(item.slot, 0, 0)
     await bot.clickWindow(-999, 0, 0)
-    bot.closeWindow(bot.currentWindow || bot.inventory)
+    await bot.closeWindow(bot.currentWindow || bot.inventory)
   }
 
   async function toss (itemType, metadata, count) {

--- a/test/externalTests/anvil.js
+++ b/test/externalTests/anvil.js
@@ -59,7 +59,7 @@ module.exports = () => {
     assert.strictEqual(bot.experience.level, 994)
     assert.strictEqual(anvil.slots[3].repairCost, 1)
     assert.deepStrictEqual(anvil.slots[3].enchants, [{ name: 'sharpness', lvl: 5 }])
-    anvil.close()
+    await anvil.close()
     await bot.test.wait(1000)
   })
 
@@ -83,7 +83,7 @@ module.exports = () => {
     assert.strictEqual(bot.experience.level, 996)
     assert.strictEqual(anvil.slots[3].repairCost, 1)
     assert.deepStrictEqual(anvil.slots[3].enchants, [{ name: 'sharpness', lvl: 5 }, { name: 'unbreaking', lvl: 3 }])
-    anvil.close()
+    await anvil.close()
     await bot.test.wait(1000)
   })
 
@@ -103,7 +103,7 @@ module.exports = () => {
     assert.strictEqual(bot.experience.level, 998)
     assert.strictEqual(anvil.slots[3].repairCost, renameCost())
     assert.deepStrictEqual(anvil.slots[3].customName, renameName('hello'))
-    anvil.close()
+    await anvil.close()
     await bot.test.wait(1000)
   })
 
@@ -128,7 +128,7 @@ module.exports = () => {
     assert.strictEqual(anvil.slots[3].repairCost, 1)
     assert.deepStrictEqual(anvil.slots[3].enchants, [{ name: 'sharpness', lvl: 5 }, { name: 'unbreaking', lvl: 3 }])
     assert.strictEqual(anvil.slots[3].customName, renameName('lol'))
-    anvil.close()
+    await anvil.close()
     await bot.test.wait(1000)
   })
 

--- a/test/externalTests/enchanting.js
+++ b/test/externalTests/enchanting.js
@@ -59,5 +59,5 @@ module.exports = () => async (bot) => {
 
   assert.notStrictEqual(result.nbt, undefined)
 
-  enchantingTable.close()
+  await enchantingTable.close()
 }

--- a/test/externalTests/furnace.js
+++ b/test/externalTests/furnace.js
@@ -61,7 +61,7 @@ module.exports = () => async (bot) => {
   await furnace.takeOutput()
   await furnace.takeInput()
   await furnace.takeFuel()
-  furnace.close()
+  await furnace.close()
 
   await bot.test.wait(500)
 

--- a/test/externalTests/playerInventory.js
+++ b/test/externalTests/playerInventory.js
@@ -32,8 +32,7 @@ module.exports = () => async (bot) => {
     timeout: 5000,
     checkCondition: (oldItem, newItem) => newItem?.type === stoneId
   })
-  bot.closeWindow(chest)
-  await returned
+  await Promise.all([bot.closeWindow(chest), returned])
 
   assert.strictEqual(bot.inventory.slots[bot.inventory.hotbarStart].type, stoneId, 'returned stone should be back in hotbar slot 0')
   assert.strictEqual(bot.inventory.slots[0], null, 'set_player_inventory slotId 0 must not write into the crafting result slot')

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -140,6 +140,6 @@ module.exports = () => async (bot) => {
   }
 
   assert.rejects(bot.trade(villager, 1, 1)) // Shouldn't be able, the trade is blocked!
-  villager.close()
+  await villager.close()
   await bot.test.killEntity(entity)
 }

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -47,7 +47,7 @@ module.exports = () => async (bot) => {
       throw new Error(`unknown item ${name}`)
     }
     await chest.deposit(item.type, null, count)
-    chest.close()
+    await chest.close()
   }
 
   async function withdrawBones (chestLocation, count) {
@@ -61,7 +61,7 @@ module.exports = () => async (bot) => {
     await chest.withdraw(item.type, null, count)
     assert(chest.containerItems().length === 0)
     assert(chest.items().length > 0)
-    chest.close()
+    await chest.close()
   }
 
   await bot.test.setInventorySlot(chestSlot, new Item(bot.registry[blockItemsByName].chest.id, 3, 0))
@@ -105,7 +105,7 @@ module.exports = () => async (bot) => {
       await bot.test.wait(500)
 
       bot.removeListener('chestLidMove', handler)
-      chest.close()
+      await chest.close()
     }
   }
   const chest = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
@@ -221,6 +221,6 @@ module.exports = () => async (bot) => {
 
   await testMouseClick(window, 250)
 
-  window.close()
+  await window.close()
   clearLargeChest()
 }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -547,6 +547,37 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
+        server.on('playerJoin', (client) => {
+          const clicks = []
+          let closed = false
+          client.on('packet', (data, meta) => {
+            if (meta.name === 'close_window') closed = true
+            if (meta.name !== 'window_click') return
+            clicks.push(data)
+            assert.ok(closed, 'the sync click must follow close_window')
+            client.write('transaction', { windowId: data.windowId, action: data.action, accepted: true })
+          })
+          const loggedIn = once(bot, 'login')
+          client.write('login', bot.test.generateLoginPacket())
+          loggedIn
+            .then(() => bot.closeWindow(bot.inventory))
+            .then(() => sleep(100))
+            .then(() => {
+              if (bot.supportFeature('stateIdUsed')) {
+                assert.strictEqual(clicks.length, 0)
+              } else {
+                assert.strictEqual(clicks.length, 1)
+                assert.strictEqual(clicks[0].windowId, 0)
+                assert.strictEqual(clicks[0].slot, -999)
+                assert.strictEqual(clicks[0].mode, 0)
+                assert.strictEqual(clicks[0].mouseButton, 0)
+              }
+            })
+            .then(done, done)
+        })
+      })
+
       it('dimension type lookup uses worldType over worldName on 1.19-1.20.4', function (done) {
         // On proxy/modded servers the worldName (level name) may differ from
         // the dimension type. For versions with dimensionDataInCodec but


### PR DESCRIPTION
Follow-up to #3974, which fixed the 1.17+ half of the `creative` `10 !== 9` failure. This is the ≤1.16.5 half, seen on #4021's CI run (`MC 1.16.5`, all retries).

### What the server does (from decompiled 1.16.5 / 1.17.1 / 1.8.8)

`ServerPlayer.doCloseContainer()` on ≤1.16.5 is just `containerMenu.removed(this); containerMenu = inventoryMenu;` — the player inventory menu's `lastSlots` (the per-slot "last thing I sent the client" list that `broadcastChanges()` diffs against) stays as it was when the container *opened*. Normally the next `ServerPlayer.tick()` diffs and resends the changed slots. But `/clear` also calls `inventoryMenu.broadcastChanges()`; when it runs in the same task drain as the close, a slot the container filled and `/clear` emptied diffs as empty→empty and no `set_slot` is ever sent. 1.17 added `inventoryMenu.transferState(containerMenu)` in `doCloseContainer`, which closes the hole — the same boundary as `supportFeature('stateIdUsed')`.

In the failing trace: `crafting` puts 3 ladders in slot 10 and sends `close_window`; `resetState`'s `/clear` follows 29 ms later; the server reports removing 7 items (planks + ladders) but sends `set_slot` only for 9, 36 and 0. The client-predicted ladders in slot 10 survive every retry. A passing run shows the tick's `set_slot 0/10` resync arriving 45 ms after the close, before the `/clear`.

### Fix

`handleContainerClick`'s accepted path runs `broadcastChanges()` under `ignoreSlotUpdateHack` (`skipPacketSlotUpdates` on 1.8.8), which refreshes `lastSlots` silently, and its `transaction` ack is a real round trip. So `closeWindow` now follows `close_window` with `clickWindow(-999, 0, 0)` — a no-op on both sides with an empty cursor — on versions without state ids, and returns a promise that settles once the server has answered (immediately on 1.17+). `craft()` awaits it and `window.close()` returns it. Every call site inside an async function now awaits it (`tossStack`, the external tests — which hand off to `resetState`'s `/clear` right after closing — and the `anvil`/`trader` examples). `anvil.js`'s `err()` and `craft()`'s catch path stay fire-and-forget: they throw next, and the click reaches the server either way.

### Verification

- New internal test asserts the click follows `close_window` on ≤1.16.5 and is absent on 1.17+ (all 28 tested versions).
- Real 1.16.5 server: `crafting`, `creative`, `furnace`, `useChests` pass; the packet trace shows each close followed by the `-999` click and `transaction accepted`.
- Internal suite: 632 passing.

