### PR TITLE
ci: fail a PR if any test gets more than 1.5x slower than master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      # Per-test durations from the last master run of this version group, so a PR
+      # can be failed if it makes a test more than 1.5x slower (test/common/compareDurations.js).
+      - name: Restore duration baseline
+        uses: actions/cache/restore@v4
+        with:
+          path: durations
+          key: durations-${{ strategy.job-index }}-${{ github.sha }}
+          restore-keys: durations-${{ strategy.job-index }}-
+      - run: |
+          mv durations baseline 2>/dev/null || mkdir -p baseline
+          mkdir -p durations
+
       - name: Start Tests
         run: |
           exit_code=0
@@ -74,7 +86,7 @@ jobs:
           for v in ${{ matrix.versions }}; do
             # TRACE is cheap (<1% runtime) and only written by the harness bot,
             # so always record a packet trace for post-mortem analysis.
-            TRACE="trace-${v}.jsonl" npm run mocha_test -- --retries 3 -g "${v}v" > "test-${v}.log" 2>&1 &
+            TRACE="trace-${v}.jsonl" DURATIONS="durations/durations-${v}.json" npm run mocha_test -- --retries 3 -g "${v}v" > "test-${v}.log" 2>&1 &
             pids="$pids $!"
           done
           for pid in $pids; do
@@ -109,6 +121,16 @@ jobs:
             fi
           done
           exit $exit_code
+
+      - name: Compare test durations against master
+        run: node test/common/compareDurations.js baseline durations
+
+      - name: Save duration baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: durations
+          key: durations-${{ strategy.job-index }}-${{ github.sha }}
 
       - name: Upload failed versions' logs and traces
         if: failure()

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
-    "mocha_test": "mocha --reporter spec --exit",
+    "mocha_test": "mocha --reporter ./test/common/durationsReporter.js --exit",
     "test": "npm run mocha_test",
     "pretest": "npm run lint",
     "lint": "standard && standard-markdown",

--- a/test/common/compareDurations.js
+++ b/test/common/compareDurations.js
@@ -1,0 +1,32 @@
+// Usage: node test/common/compareDurations.js <baselineDir> <currentDir>
+// Fails if any test that passed in both runs got more than 1.5x slower than master's baseline.
+const fs = require('fs')
+const path = require('path')
+
+const [baselineDir, currentDir] = process.argv.slice(2)
+const FACTOR = 1.5
+// Ignore tests too short for a 1.5x jump to mean anything (server/network jitter).
+const MIN_REGRESSION_MS = 5000
+
+let regressions = 0
+for (const file of fs.readdirSync(currentDir).filter(f => f.startsWith('durations-')).sort()) {
+  const baselineFile = path.join(baselineDir, file)
+  if (!fs.existsSync(baselineFile)) {
+    console.log(`${file}: no baseline yet, skipping`)
+    continue
+  }
+  const baseline = JSON.parse(fs.readFileSync(baselineFile))
+  const current = JSON.parse(fs.readFileSync(path.join(currentDir, file)))
+  console.log(`\n${file}`)
+  for (const [title, ms] of Object.entries(current)) {
+    const base = baseline[title]
+    if (base === undefined) continue
+    const regressed = ms > base * FACTOR && ms - base > MIN_REGRESSION_MS
+    if (regressed) regressions++
+    console.log(`  ${regressed ? 'SLOWER' : '      '} ${String(base).padStart(7)}ms -> ${String(ms).padStart(7)}ms  ${title}`)
+  }
+}
+if (regressions > 0) {
+  console.error(`\n${regressions} test(s) got more than ${FACTOR}x slower than master`)
+  process.exit(1)
+}

--- a/test/common/durationsReporter.js
+++ b/test/common/durationsReporter.js
@@ -1,0 +1,19 @@
+// The spec reporter, plus a JSON file of { "<test full title>": <ms> } for every
+// passing test, written to $DURATIONS. CI compares it against master's run.
+const fs = require('fs')
+const { reporters, Runner } = require('mocha')
+
+class DurationsReporter extends reporters.Spec {
+  constructor (runner, options) {
+    super(runner, options)
+    const durations = {}
+    runner.on(Runner.constants.EVENT_TEST_PASS, test => {
+      durations[test.fullTitle()] = test.duration
+    })
+    runner.once(Runner.constants.EVENT_RUN_END, () => {
+      if (process.env.DURATIONS) fs.writeFileSync(process.env.DURATIONS, JSON.stringify(durations, null, 2))
+    })
+  }
+}
+
+module.exports = DurationsReporter


### PR DESCRIPTION
## What

Recent PRs (#3977, #3984, #3999, #3990, ...) cut a lot of fixed sleeps out of the external tests. Nothing stops them creeping back in, and a fixed wall-clock budget doesn't work here since runtime is dominated by server startup and varies per version. So: compare per-test durations against master's last run and fail on a 1.5x regression.

## How

- `test/common/durationsReporter.js`: the spec reporter, plus a `{ "<test title>": ms }` file of passing tests written to `$DURATIONS`. `mocha_test` now uses it; log output is unchanged.
- `test/common/compareDurations.js <baselineDir> <currentDir>`: for each test present in both runs, fail if it took more than **1.5x** its baseline **and** at least 5s longer (so sub-second tests can't fail on jitter). Prints a `baseline -> now` table per version. Tests without a baseline are skipped.
- `ci.yml`: restore the last master baseline for the version group from `actions/cache` (`durations-<job-index>-*`), run the comparison after the tests, and on pushes to master save the run as the new baseline. Rebaselining is automatic, no committed files.

Only tests that passed count, and with `--retries 3` mocha records the passing attempt's duration, so a flaky retry doesn't register as a slowdown.

## Verification

Locally against the internal tests: 632 durations recorded with the spec output intact; the compare script exits 1 when a test goes 1s -> 20s, 0 when identical, and skips cleanly with no baseline. The first CI run on master seeds the cache; PRs before that just print "no baseline yet".