### PR TITLE
ci: comment on PRs with tests that got slower instead of failing them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      # Per-test durations from the last master run of this version group, so a PR
-      # can be failed if it makes a test more than 1.5x slower (test/common/compareDurations.js).
+      # Per-test durations from the last master run of this version group, so a PR gets a
+      # comment listing tests it made more than 1.5x slower (test/common/compareDurations.js).
       - name: Restore duration baseline
         uses: actions/cache/restore@v4
         with:
@@ -123,7 +123,19 @@ jobs:
           exit $exit_code
 
       - name: Compare test durations against master
-        run: node test/common/compareDurations.js baseline durations
+        run: |
+          mkdir -p slower
+          echo "${{ github.event.pull_request.number }}" > slower/pr
+          node test/common/compareDurations.js baseline durations "slower/${{ strategy.job-index }}.txt"
+
+      # Fork PRs get a read-only token, so the comment is posted by
+      # duration-comment.yml from this artifact instead of from here.
+      - name: Upload slower tests for the PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: slower-${{ strategy.job-index }}
+          path: slower
 
       - name: Save duration baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/duration-comment.yml
+++ b/.github/workflows/duration-comment.yml
@@ -1,0 +1,41 @@
+name: Duration comment
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: slower-*
+          merge-multiple: true
+          path: slower
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            if (!fs.existsSync('slower/pr')) return
+            const issue_number = Number(fs.readFileSync('slower/pr', 'utf8'))
+            const lines = fs.readdirSync('slower').filter(f => f.endsWith('.txt')).sort()
+              .flatMap(f => fs.readFileSync(`slower/${f}`, 'utf8').trimEnd().split('\n'))
+            const marker = '<!-- slower-tests -->'
+            const { owner, repo } = context.repo
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
+            const existing = comments.find(c => c.body.startsWith(marker))
+            if (lines.length === 0 && !existing) return
+            const body = lines.length === 0
+              ? `${marker}\nNo tests are more than 1.5x slower than master anymore.`
+              : `${marker}\nTests more than 1.5x slower than master (durations are noisy, so this is informational):\n\`\`\`\n${lines.join('\n')}\n\`\`\``
+            if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
+            else await github.rest.issues.createComment({ owner, repo, issue_number, body })

--- a/test/common/compareDurations.js
+++ b/test/common/compareDurations.js
@@ -1,14 +1,15 @@
-// Usage: node test/common/compareDurations.js <baselineDir> <currentDir>
-// Fails if any test that passed in both runs got more than 1.5x slower than master's baseline.
+// Usage: node test/common/compareDurations.js <baselineDir> <currentDir> <slowerFile>
+// Writes every test that got more than 1.5x slower than master's baseline to <slowerFile>,
+// one line each, so CI can post them as a PR comment. Never fails: durations are noisy.
 const fs = require('fs')
 const path = require('path')
 
-const [baselineDir, currentDir] = process.argv.slice(2)
+const [baselineDir, currentDir, slowerFile] = process.argv.slice(2)
 const FACTOR = 1.5
 // Ignore tests too short for a 1.5x jump to mean anything (server/network jitter).
 const MIN_REGRESSION_MS = 5000
 
-let regressions = 0
+const slower = []
 for (const file of fs.readdirSync(currentDir).filter(f => f.startsWith('durations-')).sort()) {
   const baselineFile = path.join(baselineDir, file)
   if (!fs.existsSync(baselineFile)) {
@@ -22,11 +23,12 @@ for (const file of fs.readdirSync(currentDir).filter(f => f.startsWith('duration
     const base = baseline[title]
     if (base === undefined) continue
     const regressed = ms > base * FACTOR && ms - base > MIN_REGRESSION_MS
-    if (regressed) regressions++
-    console.log(`  ${regressed ? 'SLOWER' : '      '} ${String(base).padStart(7)}ms -> ${String(ms).padStart(7)}ms  ${title}`)
+    const line = `${String(base).padStart(7)}ms -> ${String(ms).padStart(7)}ms  ${title}`
+    if (regressed) slower.push(line)
+    console.log(`  ${regressed ? 'SLOWER' : '      '} ${line}`)
   }
 }
-if (regressions > 0) {
-  console.error(`\n${regressions} test(s) got more than ${FACTOR}x slower than master`)
-  process.exit(1)
+if (slower.length > 0) {
+  console.log(`\n${slower.length} test(s) got more than ${FACTOR}x slower than master`)
+  fs.writeFileSync(slowerFile, slower.join('\n') + '\n')
 }


### PR DESCRIPTION
Follow-up to #4028. Test durations are too noisy for a hard gate: fishing and nether vary by 2-3x between identical runs (see #4045's CI, and master's own run at faa2e33e failed the same check). Keep the comparison, but post the tests that got more than 1.5x slower as a PR comment instead of failing the job.

How it works:
- `compareDurations.js` writes the slower tests to a file and never exits non-zero.
- Each matrix job uploads that file plus the PR number as a `slower-<job-index>` artifact.
- New `duration-comment.yml` runs on `workflow_run` of CI, downloads the artifacts and creates or updates a single marked comment on the PR. When a later push has no slower tests, the same comment is updated to say so.

Fork PRs get a read-only token, so the comment cannot be posted from the CI run itself; `workflow_run.pull_requests` is also empty for forks, which is why the PR number travels in the artifact.

Since the new workflow triggers on `workflow_run`, it only starts running once this is merged to master. The script was smoke-tested locally with fake duration files.
