### PR TITLE
test: replace fixed sleeps with event and condition waits

### DIFF
--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const { once } = require('../../lib/promise_utils')
+const { once, onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   // The bed is placed relative to the bot; blockAt cannot see it until the
@@ -13,6 +13,7 @@ module.exports = () => async (bot) => {
   assert(bedItem)
 
   // Put the bed
+  const bedUpdates = [bedPos1, bedPos2].map(pos => onceWithCleanup(bot.world, `blockUpdate:(${pos.x}, ${pos.y}, ${pos.z})`, { timeout: 5000 }))
   if (bot.supportFeature('setBlockUsesMetadataNumber', bot.version)) {
     bot.chat(`/setblock ${bedPos1.toArray().join(' ')} ${bedItem.name} 0`) // Footer
     bot.chat(`/setblock ${bedPos2.toArray().join(' ')} ${bedItem.name} 8`) // Head
@@ -21,8 +22,12 @@ module.exports = () => async (bot) => {
     bot.chat(`/setblock ${bedPos2.toArray().join(' ')} ${bedItem.name}[part=head,facing=south]`)
   }
   bot.chat(`/time set ${midnight}`)
-  await once(bot, 'time')
-  await bot.test.wait(1000)
+  // Periodic time packets can carry the pre-set time, so wait for one that
+  // reflects the change; the block updates are not ordered with it.
+  await Promise.all([
+    onceWithCleanup(bot, 'time', { timeout: 5000, checkCondition: () => bot.time.timeOfDay >= midnight }),
+    ...bedUpdates
+  ])
 
   console.log(bot.time.timeOfDay, bot.blockAt(bedPos1).name, bot.blockAt(bedPos2).name)
   const blockAtBed1 = bot.blockAt(bedPos1)

--- a/test/externalTests/digAndBuild.js
+++ b/test/externalTests/digAndBuild.js
@@ -1,5 +1,6 @@
 const { Vec3 } = require('vec3')
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
@@ -13,9 +14,16 @@ module.exports = () => async (bot) => {
   await bot.test.becomeSurvival()
   // we are bare handed
   await bot.dig(bot.blockAt(bot.entity.position.plus(new Vec3(0, -1, 0))))
-  // make sure we collected das dirt
-  await bot.test.wait(1000)
-  assert(Item.equal(bot.inventory.slots[36], new Item(bot.registry.itemsByName.dirt.id, 1, 0)))
+  // make sure we collected das dirt; the drop sits through its pickup delay
+  // before it can reach the inventory, so wait for the slot update
+  const dirt = new Item(bot.registry.itemsByName.dirt.id, 1, 0)
+  if (!Item.equal(bot.inventory.slots[36], dirt)) {
+    await onceWithCleanup(bot.inventory, 'updateSlot', {
+      timeout: 5000,
+      checkCondition: (slot) => slot === 36 && Item.equal(bot.inventory.slots[36], dirt)
+    })
+  }
+  assert(Item.equal(bot.inventory.slots[36], dirt))
   bot.test.sayEverywhere('dirt collect test: pass')
 
   async function waitForFall () {

--- a/test/externalTests/exampleBlockFinder.js
+++ b/test/externalTests/exampleBlockFinder.js
@@ -3,7 +3,8 @@ const assert = require('assert')
 module.exports = () => async (bot) => {
   await bot.test.runExample('examples/blockfinder.js', async (name) => {
     assert.strictEqual(name, 'finder')
-    await bot.test.wait(2000)
+    // The example answers 'Ready!' only after its own waitForChunksToLoad,
+    // so its world is already queryable here.
     await bot.test.tellAndListen(name, 'find dirt', (message) => {
       const matches = message.match(/I found ([0-9]+) (.+?) blocks in (.+?) ms/)
       if (matches.length !== 4 || matches[1] === '0' || matches[2] !== 'dirt' || parseFloat(matches[3]) > 500) {

--- a/test/externalTests/exampleDigger.js
+++ b/test/externalTests/exampleDigger.js
@@ -1,11 +1,25 @@
 const assert = require('assert')
 
+const { onceWithCleanup } = require('../../lib/promise_utils')
+
 module.exports = () => async (bot) => {
   await bot.test.runExample('examples/digger.js', async (name) => {
     assert.strictEqual(name, 'digger')
-    bot.chat('/op digger') // to counteract spawn protection
-    bot.chat('/give digger dirt 64')
-    await bot.test.wait(2000)
+    // Both commands must be confirmed before digging: the op counteracts
+    // spawn protection and the dirt is needed by the later equip step.
+    const opped = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (msg) => msg.includes(`Opped ${name}`) || msg.includes(`Made ${name} a server operator`)
+    })
+    // Old versions render the give feedback with unsubstituted placeholders
+    // ("Given [Dirt] * %d to 64"), so only the prefix can be matched.
+    const given = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (msg) => msg.startsWith('Given') || msg.startsWith('Gave')
+    })
+    bot.chat(`/op ${name}`) // to counteract spawn protection
+    bot.chat(`/give ${name} dirt 64`)
+    await Promise.all([opped, given])
     await bot.test.tellAndListen(name, 'dig', (message) => {
       if (message.startsWith('starting')) {
         return false // continue to listen

--- a/test/externalTests/experience.js
+++ b/test/externalTests/experience.js
@@ -1,9 +1,8 @@
 const assert = require('assert')
-const { once } = require('../../lib/promise_utils')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   await bot.test.becomeSurvival()
-  await bot.test.wait(1000)
 
   // Initial state
   const initialState = {
@@ -21,7 +20,9 @@ module.exports = () => async (bot) => {
     : `/xp add ${bot.username} 10 points`
 
   await bot.chat(xpCommand)
-  await once(bot, 'experience')
+  // A stale experience packet can arrive between the command and the event;
+  // wait for the state the command produces, not for any event.
+  await onceWithCleanup(bot, 'experience', { timeout: 5000, checkCondition: () => bot.experience.points >= initialState.points + 10 })
 
   // Verify after points
   assert(bot.experience.points >= 10, 'Experience points should be at least 10 after adding points')
@@ -34,7 +35,7 @@ module.exports = () => async (bot) => {
     : `/xp add ${bot.username} 100 levels`
 
   await bot.chat(levelCommand)
-  await once(bot, 'experience')
+  await onceWithCleanup(bot, 'experience', { timeout: 5000, checkCondition: () => bot.experience.level >= initialState.level + 100 })
 
   // Verify after levels
   assert(bot.experience.level >= 100, 'Experience level should be at least 100 after adding levels')

--- a/test/externalTests/sound.js
+++ b/test/externalTests/sound.js
@@ -27,8 +27,6 @@ module.exports = () => async (bot) => {
 
   // Test sound effect events
   const soundTest = async () => {
-    await new Promise(resolve => setTimeout(resolve, 2000))
-
     return retry(async () => {
       const soundPromise = once(bot, 'soundEffectHeard', 5000)
 
@@ -57,7 +55,7 @@ module.exports = () => async (bot) => {
       const isClose = positionsAreClose(position, bot.entity.position)
       assert.ok(isClose,
         `Position mismatch: expected ${JSON.stringify(bot.entity.position)}, got ${JSON.stringify(position)}`)
-    })
+    }, 2)
   }
 
   // Test note block sounds


### PR DESCRIPTION
Removes ~9s of fixed sleeps per version per suite run across six external tests, replacing each with a wait for the concrete event or condition the sleep was papering over:

| Test | Sleep removed | Replaced by |
|---|---|---|
| bed | `once('time')` + 1s | per-half `blockUpdate` waits registered before the setblocks, plus a `time` wait conditioned on `timeOfDay >= midnight` (periodic time packets can carry the pre-set time) |
| digAndBuild | 1s | `updateSlot` condition wait for slot 36 holding the dirt (the drop sits through its pickup delay), check-then-wait so an already-arrived item skips the wait |
| exampleBlockFinder | 2s | nothing needed — the example answers `Ready!` only after its own `waitForChunksToLoad` |
| exampleDigger | 2s | awaits both the op confirmation and the give feedback before digging; give matched on the `Given`/`Gave` prefix because old versions render the feedback with unsubstituted placeholders (`Given [Dirt] * %d to 64`) |
| experience | 1s | the two `once('experience')` waits became condition waits relative to captured initial state, immune to a stale experience packet arriving between command and event |
| sound | 2s | dropped; the existing `retry` wrapper gets 2 attempts as the fallback |

All waits carry 5s timeouts, so each is strictly more tolerant than the fixed sleep it replaces while normally resolving in a tick or two.

Test-only change. Ran all six tests on 1.9.4, 1.12.2, 1.19.4 and 26.1 — green on each (one transient digAndBuild timeout on a loaded machine passed on solo and full-batch re-run).