### PR TITLE
test: read rain state only after login in the isRaining internal test

### DIFF
--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -683,20 +683,25 @@ for (const supportedVersion of mineflayer.testedVersions) {
         const mapped = JSON.stringify(registry.protocol.play.toClient.types.packet_game_state_change).includes('rain_level_change')
         const reason = mapped ? 'rain_level_change' : 7
         server.on('playerJoin', (client) => {
-          assert.strictEqual(bot.isRaining, false)
-          bot.once('rain', () => {
-            assert.strictEqual(bot.isRaining, true)
+          client.write('login', bot.test.generateLoginPacket())
+          // Plugins inject after a deferred inject_allowed, so bot state is
+          // only readable once the bot has seen login.
+          bot.once('login', () => {
+            assert.strictEqual(bot.isRaining, false)
             bot.once('rain', () => {
-              assert.strictEqual(bot.isRaining, false)
-              assert.strictEqual(bot.rainState, 0)
-              done()
+              assert.strictEqual(bot.isRaining, true)
+              bot.once('rain', () => {
+                assert.strictEqual(bot.isRaining, false)
+                assert.strictEqual(bot.rainState, 0)
+                done()
+              })
+              client.write('game_state_change', { reason, gameMode: 0 })
             })
-            client.write('game_state_change', { reason, gameMode: 0 })
+            client.write('game_state_change', { reason, gameMode: 0.01 })
+            // A second wet level must not emit again: if it did, the inner
+            // once would run with isRaining still true and fail the assert.
+            client.write('game_state_change', { reason, gameMode: 0.5 })
           })
-          client.write('game_state_change', { reason, gameMode: 0.01 })
-          // A second wet level must not emit again: if it did, the inner
-          // once would run with isRaining still true and fail the assert.
-          client.write('game_state_change', { reason, gameMode: 0.5 })
         })
       })
     })


### PR DESCRIPTION
Fixes the internal `rain` test flake that has been failing master since #4032 merged (seen on 1.9.4, 1.10.2, 1.13.2 and 1.19.3, e.g. https://github.com/PrismarineJS/mineflayer/actions/runs/33949323353 and #4053's run https://github.com/PrismarineJS/mineflayer/actions/runs/33958790296).

The test asserted `bot.isRaining` inside the server's `playerJoin` handler. Plugins inject on `inject_allowed`, which the loader emits from a zero-delay timer, so on a slow runner the offline login handshake can finish first and the assert sees `undefined`. The throw happens inside the minecraft-protocol login flow, the fake server kicks the bot, and `afterEach` then waits forever for an `end` event that already fired.

Send the login packet on `playerJoin` and assert after the bot's `login` event, like the neighbouring internal tests do.

Reproduced locally by delaying the `inject_allowed` timer by 30ms: the old test fails with the CI error, the new one passes. Ran the test on 1.9.4, 1.13.2, 1.19.3 and 1.21.4, plus the full 1.13.2 internal suite.
