### PR TITLE
test: fix digWaterSpeed and furnace races against slow server ticks

### DIFF
--- a/test/externalTests/digWaterSpeed.js
+++ b/test/externalTests/digWaterSpeed.js
@@ -1,5 +1,6 @@
 const { Vec3 } = require('vec3')
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const groundY = bot.test.groundY
@@ -8,6 +9,15 @@ module.exports = () => async (bot) => {
   const testZ = 10
   const floorY = groundY
 
+  // Command feedback is sent immediately while block changes flush at tick
+  // end, so a chat echo does not prove the fill's updates arrived; the probe
+  // block reaching its expected state does.
+  const untilBlockIs = async (pos, names) => {
+    const reached = () => names.includes(bot.blockAt(pos)?.name)
+    if (reached()) return
+    await onceWithCleanup(bot.world, 'blockUpdate', { timeout: 5000, checkCondition: reached })
+  }
+
   // --- Setup: teleport and prepare the area ---
   await bot.test.becomeCreative()
   await bot.test.teleport(new Vec3(testX, floorY + 2, testZ))
@@ -15,9 +25,8 @@ module.exports = () => async (bot) => {
 
   // Clear the test area and place a solid floor
   bot.chat(`/fill ${testX - 2} ${floorY} ${testZ - 2} ${testX + 2} ${floorY + 5} ${testZ + 2} air`)
-  await bot.test.wait(500)
   bot.chat(`/fill ${testX - 2} ${floorY} ${testZ - 2} ${testX + 2} ${floorY} ${testZ + 2} stone`)
-  await bot.test.wait(500)
+  await untilBlockIs(new Vec3(testX, floorY, testZ), ['stone'])
 
   // Place a dirt block for digTime testing
   const digBlockPos = new Vec3(testX + 1, floorY + 1, testZ)
@@ -25,7 +34,6 @@ module.exports = () => async (bot) => {
 
   // Teleport bot to the test position
   await bot.test.teleport(new Vec3(testX, floorY + 1, testZ))
-  await bot.test.wait(500)
 
   // === Test 1: No water around bot - eye-level block should not be water ===
   const eyeBlock1 = bot._getBlockAtEyeLevel()
@@ -34,8 +42,9 @@ module.exports = () => async (bot) => {
     'Eye-level block should not be water when area is dry')
 
   // === Test 2: Fill water column around bot - eye-level block should be water ===
+  const eyePos = new Vec3(testX, floorY + 2, testZ)
   bot.chat(`/fill ${testX} ${floorY + 1} ${testZ} ${testX} ${floorY + 4} ${testZ} water`)
-  await bot.test.wait(500)
+  await untilBlockIs(eyePos, ['water', 'flowing_water'])
 
   const eyeBlock2 = bot._getBlockAtEyeLevel()
   bot.test.sayEverywhere(`Test 2 (submerged): eye-level block = ${eyeBlock2?.name ?? 'null'}`)
@@ -47,12 +56,11 @@ module.exports = () => async (bot) => {
   // at eye level instead of using bot.entity.isInWater
   // Clear water and restore dirt
   bot.chat(`/fill ${testX - 1} ${floorY + 1} ${testZ - 1} ${testX + 1} ${floorY + 5} ${testZ + 1} air`)
-  await bot.test.wait(500)
+  await untilBlockIs(digBlockPos, ['air'])
+  await untilBlockIs(eyePos, ['air'])
   await bot.test.setBlock({ x: digBlockPos.x, y: digBlockPos.y, z: digBlockPos.z, blockName: 'dirt' })
-  await bot.test.wait(300)
 
   await bot.test.becomeSurvival()
-  await bot.test.wait(500)
 
   const block = bot.blockAt(digBlockPos)
   assert(block && block.name !== 'air', 'Expected a dirt block to measure digTime')
@@ -73,7 +81,6 @@ module.exports = () => async (bot) => {
   // Cleanup
   await bot.test.becomeCreative()
   bot.chat(`/fill ${testX - 2} ${floorY + 1} ${testZ - 2} ${testX + 2} ${floorY + 5} ${testZ + 2} air`)
-  await bot.test.wait(200)
 
   bot.test.sayEverywhere('digWaterSpeed: all tests passed')
 }

--- a/test/externalTests/furnace.js
+++ b/test/externalTests/furnace.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { onceWithCleanup } = require('../../lib/promise_utils')
 
 module.exports = () => async (bot) => {
   const Item = require('prismarine-item')(bot.registry)
@@ -42,8 +43,12 @@ module.exports = () => async (bot) => {
   assert.strictEqual(furnace.inputItem().type, porkchopId)
   assert.strictEqual(furnace.inputItem().count, porkchopInputCount)
 
-  // Wait and take the output and inputs
-  await bot.test.wait(500)
+  // Burning starts on the next server tick; the window properties carrying
+  // fuel and progress arrive as furnace updates, not with the item packets.
+  await onceWithCleanup(furnace, 'update', {
+    timeout: 5000,
+    checkCondition: () => furnace.fuel > 0 && furnace.fuel < 1 && furnace.progress > 0 && furnace.progress < 1
+  })
   assert(furnace.fuel > 0 && furnace.fuel < 1)
   assert(furnace.progress > 0 && furnace.progress < 1)
 
@@ -62,8 +67,6 @@ module.exports = () => async (bot) => {
   await furnace.takeInput()
   await furnace.takeFuel()
   furnace.close()
-
-  await bot.test.wait(500)
 
   // Check inventory
   const cookedPorkchopCount = bot.inventory.count(cookedPorkchopId)


### PR DESCRIPTION
Two external tests race the server's tick processing and fail whenever a tick runs long (CI under load); both were reproduced deterministically on unmodified master by stalling the server process (SIGSTOP, mechanically identical to a lagging tick) at the critical moment:

**digWaterSpeed**: the water `/fill`s were unawaited and padded with fixed sleeps; a 1.6s stall on the fill feedback made `setBlock` read stale dirt, skip its `/setblock`, and the late fill left air → `Expected a dirt block to measure digTime`. Now each fill/setblock is awaited via a probe on the block that must actually change (a chat-echo marker is not enough: command feedback is sent immediately while block changes flush at tick end). Also ~3.3s faster (4.1s → 0.8s).

**furnace**: a 500ms sleep raced the window-property packets after inserting fuel — a 1.2s stall on the slot-click ack failed `assert(furnace.fuel > 0 && furnace.fuel < 1)` on the first attempt. Now waits for the furnace `update` event carrying mid-burn fuel/progress; the second settle sleep before the inventory check is dropped.

Test-only change, no version compares. Verified:
- both tests pass under the identical injected stalls that fail master
- plain runs green on 1.8.8, 1.19.4 and 26.1