### PR TITLE
Flip isRaining on rain level zero-crossings, not only start/stop_raining

### DIFF
--- a/lib/plugins/rain.js
+++ b/lib/plugins/rain.js
@@ -5,17 +5,23 @@ function inject (bot) {
   bot.isRaining = false
   bot.thunderState = 0
   bot.rainState = 0
+  function setRaining (isRaining) {
+    if (bot.isRaining === isRaining) return
+    bot.isRaining = isRaining
+    bot.emit('rain')
+  }
+
   bot._client.on('game_state_change', (packet) => {
     const reason = states[packet.reason] ?? packet.reason
     if (reason === 'start_raining') {
-      bot.isRaining = true
-      bot.emit('rain')
+      setRaining(true)
     } else if (reason === 'stop_raining') {
-      bot.isRaining = false
-      bot.emit('rain')
+      setRaining(false)
     } else if (reason === 'rain_level_change') {
+      const wasWet = bot.rainState > 0
       bot.rainState = packet.gameMode
       bot.emit('weatherUpdate')
+      if (wasWet !== (packet.gameMode > 0)) setRaining(packet.gameMode > 0)
     } else if (reason === 'thunder_level_change') {
       bot.thunderState = packet.gameMode
       bot.emit('weatherUpdate')

--- a/test/externalTests/rain.js
+++ b/test/externalTests/rain.js
@@ -2,8 +2,11 @@ const assert = require('assert')
 const { once } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
-  bot.test.sayEverywhere('/weather clear')
-  await bot.test.wait(1000)
+  if (bot.isRaining) {
+    bot.test.sayEverywhere('/weather clear')
+    await once(bot, 'rain')
+  }
+  assert.strictEqual(bot.isRaining, false)
   bot.test.sayEverywhere('/weather rain')
 
   await once(bot, 'rain')

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -578,6 +578,32 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('rain', () => {
+      it('flips isRaining on rain level zero-crossings without start_raining', (done) => {
+        // Vanilla 26.1 can bring rain in with only rain_level_change ramps,
+        // never sending start_raining/stop_raining (observed on a quick
+        // weather flip), so level crossings alone must drive isRaining.
+        const mapped = JSON.stringify(registry.protocol.play.toClient.types.packet_game_state_change).includes('rain_level_change')
+        const reason = mapped ? 'rain_level_change' : 7
+        server.on('playerJoin', (client) => {
+          assert.strictEqual(bot.isRaining, false)
+          bot.once('rain', () => {
+            assert.strictEqual(bot.isRaining, true)
+            bot.once('rain', () => {
+              assert.strictEqual(bot.isRaining, false)
+              assert.strictEqual(bot.rainState, 0)
+              done()
+            })
+            client.write('game_state_change', { reason, gameMode: 0 })
+          })
+          client.write('game_state_change', { reason, gameMode: 0.01 })
+          // A second wet level must not emit again: if it did, the inner
+          // once would run with isRaining still true and fail the assert.
+          client.write('game_state_change', { reason, gameMode: 0.5 })
+        })
+      })
+    })
+
     describe('entities', () => {
       it('entity id changes on login', (done) => {
         const loginPacket = bot.test.generateLoginPacket()


### PR DESCRIPTION
## Problem

On 26.1 a quick weather flip (rain → clear → rain within the ~1s rain-level ramp) produces **no `start_raining` or `stop_raining` at all** — the server only sends `rain_level_change` packets ramping the level. Packet-traced: `/weather clear` followed by `/weather rain` a second later yields just a `0.81 → 1.00` ramp, no state-change reasons. `bot.isRaining` and the `'rain'` event silently miss such transitions (`once(bot, 'rain')` hangs its full timeout).

Found via the 26.1 external suite, where a test that leaves the world raining makes the rain test time out for 20s every run.

## Change

`lib/plugins/rain.js` also derives the flip from rain-level **zero-crossings**: level 0 → >0 sets `isRaining`, >0 → 0 clears it. Crossings rather than the absolute level, because after an explicit `stop_raining` the level still ramps down through wet values, which must not flip the state back. `start_raining`/`stop_raining` still work and are deduped through a single setter, so whichever signal arrives first emits exactly one `'rain'`.

The external rain test now awaits the `'rain'` event when clearing pre-existing rain instead of a fixed 1s wait, so it is robust to inheriting a raining world from an earlier failed test.

## Tests

- New internal test replays the traced 26.1 sequence (a `rain_level_change` ramp with no `start_raining`, then a drop to 0) and asserts both flips plus dedupe of a second wet level. It **fails on master's lib (timeout)** and passes with the change; run on 1.8.8, 1.19.4 and 26.1.
- External rain test run on 1.12.2, 1.19.4 and 26.1 — all passing, including paired with the fishing test on 26.1.
- No version compares — the behavior is packet-data-driven and version-agnostic (numeric reason 7 and the mapped `rain_level_change` both covered).