### PR TITLE
fix: preserve item use across unrelated entity status notifications

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -72,7 +72,8 @@ function inject (bot, { hideErrors }) {
   })
 
   bot._client.on('entity_status', (packet) => {
-    if (packet.entityId === bot.entity.id && packet.entityStatus === 9 && !eatingTask.done) {
+    if (packet.entityId !== bot.entity.id) return
+    if (packet.entityStatus === 9 && !eatingTask.done) {
       eatingTask.finish()
     }
     bot.usingHeldItem = false

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -73,6 +73,8 @@ function inject (bot, { hideErrors }) {
 
   bot._client.on('entity_status', (packet) => {
     if (packet.entityId !== bot.entity.id) return
+    // Hurt and shield-block notifications do not end the active item use.
+    if (packet.entityStatus !== 9 && packet.entityStatus !== 3) return
     if (packet.entityStatus === 9 && !eatingTask.done) {
       eatingTask.finish()
     }

--- a/test/inventoryItemUseTest.js
+++ b/test/inventoryItemUseTest.js
@@ -3,9 +3,9 @@
 const assert = require('assert')
 const { EventEmitter } = require('events')
 const injectInventory = require('../lib/plugins/inventory')
-const registry = require('prismarine-registry')('1.21.4')
+const { testedVersions } = require('../lib/version')
 
-function createBot () {
+function createBot (registry) {
   const bot = new EventEmitter()
   bot._client = new EventEmitter()
   bot._client.write = () => {}
@@ -21,29 +21,32 @@ function createBot () {
   return bot
 }
 
-describe('inventory item use and entity status', () => {
-  for (const entityStatus of [2, 3, 9, 29]) {
-    it(`keeps using an item when another entity receives status ${entityStatus}`, () => {
-      const bot = createBot()
-      bot.activateItem()
-      bot._client.emit('entity_status', { entityId: 2, entityStatus })
+for (const version of testedVersions) {
+  const registry = require('prismarine-registry')(version)
+  describe(`inventory item use and entity status ${version}v`, () => {
+    for (const entityStatus of [2, 3, 9, 29]) {
+      it(`keeps using an item when another entity receives status ${entityStatus}`, () => {
+        const bot = createBot(registry)
+        bot.activateItem()
+        bot._client.emit('entity_status', { entityId: 2, entityStatus })
+        assert.strictEqual(bot.usingHeldItem, true)
+        bot.deactivateItem()
+        assert.strictEqual(bot.usingHeldItem, false)
+      })
+    }
+
+    it('finishes consuming only when the bot receives its completion status', async () => {
+      const bot = createBot(registry)
+      const Item = require('prismarine-item')(registry)
+      bot.inventory.slots[36] = new Item(registry.itemsByName.bread.id, 1)
+      const consumed = bot.consume()
       assert.strictEqual(bot.usingHeldItem, true)
-      bot.deactivateItem()
+      bot._client.emit('entity_status', { entityId: 2, entityStatus: 9 })
+      const usingAfterOtherEntity = bot.usingHeldItem
+      bot._client.emit('entity_status', { entityId: bot.entity.id, entityStatus: 9 })
+      await consumed
+      assert.strictEqual(usingAfterOtherEntity, true)
       assert.strictEqual(bot.usingHeldItem, false)
     })
-  }
-
-  it('finishes consuming only when the bot receives its completion status', async () => {
-    const bot = createBot()
-    const Item = require('prismarine-item')(registry)
-    bot.inventory.slots[36] = new Item(registry.itemsByName.bread.id, 1)
-    const consumed = bot.consume()
-    assert.strictEqual(bot.usingHeldItem, true)
-    bot._client.emit('entity_status', { entityId: 2, entityStatus: 9 })
-    const usingAfterOtherEntity = bot.usingHeldItem
-    bot._client.emit('entity_status', { entityId: bot.entity.id, entityStatus: 9 })
-    await consumed
-    assert.strictEqual(usingAfterOtherEntity, true)
-    assert.strictEqual(bot.usingHeldItem, false)
   })
-})
+}

--- a/test/inventoryItemUseTest.js
+++ b/test/inventoryItemUseTest.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const { EventEmitter } = require('events')
+const injectInventory = require('../lib/plugins/inventory')
+const registry = require('prismarine-registry')('1.21.4')
+
+function createBot () {
+  const bot = new EventEmitter()
+  bot._client = new EventEmitter()
+  bot._client.write = () => {}
+  bot.registry = registry
+  bot.version = registry.version.minecraftVersion
+  bot.supportFeature = registry.supportFeature
+  bot.entity = { id: 1, yaw: 0, pitch: 0 }
+  bot.QUICK_BAR_START = 36
+  bot.game = { gameMode: 'survival' }
+  bot.food = 19
+  injectInventory(bot, { hideErrors: false })
+  bot.quickBarSlot = 0
+  return bot
+}
+
+describe('inventory item use and entity status', () => {
+  for (const entityStatus of [2, 3, 9, 29]) {
+    it(`keeps using an item when another entity receives status ${entityStatus}`, () => {
+      const bot = createBot()
+      bot.activateItem()
+      bot._client.emit('entity_status', { entityId: 2, entityStatus })
+      assert.strictEqual(bot.usingHeldItem, true)
+      bot.deactivateItem()
+      assert.strictEqual(bot.usingHeldItem, false)
+    })
+  }
+
+  it('finishes consuming only when the bot receives its completion status', async () => {
+    const bot = createBot()
+    const Item = require('prismarine-item')(registry)
+    bot.inventory.slots[36] = new Item(registry.itemsByName.bread.id, 1)
+    const consumed = bot.consume()
+    assert.strictEqual(bot.usingHeldItem, true)
+    bot._client.emit('entity_status', { entityId: 2, entityStatus: 9 })
+    const usingAfterOtherEntity = bot.usingHeldItem
+    bot._client.emit('entity_status', { entityId: bot.entity.id, entityStatus: 9 })
+    await consumed
+    assert.strictEqual(usingAfterOtherEntity, true)
+    assert.strictEqual(bot.usingHeldItem, false)
+  })
+})

--- a/test/inventoryItemUseTest.js
+++ b/test/inventoryItemUseTest.js
@@ -35,6 +35,24 @@ for (const version of testedVersions) {
       })
     }
 
+    for (const entityStatus of [2, 29]) {
+      it(`keeps using an item when the bot receives unrelated status ${entityStatus}`, () => {
+        const bot = createBot(registry)
+        bot.activateItem()
+        bot._client.emit('entity_status', { entityId: bot.entity.id, entityStatus })
+        assert.strictEqual(bot.usingHeldItem, true)
+        bot.deactivateItem()
+        assert.strictEqual(bot.usingHeldItem, false)
+      })
+    }
+
+    it('clears item use when the bot receives its death status', () => {
+      const bot = createBot(registry)
+      bot.activateItem()
+      bot._client.emit('entity_status', { entityId: bot.entity.id, entityStatus: 3 })
+      assert.strictEqual(bot.usingHeldItem, false)
+    })
+
     it('finishes consuming only when the bot receives its completion status', async () => {
       const bot = createBot(registry)
       const Item = require('prismarine-item')(registry)


### PR DESCRIPTION
An `entity_status` notification does not necessarily end the bot's active item use. A nearby mob's hurt status currently clears `bot.usingHeldItem`; after filtering foreign entities, the bot's own hurt and successful shield-block statuses still clear it. That can make callers believe a bow draw or shield use has already ended.

This change checks both facts in the inventory handler:

- Ignore notifications for other entities.
- For the bot itself, preserve item use unless the status is consumption completion (9) or death (3).

Consumption completion still finishes the pending `consume()` task. Explicit item deactivation remains effective. A successful shield block or hurt notification preserves the active-use flag.

The real inventory-plugin regression runs in every supported CI version group. It covers foreign hurt/death/completion/shield-block notifications, own hurt/shield-block notifications, own death, and a successful consumption completion. The own hurt and shield-block cases both fail against the previous PR head on 1.21.4 and pass with this follow-up.

Validation:

- `bun node_modules/mocha/bin/mocha.js test/inventoryItemUseTest.js test/diggingDeathTest.js --exit`: 228 passing, including 224 inventory cases across 28 supported versions.
- JavaScript Standard Style on both changed files: passed.
- `node node_modules/mocha/bin/mocha.js test/internalTest.js --grep '1.8.8v|1.21.4v' --exit`: 54 passing, 4 version-dependent skips.
- A separate Minecraft 1.21.4 physical qualification of this same handler repair in our combined fork observed a real arrow blocked at full health, with item use remaining active until explicit release.
- The broader local internal suite under Bun finished with 709 passing, 53 pending, 8 failing. Failures involved rain-state assertions, world-respawn timeouts, and their cleanup hooks; the isolated baseline 1.8.8 rerun passed, so those broader-run failures are not attributed to a confirmed cause. The full external Minecraft server/version matrix has not been rerun locally for this follow-up; upstream CI supplies that check.
