### PR TITLE
test(trade): await the command block echoes instead of sleeping 2x500ms

### DIFF
--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -24,10 +24,11 @@ module.exports = () => async (bot) => {
   await bot.test.setInventorySlot(18, new Item(bot.registry.itemsByName.book.id, 11, 0))
 
   // A command block is needed to spawn the villager due to the chat's character limit in some versions
-  bot.test.sayEverywhere(`/setblock ${commandBlockPos.toArray().join(' ')} command_block`)
-  await bot.test.wait(500)
+  await bot.test.setBlock({ ...commandBlockPos, blockName: 'command_block' })
+  // The server echoes the command block (an unchanged block_change) once the command is set
+  const commandSet = once(bot.world, `blockUpdate:${commandBlockPos}`)
   bot.setCommandBlock(commandBlockPos, summonCommand)
-  await bot.test.wait(500)
+  await commandSet
   bot.test.sayEverywhere(`/setblock ${redstoneBlockPos.toArray().join(' ')} redstone_block`) // Activate the command block
 
   const [entity] = await once(bot, 'entitySpawn')


### PR DESCRIPTION
## Problem

`trade` spends ~1s of its runtime in two fixed sleeps around the command block that summons the villager (`trade.js:31,33`): 500ms after `/setblock … command_block` and 500ms after `bot.setCommandBlock`. Packet traces show the server answers both within ~50ms.

## Changes

Both sleeps become event waits; no API change.

- `/setblock … command_block` → `bot.test.setBlock(...)`, which already awaits the `block_change` for that position. That is also what `bot.setCommandBlock` needs, since it asserts client-side that the block is a command block.
- `bot.setCommandBlock(...)` → await `blockUpdate:<pos>`. Once the command is set, the server re-sends the command block as an unchanged `block_change` (alongside `advMode.setCommand.success`); prismarine-world emits `blockUpdate` for it even though the state id is the same.

Verified from traces on 1.8.8, 1.9.4, 1.13.2, 1.21.8 and 26.1 that both replies are sent on every version. (`tile_entity_data` is only sent on 1.8, so a block entity event would not work here.)

## Verification

`trade` passes on 1.8.8, 1.13.2 and 26.1. Time from `/setblock` to the villager's `spawn_entity`:

| Version | Before | After |
|---|---|---|
| 1.8.8 | 1067ms | 173ms |
| 1.13.2 | 1076ms | 161ms |
| 26.1 | 1106ms | 188ms |