### PR TITLE
test: connect the bot only after the nether forceload has finished

### DIFF
--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -9,7 +9,7 @@ const path = require('path')
 
 const { getPort } = require('./common/util')
 const trace = require('./common/trace')
-const { once } = require('../lib/promise_utils')
+const { once, onceWithCleanup } = require('../lib/promise_utils')
 
 // set this to false if you want to test without starting a server automatically
 const START_THE_SERVER = true
@@ -128,16 +128,23 @@ for (const supportedVersion of mineflayer.testedVersions) {
             wrap.writeServer('seed\n')
             // The nether test's portal travel otherwise generates these chunks
             // synchronously on the main thread while its clock runs. forceload
-            // itself blocks the main thread until every chunk is FULL, so it
-            // must run before the bot connects; pings are served off-thread,
-            // so the stall stays inside this hook's budget. 7x7 chunks covers
-            // the portal placement scan and every chunk the test's waits touch.
+            // itself blocks the main thread until every chunk is FULL, and a
+            // connection that is mid-login while it blocks hits the server's
+            // 30s read timeout, so the bot must not connect until the server
+            // reports the chunks loaded. Pings are served off-thread, so the
+            // stall stays inside this hook's budget. 7x7 chunks covers the
+            // portal placement scan and every chunk the test's waits touch.
+            let netherLoaded = Promise.resolve()
             if (registry.supportFeature('hasExecuteCommand')) {
+              netherLoaded = onceWithCleanup(wrap, 'line', {
+                timeout: 120000,
+                checkCondition: line => /Marked \d+ chunks in minecraft:the_nether/.test(line)
+              })
               wrap.writeServer('execute in minecraft:the_nether run forceload add -48 -48 63 63\n')
             }
             console.log(`pinging ${version.minecraftVersion} port : ${PORT}`)
             trace.log('server started, pinging')
-            pingUntilReady(PORT, '127.0.0.1', supportedVersion).then(results => {
+            Promise.all([pingUntilReady(PORT, '127.0.0.1', supportedVersion), netherLoaded]).then(([results]) => {
               console.log('pong')
               trace.log('pong', { latency: results.latency })
               assert.ok(results.latency >= 0)


### PR DESCRIPTION
Stacked on #4037 (`test/cheap-nether-gen`); fixes the failure that has made its CI red three times.

### Why #4037 fails

The warm-up `forceload` blocks the server's main thread until all 49 nether chunks are FULL. Status pings are answered off-thread, so `pingUntilReady` resolves while the main thread is still generating, and the bot connects into a server that cannot process its login. Netty's `ReadTimeoutHandler(30)` runs on the IO thread, so a login-phase connection that has sent `login_start` and heard nothing for 30s is dropped regardless of what the main thread is doing. Whether a version fails is just whether the stall crosses 30s on that runner:

| run | stall | result |
|---|---|---|
| [33919891284](https://github.com/PrismarineJS/mineflayer/actions/runs/33919891284) 1.16.5 | 32.3s | `GameProfile ... lost connection: Timed out`, before-all hook fails |
| same run, 1.18.2 / 1.19 | 32.0s / 31.9s | same |
| [33905032370](https://github.com/PrismarineJS/mineflayer/actions/runs/33905032370) 1.16.5 | 20.4s | passed |
| same run, 1.18.2 | 30.9s | failed |

### Change

`test/externalTest.js` waits for the console's `Marked N chunks in minecraft:the_nether ... to be force loaded` line as well as the ping before `begin()`, so no connection exists while the main thread is blocked. Versions without the execute command (pre-1.14) skip the wait and are unchanged. The stall still lands inside the hook's budget, as #4037 intended.

### Verification

Local, nether test only, with another server running on the same box:

| version | forceload stall | nether |
|---|---|---|
| 1.12.2 (no forceload) | - | pass |
| 1.16.5 | 8s | pass, 5295ms |
| 1.21.8 | 26s, bot connected after | pass, 9574ms |

The log order is now `Marked 49 chunks` -> `pong` -> `starting bot` on every forceload version.
