### PR TITLE
Re-enable the book test and fix writeBook/signBook on 1.13+

### DIFF
--- a/lib/plugins/book.js
+++ b/lib/plugins/book.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { once } = require('../promise_utils')
+const { onceWithCleanup } = require('../promise_utils')
 
 module.exports = inject
 
@@ -15,20 +15,20 @@ function inject (bot) {
       else bot._client.writeChannel('MC|BEdit', Item.toNotch(book))
     }
   } else if (bot.supportFeature('hasEditBookPacket')) {
-    if (bot.supportFeature('editBookPacketUsesNbt')) { // 1.13 - 1.17
-      editBook = (book, pages, title, slot, signing = false, hand = 0) => {
-        bot._client.write('edit_book', {
-          hand: slot,
-          pages,
-          title
-        })
-      }
-    } else { // 1.18+
+    if (bot.supportFeature('editBookPacketUsesNbt')) {
       editBook = (book, pages, title, slot, signing = false, hand = 0) => {
         bot._client.write('edit_book', {
           new_book: Item.toNotch(book),
           signing,
           hand
+        })
+      }
+    } else {
+      editBook = (book, pages, title, slot, signing = false, hand = 0) => {
+        bot._client.write('edit_book', {
+          hand: slot,
+          pages,
+          title
         })
       }
     }
@@ -43,19 +43,34 @@ function inject (bot) {
 
     if (moveToQuickBar) {
       await bot.moveSlotItem(slot, 36)
+      // 1.21.9+ never acknowledges an edit_book handled in the same tick as
+      // the clicks that put the book in hand, so those must round-trip first.
+      await bot._syncWindow(bot.inventory)
     }
 
     bot.setQuickBarSlot(moveToQuickBar ? 0 : slot - 36)
 
-    const modifiedBook = await modifyBook(moveToQuickBar ? 36 : slot, pages, author, title, signing)
+    const bookSlot = moveToQuickBar ? 36 : slot
+    const modifiedBook = await modifyBook(bookSlot, pages, author, title, signing)
     editBook(modifiedBook, pages, title, moveToQuickBar ? 0 : slot - 36, signing)
-    await once(bot.inventory, `updateSlot:${moveToQuickBar ? 36 : slot}`)
+    // Clicks are echoed by the server as slot updates that predate the edit,
+    // and the edit itself is applied asynchronously, so only an update that
+    // already reflects it counts as the acknowledgement.
+    await onceWithCleanup(bot.inventory, `updateSlot:${bookSlot}`, {
+      timeout: 20000,
+      checkCondition: (oldItem, newItem) => newItem && (signing ? newItem.type === bot.registry.itemsByName.written_book.id : hasPages(newItem))
+    })
 
     bot.setQuickBarSlot(quickBarSlot)
 
     if (moveToQuickBar) {
       await bot.moveSlotItem(36, slot)
     }
+  }
+
+  function hasPages (item) {
+    if (item.componentMap) return item.componentMap.has('writable_book_content')
+    return Boolean(item.nbt?.value?.pages)
   }
 
   function modifyBook (slot, pages, author, title, signing) {

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -16,7 +16,7 @@ const START_THE_SERVER = true
 // if you want to have time to look what's happening increase this (milliseconds)
 const TEST_TIMEOUT_MS = 90000
 
-const excludedTests = ['digEverything', 'book', 'anvil', 'placeEntity']
+const excludedTests = ['digEverything', 'anvil', 'placeEntity']
 
 const propOverrides = {
   'level-type': 'FLAT',

--- a/test/externalTests/book.js
+++ b/test/externalTests/book.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
+  const usesComponents = bot.supportFeature('itemsWithComponents')
 
   const pages = [
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
@@ -17,11 +18,23 @@ module.exports = () => async (bot) => {
 
   await bot.writeBook(30, pages)
   let book = bot.inventory.slots[30]
-  book.nbt.value.pages.value.value.forEach((page, i) => assert.strictEqual(page, pages[i]))
+  if (usesComponents) {
+    const content = book.componentMap.get('writable_book_content').data
+    assert.deepStrictEqual(content.pages.map(page => page.content), pages)
+  } else {
+    assert.deepStrictEqual(book.nbt.value.pages.value.value, pages)
+  }
 
   await bot.signBook(30, pages, bot.username, 'My Very First Book')
   book = bot.inventory.slots[30]
   assert.strictEqual(book.type, bot.registry.itemsByName.written_book.id)
-  assert.strictEqual(book.nbt.value.author.value, bot.username)
-  assert.strictEqual(book.nbt.value.title.value, 'My Very First Book')
+  if (usesComponents) {
+    const content = book.componentMap.get('written_book_content').data
+    assert.strictEqual(content.author, bot.username)
+    assert.strictEqual(content.rawTitle, 'My Very First Book')
+    assert.deepStrictEqual(content.pages.map(page => page.content.value), pages)
+  } else {
+    assert.strictEqual(book.nbt.value.author.value, bot.username)
+    assert.strictEqual(book.nbt.value.title.value, 'My Very First Book')
+  }
 }


### PR DESCRIPTION
The `book` external test has been in `excludedTests` since #3373, and enabling it turned up three problems. It now passes on all 28 tested versions (1.8.8 → 26.1), verified locally with `-g "<v>v book"` for each.

### 1. The `edit_book` branches in `lib/plugins/book.js` were swapped
Same fix as #3677 (credit to @autowert66 for finding it first); this PR additionally re-enables the existing test and fixes what enabling it turned up on 1.20.5+.

#3373 put the 1.17+ `hand/pages/title` packet shape under `editBookPacketUsesNbt` (1.13–1.16) and the 1.13–1.16 `new_book/signing/hand` shape under the else branch, so `writeBook`/`signBook` failed to serialize the packet on every version from 1.13 up. Swapped back.

### 2. 1.20.5+: the first `updateSlot` after `edit_book` is often a stale click echo
The bot's `window_click` sends full item components where the server expects `HashedSlot` hashes, so the server re-sends the affected slots after every click, and it applies the edit asynchronously. The plugin was resolving on the first `updateSlot` for the hand slot, which was frequently a pre-edit echo; the signed book then ended up on the cursor while the caller read the old item. It now waits for an update that actually carries the edit (pages present / `written_book`).

### 3. 1.21.9+: an `edit_book` handled in the same tick as the preceding clicks is never acknowledged
Confirmed with packet traces: with a 100 ms gap before `edit_book`, or with the book already in the hotbar, the server acks with `set_slot`; back-to-back with the move clicks it sends nothing. A `bot._syncWindow` round-trip after the move (same idiom as `craft.js`) forces the edit into a later tick.

The test reads book content from `writable_book_content` / `written_book_content` components on 1.20.5+ instead of `nbt`.

Not addressed here: the hashed-slot mismatch in `clickWindow` behind (2) affects every click on an item with components on 1.21.5+; fixing it properly means hashing component NBT in prismarine-item / minecraft-protocol.

