### PR TITLE
Repeat duration regressions at the end of compareDurations output

### DIFF
--- a/test/common/compareDurations.js
+++ b/test/common/compareDurations.js
@@ -29,6 +29,7 @@ for (const file of fs.readdirSync(currentDir).filter(f => f.startsWith('duration
   }
 }
 if (slower.length > 0) {
-  console.log(`\n${slower.length} test(s) got more than ${FACTOR}x slower than master`)
+  console.log(`\n${slower.length} test(s) got more than ${FACTOR}x slower than master:`)
+  for (const line of slower) console.log(`  SLOWER ${line}`)
   fs.writeFileSync(slowerFile, slower.join('\n') + '\n')
 }


### PR DESCRIPTION
compareDurations.js printed its regression summary with `console.error`. GitHub Actions interleaves stderr out of order with buffered stdout, so in a long job (e.g. [this run](https://github.com/PrismarineJS/mineflayer/actions/runs/33342887454/job/99341610997?pr=4031), ~4900 lines) the `1 test(s) got more than 1.5x slower than master` line landed mid-table, the single `SLOWER` row was hundreds of lines further up, and the step log ended with unmarked duration rows followed by `Process completed with exit code 1` — no indication of what failed without searching the log.

Now the regressed rows are collected and printed again with the summary at the very end, on stdout, so the final lines of a failing step are exactly the tests that regressed:

```
1 test(s) got more than 1.5x slower than master:
  SLOWER    1644ms ->   16107ms  mineflayer_external 1.16.5v spawnEvent
```

CI-tooling only, no bot behaviour change; both exit paths exercised locally with fixture duration files.