### PR TITLE
settings: send particleStatus to the server

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,6 +128,7 @@
         - [bot.settings.skinParts.showHat - boolean](#botsettingsskinpartsshowhat---boolean)
       - [bot.settings.enableTextFiltering - boolean](#botsettingsenabletextfiltering---boolean)
       - [bot.settings.enableServerListing - boolean](#botsettingsenableserverlisting---boolean)
+      - [bot.settings.particleStatus - string](#botsettingsparticlestatus---string)
       - [bot.experience.level](#botexperiencelevel)
       - [bot.experience.points](#botexperiencepoints)
       - [bot.experience.progress](#botexperienceprogress)
@@ -827,6 +828,7 @@ Create and return an instance of the class bot.
  * [skinParts](#bot.settings.skinParts)
  * [enableTextFiltering](#bot.settings.enableTextFiltering)
  * [enableServerListing](#bot.settings.enableServerListing)
+ * [particleStatus](#bot.settings.particleStatus)
  * chatLengthLimit : the maximum amount of characters that can be sent in a single message. If this is not set, it will be 100 in < 1.11 and 256 in >= 1.11.
  * defaultChatPatterns: defaults to true, set to false to not add the patterns such as chat and whisper
 
@@ -1013,6 +1015,8 @@ If you have a cape you can turn it off by setting this to false.
 Unused, defaults to false in Notchian (Vanilla) client.
 #### bot.settings.enableServerListing - boolean
 This setting is sent to the server to determine whether the player should show up in server listings
+#### bot.settings.particleStatus - string
+Particle status sent to the server (1.21.3+): `all`, `decreased` or `minimal`. Defaults to `all`.
 #### bot.experience.level
 
 #### bot.experience.points

--- a/lib/plugins/settings.js
+++ b/lib/plugins/settings.js
@@ -61,7 +61,8 @@ function inject (bot, options) {
       skinParts,
       mainHand: handBits,
       enableTextFiltering: bot.settings.enableTextFiltering,
-      enableServerListing: bot.settings.enableServerListing
+      enableServerListing: bot.settings.enableServerListing,
+      particleStatus: bot.settings.particleStatus
     })
   }
 


### PR DESCRIPTION
`bot.settings.particleStatus` has defaulted to `'all'` since the field was added, but the `settings` packet mineflayer writes on login never included it. On 1.21.3+ (`particleStatus` is a mapper: `all` / `decreased` / `minimal`) the field was serialized from `undefined`. It only came out as `0` = `all` because protodef's *compiled* mapper falls an unmapped value through to the numeric type, where `NaN` writes as `0`; the interpreted mapper throws on the same input.

ProtoDef-io/node-protodef#176 (merged, unreleased — latest protodef is 1.19.0 from 2025-04) makes the compiled mapper strict too, which turns this into a serialization error on every 1.21.3+ login. Send the field. The companion fix for node-minecraft-protocol's configuration-phase `settings` is PrismarineJS/node-minecraft-protocol#1519.

No version gate needed: protodef containers only write the fields the version defines, so the extra property is ignored pre-1.21.3. Confirmed in minecraft-data — `packet_common_settings` carries `particleStatus` from 1.21.3 on, and 1.21.1 / 1.16.5 / 1.8.8 have no such field.

This re-lands #4045, which was opened against the `ci/duration-comment` branch by mistake and merged there instead of into master, so the fix never reached master.

**Tests:** no test can fail without this change on the current protodef. Serializing the 1.21.4 `settings` packet both ways gives identical bytes (`…000100` with `particleStatus` omitted and with `'all'`), while `'minimal'` writes `02` — the field is wired through correctly and is a no-op on the wire until protodef ships the strict mapper. Once it does, every existing 1.21.3+ external test exercises this (login would throw without it).

Ran locally: internal suite 688 passing; external suite 51 passing on each of 1.16.5, 1.20.4 and 1.21.4; lint clean.
