### PR TITLE
placeBlock: reject as soon as the server refuses the placement

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1948,6 +1948,7 @@ Denies resource pack.
 #### bot.placeBlock(referenceBlock, faceVector)
 
 This function returns a `Promise`, with `void` as its argument when the server confirms that the block has indeed been placed.
+It rejects as soon as the server refuses the placement (for example because an entity is in the way).
 
  * `referenceBlock` - the block you want to place a new block next to
  * `faceVector` - one of the six cardinal directions, such as `new Vec3(0, 1, 0)` for the top face,

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -7,6 +7,8 @@ function inject (bot) {
     const dest = referenceBlock.position.plus(faceVector)
     const oldBlock = bot.blockAt(dest)
 
+    await bot._genericPlace(referenceBlock, faceVector, options)
+
     // Whether or not it placed anything, the server answers block_place with a
     // block update for the reference block, then one for the block across the
     // face. Updates for dest that arrive before the reference one are stale
@@ -14,19 +16,12 @@ function inject (bot) {
     let acked = false
     const onAck = () => { acked = true }
     bot.on(`blockUpdate:${referenceBlock.position}`, onAck)
-    let newBlock
-    try {
-      await bot._genericPlace(referenceBlock, faceVector, options)
-      ;[, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
-        timeout: 5000,
-        checkCondition: () => acked
-      })
-    } catch (err) {
-      if (!acked) throw new Error(`Server did not answer the placement at ${dest}: ${err.message}`)
-      throw err
-    } finally {
-      bot.removeListener(`blockUpdate:${referenceBlock.position}`, onAck)
-    }
+    const [, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
+      timeout: 5000,
+      checkCondition: () => acked
+    }).catch((err) => {
+      throw acked ? err : new Error(`Server did not answer the placement at ${dest}: ${err.message}`)
+    }).finally(() => bot.removeListener(`blockUpdate:${referenceBlock.position}`, onAck))
 
     // blockUpdate emits (null, null) when the world unloads
     if (!newBlock) return

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -3,6 +3,11 @@ const { onceWithCleanup } = require('../promise_utils')
 module.exports = inject
 
 function inject (bot) {
+  // Placements in flight per destination. The server's replies carry no
+  // request id, so a reply can only be attributed when a single call is
+  // waiting on that destination.
+  const inFlight = new Map()
+
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
     const oldBlock = bot.blockAt(dest)
@@ -13,17 +18,25 @@ function inject (bot) {
     // block update for the reference block, then one for the block across the
     // face. Updates for dest that arrive before the reference one are stale
     // (sent before the server saw our packet) and say nothing about the result.
+    // With several placements in flight the reply cannot be told apart, so a
+    // call only settles on a type change and all of them share the outcome.
+    const key = dest.toString()
+    inFlight.set(key, (inFlight.get(key) ?? 0) + 1)
     let acked = false
     const onAck = () => { acked = true }
     bot.on(`blockUpdate:${referenceBlock.position}`, onAck)
     const [, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
       timeout: 5000,
-      checkCondition: () => acked
+      // oldBlock and newBlock are both null when the world unloads
+      checkCondition: (oldBlock, newBlock) => !oldBlock || !newBlock || oldBlock.type !== newBlock.type || (acked && inFlight.get(key) === 1)
     }).catch((err) => {
       throw acked ? err : new Error(`Server did not answer the placement at ${dest}: ${err.message}`)
-    }).finally(() => bot.removeListener(`blockUpdate:${referenceBlock.position}`, onAck))
+    }).finally(() => {
+      bot.removeListener(`blockUpdate:${referenceBlock.position}`, onAck)
+      if (inFlight.get(key) === 1) inFlight.delete(key)
+      else inFlight.set(key, inFlight.get(key) - 1)
+    })
 
-    // blockUpdate emits (null, null) when the world unloads
     if (!newBlock) return
     if (newBlock.type === oldBlock.type) {
       throw new Error(`Server refused to place ${bot.heldItem?.name ?? 'block'} at ${dest}: the block is still ${newBlock.name}`)

--- a/lib/plugins/place_block.js
+++ b/lib/plugins/place_block.js
@@ -5,28 +5,35 @@ module.exports = inject
 function inject (bot) {
   async function placeBlockWithOptions (referenceBlock, faceVector, options) {
     const dest = referenceBlock.position.plus(faceVector)
-    let oldBlock = bot.blockAt(dest)
-    await bot._genericPlace(referenceBlock, faceVector, options)
+    const oldBlock = bot.blockAt(dest)
 
-    let newBlock = bot.blockAt(dest)
-    if (oldBlock.type === newBlock.type) {
-      [oldBlock, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
+    // Whether or not it placed anything, the server answers block_place with a
+    // block update for the reference block, then one for the block across the
+    // face. Updates for dest that arrive before the reference one are stale
+    // (sent before the server saw our packet) and say nothing about the result.
+    let acked = false
+    const onAck = () => { acked = true }
+    bot.on(`blockUpdate:${referenceBlock.position}`, onAck)
+    let newBlock
+    try {
+      await bot._genericPlace(referenceBlock, faceVector, options)
+      ;[, newBlock] = await onceWithCleanup(bot, `blockUpdate:${dest}`, {
         timeout: 5000,
-        // Condition to wait to receive block update actually changing the block type, in case the bot receives block updates with no changes
-        // oldBlock and newBlock will both be null when the world unloads
-        checkCondition: (oldBlock, newBlock) => !oldBlock || !newBlock || oldBlock.type !== newBlock.type
+        checkCondition: () => acked
       })
+    } catch (err) {
+      if (!acked) throw new Error(`Server did not answer the placement at ${dest}: ${err.message}`)
+      throw err
+    } finally {
+      bot.removeListener(`blockUpdate:${referenceBlock.position}`, onAck)
     }
 
     // blockUpdate emits (null, null) when the world unloads
-    if (!oldBlock && !newBlock) {
-      return
+    if (!newBlock) return
+    if (newBlock.type === oldBlock.type) {
+      throw new Error(`Server refused to place ${bot.heldItem?.name ?? 'block'} at ${dest}: the block is still ${newBlock.name}`)
     }
-    if (oldBlock?.type === newBlock.type) {
-      throw new Error(`No block has been placed : the block is still ${oldBlock?.name}`)
-    } else {
-      bot.emit('blockPlaced', oldBlock, newBlock)
-    }
+    bot.emit('blockPlaced', oldBlock, newBlock)
   }
 
   async function placeBlock (referenceBlock, faceVector) {

--- a/test/externalTests/digAndBuild.js
+++ b/test/externalTests/digAndBuild.js
@@ -18,12 +18,6 @@ module.exports = () => async (bot) => {
   assert(Item.equal(bot.inventory.slots[36], new Item(bot.registry.itemsByName.dirt.id, 1, 0)))
   bot.test.sayEverywhere('dirt collect test: pass')
 
-  // the server refuses a block inside the bot's own hitbox and says so in its
-  // reply, which must surface as a rejection instead of a timeout
-  const start = Date.now()
-  await assert.rejects(bot.test.placeBlock(36, bot.entity.position.floored()), /refused to place dirt .* still air/)
-  assert(Date.now() - start < 2000, `refused placement took ${Date.now() - start}ms to surface`)
-
   async function waitForFall () {
     return new Promise((resolve, reject) => {
       assert(!bot.entity.onGround, 'waitForFall called when we were already on the ground')

--- a/test/externalTests/digAndBuild.js
+++ b/test/externalTests/digAndBuild.js
@@ -18,6 +18,12 @@ module.exports = () => async (bot) => {
   assert(Item.equal(bot.inventory.slots[36], new Item(bot.registry.itemsByName.dirt.id, 1, 0)))
   bot.test.sayEverywhere('dirt collect test: pass')
 
+  // the server refuses a block inside the bot's own hitbox and says so in its
+  // reply, which must surface as a rejection instead of a timeout
+  const start = Date.now()
+  await assert.rejects(bot.test.placeBlock(36, bot.entity.position.floored()), /refused to place dirt .* still air/)
+  assert(Date.now() - start < 2000, `refused placement took ${Date.now() - start}ms to surface`)
+
   async function waitForFall () {
     return new Promise((resolve, reject) => {
       assert(!bot.entity.onGround, 'waitForFall called when we were already on the ground')

--- a/test/externalTests/placeBlock.js
+++ b/test/externalTests/placeBlock.js
@@ -1,0 +1,78 @@
+const assert = require('assert')
+const { Vec3 } = require('vec3')
+const { once } = require('../../lib/promise_utils')
+
+module.exports = () => {
+  const tests = []
+
+  function addTest (name, f) {
+    tests[name] = f
+  }
+
+  // the block the tests place, one block east of the bot's spawn point
+  const target = bot => new Vec3(1, bot.test.groundY, 0)
+
+  async function holdDirt (bot) {
+    const Item = require('prismarine-item')(bot.registry)
+    await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.dirt.id, 1, 0))
+  }
+
+  async function expectRefusal (bot, placement, item) {
+    const start = Date.now()
+    await assert.rejects(placement, new RegExp(`^Error: Server refused to place ${item} at \\(\\d+, -?\\d+, \\d+\\): the block is still air$`))
+    assert(Date.now() - start < 2000, `refused placement took ${Date.now() - start}ms to surface`)
+  }
+
+  addTest('emits blockPlaced with the old and new block', async (bot) => {
+    await holdDirt(bot)
+    const placed = once(bot, 'blockPlaced')
+    await bot.test.placeBlock(36, target(bot))
+    const [oldBlock, newBlock] = await placed
+    assert.strictEqual(oldBlock.name, 'air')
+    assert.strictEqual(newBlock.name, 'dirt')
+    assert(newBlock.position.equals(target(bot)))
+    await bot.test.setBlock({ ...target(bot), blockName: 'air' })
+  })
+
+  addTest('rejects when an entity is in the way, then works once it is gone', async (bot) => {
+    await holdDirt(bot)
+    const name = bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'ArmorStand' : 'armor_stand'
+    const { x, y, z } = target(bot)
+    const spawned = once(bot, 'entitySpawn')
+    bot.chat(`/summon ${name} ${x + 0.5} ${y} ${z + 0.5}`)
+    await spawned
+
+    // only the server knows the block is occupied, so the client sends the
+    // placement and the refusal has to come from the server's reply
+    await expectRefusal(bot, bot.test.placeBlock(36, target(bot)), 'dirt')
+    assert.strictEqual(bot.blockAt(target(bot)).name, 'air')
+
+    const gone = once(bot, 'entityGone')
+    bot.chat(`/kill @e[type=${name}]`)
+    await gone
+    await bot.test.placeBlock(36, target(bot))
+    assert.strictEqual(bot.blockAt(target(bot)).name, 'dirt')
+    await bot.test.setBlock({ ...target(bot), blockName: 'air' })
+  })
+
+  addTest('rejects when the held item cannot be placed', async (bot) => {
+    const Item = require('prismarine-item')(bot.registry)
+    await bot.test.setInventorySlot(36, new Item(bot.registry.itemsByName.stick.id, 1, 0))
+    await expectRefusal(bot, bot.test.placeBlock(36, target(bot)), 'stick')
+    assert.strictEqual(bot.blockAt(target(bot)).name, 'air')
+  })
+
+  addTest('rejects each refused placement in a row', async (bot) => {
+    await holdDirt(bot)
+    // the bot cannot place into its own hitbox; a refusal must leave nothing
+    // behind that would mis-attribute the next reply
+    for (let i = 0; i < 3; i++) {
+      await expectRefusal(bot, bot.test.placeBlock(36, bot.entity.position.floored()), 'dirt')
+    }
+    await bot.test.placeBlock(36, target(bot))
+    assert.strictEqual(bot.blockAt(target(bot)).name, 'dirt')
+    await bot.test.setBlock({ ...target(bot), blockName: 'air' })
+  })
+
+  return tests
+}


### PR DESCRIPTION
## Problem

`useChests` failed on 1.9.4 with

```
Error: Event blockUpdate:(1, 4, 1) did not fire within timeout of 5000ms
    at placeBlockWithOptions (lib/plugins/place_block.js:13:36)
```

The packet trace shows the server had answered within 25 ms: `block_place (1,3,1)/top` → `block_change (1,3,1)=grass`, `block_change (1,4,1)=air`, no `set_slot`. Vanilla replies to every `block_place` with a block update for the reference block and then one for the block across the face, whether or not it placed anything. `placeBlock` only waited for the target's *type to change*, so an explicit refusal was discarded and reported five seconds later as a generic "event did not fire".

(Why the server refused in that run: `trade` summons its villager on a command block at (1,4,1); `/kill` only starts the 20-tick death animation, the reset's `/fill` removes the command block, the corpse falls onto (1,4,1), and `useChests`'s second chest is refused there for the ~1 s until the entity is removed. That test race is left for a separate change; this PR is about reporting the server's answer.)

## Changes

- **`placeBlock`** listens for the reference-block update as the server's ack, then treats the next target update as the verdict. A refusal now rejects immediately with `Server refused to place chest at (1, 4, 1): the block is still air`; a genuine no-reply says `Server did not answer the placement at <pos>: …`. Unchanged target updates that arrive *before* the ack are still ignored, which is what #3090 guarded against.
- **`digAndBuild.js`** asserts that placing into the bot's own hitbox rejects with the new message in under 2 s.
- **`api.md`** notes that `placeBlock` rejects when the server refuses.

Complements #4021, which pre-checks a target the *client* can see is occupied; this handles refusals only the server knows about (entities in the way, spawn protection, …). The two touch adjacent lines in `place_block.js` and `api.md`, so whichever lands second needs a trivial rebase.

## Verification

| Version | Tests | Result |
|---|---|---|
| 1.8.8 | digAndBuild, nether, sign | pass |
| 1.9.4 | digAndBuild, nether, sign, useChests | pass |
| 1.21.8 | digAndBuild, nether, sign, useChests | pass |
| 26.1 | digAndBuild, sign | pass |

With the `trade` → `useChests` race reproduced on 1.9.4, the failure now surfaces instantly with the message above instead of timing out.
