### PR TITLE
Expose cape URL in player skinData

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -424,7 +424,8 @@ The skin data is stored in the `skinData` property of the player object, if pres
 // player.skinData
 {
   url: 'http://textures.minecraft.net/texture/...',
-  model: 'slim' // or 'classic'
+  model: 'slim', // or 'classic'
+  capeUrl: 'http://textures.minecraft.net/texture/...' // only if the player has a cape
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -501,6 +501,7 @@ export interface Player {
 export interface SkinData {
   url: string
   model: string | null
+  capeUrl?: string
 }
 
 export interface ChatPattern {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -962,10 +962,11 @@ function extractSkinInformation (properties) {
 
   const skinTextureUrl = skinTexture?.textures?.SKIN?.url ?? undefined
   const skinTextureModel = skinTexture?.textures?.SKIN?.metadata?.model ?? undefined
+  const capeTextureUrl = skinTexture?.textures?.CAPE?.url ?? undefined
 
   if (!skinTextureUrl) {
     return undefined
   }
 
-  return { url: skinTextureUrl, model: skinTextureModel }
+  return { url: skinTextureUrl, model: skinTextureModel, capeUrl: capeTextureUrl }
 }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -716,6 +716,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
             assert.ok(player.skinData, 'skinData should be parsed from mojangson')
             assert.strictEqual(player.skinData.url, 'http://textures.minecraft.net/texture/abc123')
             assert.strictEqual(player.skinData.model, 'slim')
+            assert.strictEqual(player.skinData.capeUrl, undefined)
             done()
           })
 
@@ -792,6 +793,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
             SKIN: {
               url: 'http://textures.minecraft.net/texture/def456',
               metadata: { model: 'default' }
+            },
+            CAPE: {
+              url: 'http://textures.minecraft.net/texture/cape789'
             }
           }
         })
@@ -804,6 +808,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
             assert.ok(player.skinData, 'skinData should be parsed from JSON')
             assert.strictEqual(player.skinData.url, 'http://textures.minecraft.net/texture/def456')
             assert.strictEqual(player.skinData.model, 'default')
+            assert.strictEqual(player.skinData.capeUrl, 'http://textures.minecraft.net/texture/cape789')
             done()
           })
 


### PR DESCRIPTION
The profile `textures` property carries a `CAPE` entry next to `SKIN` for players who have one. This surfaces it as `player.skinData.capeUrl` (undefined when absent), with the type, docs and the existing skin-data internal tests updated.

Needed by PrismarineJS/prismarine-viewer#490 to render capes.


CI note: the earlier red runs were the new duration-comparison step flagging `fishing` (1.12.2, 1.15.2) and `nether` (1.20.2, 1.20.4, 1.21.3) as >1.5x slower than master; every test passed and none of them touch skin data.
