### PR TITLE
inventory: claim clicked slots by hash on 1.21.5+

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -549,6 +549,10 @@ function inject (bot, { hideErrors }) {
     return changedSlots
   }
 
+  // 1.21.5+ clicks claim slot contents by hash; the server resends any slot
+  // whose claim doesn't match its own state.
+  const toClickNotch = bot.registry.protocol.types.HashedSlot ? Item.toHashedNotch : Item.toNotch
+
   async function clickWindow (slot, mouseButton, mode) {
     // if you click on the quick bar and have dug recently,
     // wait a bit
@@ -600,7 +604,7 @@ function inject (bot, { hideErrors }) {
       changedSlots = changedSlots.map(slot => {
         return {
           location: slot,
-          item: Item.toNotch(window.slots[slot])
+          item: toClickNotch(window.slots[slot])
         }
       })
     }
@@ -614,7 +618,7 @@ function inject (bot, { hideErrors }) {
         mouseButton,
         mode,
         changedSlots,
-        cursorItem: Item.toNotch(window.selectedItem)
+        cursorItem: toClickNotch(window.selectedItem)
       })
     } else if (bot.supportFeature('actionIdUsed')) { // <= 1.16.5
       bot._client.write('window_click', {
@@ -834,7 +838,7 @@ function inject (bot, { hideErrors }) {
       mouseButton: 2, // end of a drag that never started
       mode: 5,
       changedSlots: [],
-      cursorItem: Item.toNotch(window.selectedItem)
+      cursorItem: toClickNotch(window.selectedItem)
     })
     await synced
   }


### PR DESCRIPTION
Depends on PrismarineJS/prismarine-item#184 (`Item.toHashedNotch`); CI will fail until that is released and `prismarine-item` is bumped.

### Problem
Since 1.21.5, `window_click`'s `changedSlots` and `cursorItem` are `HashedSlot`s — item id, count and a CRC32C per component — not full items. `clickWindow` still passes `Item.toNotch` output, so the `hash` field is never set and the server resyncs every slot holding an item with components after every click (`set_slot`/`set_cursor_item`). Those resyncs look exactly like the acknowledgement packets plugins wait for; #4026 shows the resulting race in `writeBook`/`signBook`.

### Change
`clickWindow` and `_syncWindow` use `Item.toHashedNotch` for slot and cursor claims when the protocol defines `HashedSlot`. Nothing else changes: a component prismarine-item can't hash is sent with hash 0, which keeps today's behaviour (a resync) for that slot only.

The switch is keyed on `bot.registry.protocol.types.HashedSlot` rather than a `supportFeature` because minecraft-data has no feature for this; happy to add one there if preferred.

### Verification
- Per-component: `/give`-ing items with each supported component on vanilla 1.21.5, 1.21.11 and 26.1 and moving them between slots produced **no** server resync (packet trace), i.e. the hashes were accepted. Those accepted values are frozen as unit vectors in the prismarine-item PR.
- Regression: the full external test suite passes on 1.21.5, 1.21.11 and 26.1 with this change (74 passing, 0 failing, no retries on each).
