### PR TITLE
test(trade): seed one stack per deposit so every transfer is a pick-up and place

### DIFF
--- a/test/externalTests/trade.js
+++ b/test/externalTests/trade.js
@@ -19,12 +19,18 @@ module.exports = () => async (bot) => {
   const commandBlockPos = bot.entity.position.offset(0.5, 0, 0.5)
   const redstoneBlockPos = commandBlockPos.offset(1, 0, 0)
 
-  let shouldHaveEmeralds = 0
-  for (let slot = 9; slot <= 10; slot += 1) {
-    await bot.test.setInventorySlot(slot, new Item(bot.registry.itemsByName.emerald.id, 64, 0))
-    shouldHaveEmeralds += 64
-  }
-  await bot.test.setInventorySlot(18, new Item(bot.registry.itemsByName.book.id, trades, 0))
+  // One stack per deposit, in the order the trades consume them: transfer takes
+  // the first matching stack, so every deposit is a single pick-up and place
+  // instead of splitting a bigger stack one right click at a time.
+  const emeraldPrice1 = testFluctuations ? 4 : 2
+  const emeraldStacks = [emeraldPrice1, 2, 1, 36].flatMap(price => Array(trades).fill(price))
+  const bookStacks = Array(trades).fill(1)
+  let shouldHaveEmeralds = emeraldStacks.reduce((a, b) => a + b, 0)
+  // Set the slots concurrently: on versions without a creative slot ack each set waits 400ms for a rejection.
+  await Promise.all([
+    ...emeraldStacks.map((count, i) => bot.test.setInventorySlot(9 + i, new Item(bot.registry.itemsByName.emerald.id, count, 0))),
+    ...bookStacks.map((count, i) => bot.test.setInventorySlot(9 + emeraldStacks.length + i, new Item(bot.registry.itemsByName.book.id, count, 0)))
+  ])
 
   // A command block is needed to spawn the villager due to the chat's character limit in some versions
   await bot.test.setBlock({ ...commandBlockPos, blockName: 'command_block' })


### PR DESCRIPTION
Rebased on master. The first commit is the test half of #3983 (`trades = 2`): with master's 11 uses, one stack per deposit would need 44 stacks, more than the inventory holds. If #3983 merges first this rebases down to the second commit.

## Problem

`trade` seeds two 64-stacks of emeralds. `bot.transfer` takes the first stack of the item it finds, so each deposit picks up 64, right-clicks the price in one at a time and puts the rest back — 36 right clicks per deposit for the wooden sword trade. Every click is a server tick, so pre-1.14 the test spends ~5s in 101 clicks.

## Changes

Seed one stack of exactly the price for each deposit, in the order the trades consume them (`[p0, p0, 2, 2, 1, 1, 36, 36]` emeralds and `[1, 1]` books). `transfer` then finds the exact stack first and every deposit is pick-up + place. Assertions are unchanged; they only check totals.

The slots are set with `Promise.all` (as `clearInventory` already does): on 1.21.3+ (`noAckOnCreateSetSlotPacket`) there is no ack for `set_creative_slot`, so each `setInventorySlot` waits 400ms for a rejection; serialised over 10 slots that is 4s.

## Verification

`trade` on the base branch vs this PR (clicks are `window_click`s from the packet trace):

| Version | Clicks | Before | After |
|---|---|---|---|
| 1.8.8 | 101 → 34 | 6976ms | 3577ms |
| 1.9.4 | 101 → 34 | 7075ms | 3625ms |
| 1.13.2 | 101 → 34 | 7037ms | 3232ms |
| 1.16.5 | — | — | 2348ms |
| 1.21.8 | 29 → 21 | 2909ms | 2073ms |
| 26.1 | 29 → 21 | 3497ms | 2618ms |

On 1.14+ the server moves whole stacks into the trade slots itself when a trade is selected, so the click count barely changes there; the gain is from the concurrent slot setup. The remaining ~1s of the pre-1.14 runs is the two command-block sleeps (#4029).
