### PR TITLE
test: survive server stalls without cascading ~17 false failures

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -80,10 +80,16 @@ for (const supportedVersion of mineflayer.testedVersions) {
           viewDistance: 'tiny',
           port: PORT,
           host: '127.0.0.1',
-          version: supportedVersion
+          version: supportedVersion,
+          // Dimension travel can stall the server thread past the 30s
+          // keepalive default; mocha's per-test timeout is the real watchdog.
+          checkTimeoutInterval: TEST_TIMEOUT_MS
         })
         commonTest(bot, wrap)
         bot.test.port = PORT
+        // bot.entity survives a disconnect, so only the end event proves the
+        // connection is gone; the flag dies with the bot on reconnect.
+        bot.once('end', () => { bot.test.disconnected = true })
 
         console.log('starting bot')
         trace.log('bot created')
@@ -173,10 +179,12 @@ for (const supportedVersion of mineflayer.testedVersions) {
         viewDistance: 'tiny',
         port: PORT,
         host: '127.0.0.1',
-        version: supportedVersion
+        version: supportedVersion,
+        checkTimeoutInterval: TEST_TIMEOUT_MS
       })
       commonTest(bot, wrap)
       bot.test.port = PORT
+      bot.once('end', () => { bot.test.disconnected = true })
       await once(bot, 'spawn')
       console.log('  Bot reconnected')
       wrap.writeServer('op flatbot\n')
@@ -210,7 +218,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
               console.log(`  [retry ${this.test._currentRetry}] ${testName}`)
             }
             // Reconnect if bot got disconnected by a previous test
-            const reconnect = !bot.entity
+            const reconnect = (!bot.entity || bot.test.disconnected)
               ? reconnectBot()
               : Promise.resolve()
             reconnect.then(() => bot.test.resetState())


### PR DESCRIPTION
## Problem

When the vanilla server's tick thread stalls past 30s (nether world-gen under a loaded CI runner is the usual trigger), the client's keepalive watchdog disconnects the test bot. `bot.entity` survives disconnect, so the harness's reconnect check (`!bot.entity`) never fires — and every subsequent test fails its 5s `resetState` with "No entity was found". Observed as 17-23 false failures per run on 1.8.8 and 1.13.2 under concurrent load.

Reproduced deterministically on unmodified master by SIGSTOPping the server process for 35s at the nether test (mechanically identical to a world-gen stall): **34 passing / 17 failing** — nether plus all 16 subsequent tests, twice. (An idle machine won't show it naturally: nether gen completes in ~5s there. CI runners are not idle machines.)

## Change (test harness only)

- `checkTimeoutInterval: TEST_TIMEOUT_MS` on the harness bots — mocha's existing per-test timeout is the real watchdog, so the client-side keepalive check shouldn't fire first. Reuses the existing constant.
- A per-bot `bot.test.disconnected` flag set on `'end'`, checked alongside `!bot.entity` in the reconnect gate. This half is not optional: after a >30s stall the *server* kicks the bot ("Timed out") on resume even when the client no longer disconnects, so detection is required, not just avoidance. Per-bot rather than module-level so a late `'end'` from the replaced bot can't poison the reconnected one.

## Verification

| Run | Result |
|---|---|
| 1.13.2 master, natural ×2 | 51/0 |
| 1.13.2 master + injected 35s stall ×2 | 34/17 cascade |
| 1.13.2 fixed + identical stall | 45/6, one clean reconnect, no cascade (residuals are injection collateral: nether's own timeout expiring mid-freeze and clock-skew aftershocks from a server 766 ticks behind) |
| 1.13.2 fixed, natural | 51/0 |
| 1.8.8 master → fixed, natural | 51/0 → 51/0 |
| 26.1 fixed, harness smoke | green |