### PR TITLE
test: await entity removal after /kill

### DIFF
--- a/test/externalTests/placeEntity.js
+++ b/test/externalTests/placeEntity.js
@@ -75,7 +75,7 @@ module.exports = (version) => {
     const name = bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'Zombie' : 'zombie'
     const entity = bot.nearestEntity(o => o.name === name)
     assert(entity?.name === name)
-    await bot.test.killEntity(entity) // instead of bot.attack(), which takes more than one hit
+    await bot.test.killEntity(entity)
   })
 
   addTest('place armor stand', async (bot) => {

--- a/test/externalTests/placeEntity.js
+++ b/test/externalTests/placeEntity.js
@@ -75,8 +75,7 @@ module.exports = (version) => {
     const name = bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'Zombie' : 'zombie'
     const entity = bot.nearestEntity(o => o.name === name)
     assert(entity?.name === name)
-    bot.chat(`/kill @e[type=${name}]`) // use /kill instead of bot.attack() because it takes more than one hit to kill
-    await once(bot, 'entityGone')
+    await bot.test.killEntity(entity) // instead of bot.attack(), which takes more than one hit
   })
 
   addTest('place armor stand', async (bot) => {

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -41,6 +41,7 @@ function inject (bot, wrap) {
   bot.test.runExample = runExample
   bot.test.tellAndListen = tellAndListen
   bot.test.selfKill = selfKill
+  bot.test.killEntity = killEntity
   bot.test.wait = function (ms) {
     return new Promise((resolve) => { setTimeout(resolve, ms) })
   }
@@ -320,6 +321,14 @@ function inject (bot, wrap) {
 
   function selfKill () {
     bot.chat('/kill @p')
+  }
+
+  // /kill only starts the death animation; until the server removes the
+  // entity about a second later it still blocks placing blocks where it stands
+  async function killEntity (entity) {
+    const gone = onceWithCleanup(bot, 'entityGone', { timeout: 5000, checkCondition: (e) => e.id === entity.id })
+    bot.chat(`/kill @e[type=${entity.name}]`)
+    await gone
   }
 
   // Debug packet IO when tests are re-run with "Enable debug logging" - https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables

--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -141,5 +141,5 @@ module.exports = () => async (bot) => {
 
   assert.rejects(bot.trade(villager, 1, 1)) // Shouldn't be able, the trade is blocked!
   villager.close()
-  bot.test.sayEverywhere(`/kill @e[type=${villagerType}]`)
+  await bot.test.killEntity(entity)
 }


### PR DESCRIPTION
## Problem

`/kill` only starts the 20-tick death animation; the entity keeps blocking block placement where it stands until the server removes it about a second later.

`trade` summons its villager on a command block at (1,4,1) and returns right after `/kill`. The reset's `/fill` removes the command block, the corpse falls onto (1,4,1), and `useChests`'s second chest — also at (1,4,1) — is refused by the server if it is placed within that second. On 1.9.4 this reproduced 2/2 locally (`entity_destroy` arrived 77 ms *after* the refused `block_place`). With #4024 the failure reads `Server refused to place chest at (1, 4, 1): the block is still air`; before it, a 5 s `Event blockUpdate:(1, 4, 1) did not fire` timeout.

## Changes

- `bot.test.killEntity(entity)` in `testCommon.js`: sends `/kill @e[type=<entity.name>]` and awaits that entity's `entityGone`.
- `trade.js` uses it instead of a fire-and-forget kill.
- `placeEntity.js` uses it instead of its own kill + unfiltered `once(bot, 'entityGone')`.

## Verification

1.9.4 `trade` → `useChests`: pass (previously refused at (1,4,1) on both attempts).
