### PR TITLE
bed: wake() sends the right entity_action on 1.21.11+ (leave_bed renumbered; 2 is stop_sprinting there)

### DIFF
--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -64,13 +64,21 @@ function inject (bot) {
     return metadata
   }
 
+  // entity_action's ids shifted in 1.21.11: start/stop sneaking moved to
+  // player_input, so "leave bed" went from 2 to 0 and the field became a
+  // named mapping. Older protocols take the bare number. Read the protocol
+  // rather than hardcoding either — sending 2 to a 1.21.11+ server means
+  // "stop sprinting", and the bot stays in bed until the server wakes it.
+  const actionField = bot.registry.protocol?.play?.toServer?.types?.packet_entity_action?.[1]?.find?.(f => f.name === 'actionId')
+  const leaveBedAction = Array.isArray(actionField?.type) && actionField.type[0] === 'mapper' ? 'leave_bed' : 2
+
   async function wake () {
     if (!bot.isSleeping) {
       throw new Error('already awake')
     } else {
       bot._client.write('entity_action', {
         entityId: bot.entity.id,
-        actionId: 2,
+        actionId: leaveBedAction,
         jumpBoost: 0
       })
     }

--- a/test/externalTests/bed.js
+++ b/test/externalTests/bed.js
@@ -41,4 +41,10 @@ module.exports = () => async (bot) => {
   await bot.wake()
   await wakePromise
   assert(!bot.isSleeping)
+  // A lone sleeper on a vanilla server skips the night after ~100 ticks and
+  // is woken BY THE SERVER — which is what happened on 1.21.11+ before
+  // wake() sent the right action, and it made this test pass anyway. A real
+  // wake leaves the clock where it was; a night skip resets it to morning.
+  await once(bot, 'time')
+  assert(bot.time.timeOfDay >= midnight, `bot was woken by the night ending (time ${bot.time.timeOfDay}), not by wake()`)
 }


### PR DESCRIPTION
## Problem

On 1.21.11 and later, `bot.wake()` does nothing: the bot stays in bed until the server wakes it.

1.21.11 moved start/stop sneaking out of `entity_action` (they went to `player_input`), so the remaining actions renumbered and the field became a named mapping. `leave_bed` is **0** there; it was **2** before. `wake()` still sends `2`, which those servers read as `stop_sprinting`.

Seen live on a Paper 26.1.2 server with a second player online: `bot.sleep()` worked (advancement "Sweet Dreams" logged), `bot.wake()` resolved, `bot.isSleeping` stayed `true`, and the bot lay there until it was disconnected.

## Fix

Read the protocol definition once at inject time: when `actionId` is a mapper, send `'leave_bed'` by name; otherwise send the bare `2` as before. No version table to maintain, and older servers are unchanged.

## Why the external test didn't catch it

`test/externalTests/bed.js` sleeps and then awaits `wake`. On the test server the bot is the only player, so ~100 ticks after it lies down the night is skipped and **the server wakes it**, whether or not `wake()` worked. The test now checks that the clock is still night after `wake()` resolves — a real wake leaves the clock alone, a night skip resets it to morning.

## Notes

- Verified against minecraft-data: `entity_action.actionId` is a bare varint on 1.8–1.21.10 and a mapper (`0: leave_bed, 1: start_sprinting, 2: stop_sprinting, …`) on 1.21.11 and 26.1.
- If you'd rather gate this on a `features.json` flag in minecraft-data than on the protocol shape, happy to change it — the protocol read seemed the least surprising since it's the packet itself that changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
