### PR TITLE
test(nether): wait for the overworld chunks after the return portal

### DIFF
--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -61,4 +61,7 @@ module.exports = () => async (bot) => {
 
   bot.chat(`/setblock ~ ~ ~ ${portalName}`)
   await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
+  // The respawn lands at origin, so the next reset skips its chunk wait; the
+  // overworld column must be back before a later test reads blocks from it.
+  await bot.waitForChunksToLoad()
 }


### PR DESCRIPTION
The nether test's return leg only awaited the `spawn` event. The respawn lands the bot exactly at origin, so `resetState` takes its no-teleport path and never calls `waitForChunksToLoad`. On a slow runner the overworld spawn column arrives after the following tests have already started; in [run 33949373493](https://github.com/PrismarineJS/mineflayer/actions/runs/33949373493/job/101261210762) the 1.14.4 trace shows the position packet, then `particles` and all four `placeBlock` attempts inside ~60ms, and only then the `map_chunk` for 0,0. `bot.blockAt` returned null for the reference block on every attempt, since mocha's retries re-run instantly against the same empty world.

Wait for the chunks on the way back, as the outbound leg already does. `waitForChunksToLoad` is a no-op when the columns are present, so normal runs pay nothing.

Ran `nether` and `placeBlock emits blockPlaced` locally on 1.8.8, 1.14.4 and 1.21.8: all pass.