### PR TITLE
test: reset the bot onto the origin block centre, not within a block of it

### DIFF
--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -119,8 +119,10 @@ function inject (bot, wrap) {
   async function resetState () {
     await becomeCreative()
     bot.creative.startFlying()
-    const origin = new Vec3(0, bot.test.groundY, 0)
-    if (bot.entity.position.distanceTo(origin) >= 0.9) {
+    // Tests build in the columns around the origin: the bot must be on the
+    // origin block's centre, not merely within a block of it.
+    const origin = new Vec3(0.5, bot.test.groundY, 0.5)
+    if (bot.entity.position.distanceTo(origin) >= 0.1) {
       await teleport(origin)
       await bot.waitForChunksToLoad()
     }
@@ -213,15 +215,20 @@ function inject (bot, wrap) {
   }
 
   async function teleport (position) {
+    // Integer x/z land on the block centre. 'move' also fires for periodic
+    // position packets with no movement, so the wait must match the landing
+    // point exactly rather than a radius the bot may already be inside.
+    const centre = (v) => Number.isInteger(v) ? v + 0.5 : v
+    const landing = new Vec3(centre(position.x), position.y, centre(position.z))
     // Use server console for teleport — works even if bot is in a bad state
     if (bot.supportFeature('hasExecuteCommand')) {
-      wrap.writeServer(`execute in overworld run teleport ${bot.username} ${position.x} ${position.y} ${position.z}\n`)
+      wrap.writeServer(`execute in overworld run teleport ${bot.username} ${landing.x} ${landing.y} ${landing.z}\n`)
     } else {
-      wrap.writeServer(`tp ${bot.username} ${position.x} ${position.y} ${position.z}\n`)
+      wrap.writeServer(`tp ${bot.username} ${landing.x} ${landing.y} ${landing.z}\n`)
     }
     return onceWithCleanup(bot, 'move', {
       timeout,
-      checkCondition: () => bot.entity.position.distanceTo(position) < 0.9
+      checkCondition: () => bot.entity.position.distanceTo(landing) < 0.1
     })
   }
 


### PR DESCRIPTION
Follow-up to the useChests failure on 1.18.2 in #4055's first CI run (https://github.com/PrismarineJS/mineflayer/actions/runs/33970786717/job/101318818124).

`resetState` skipped the teleport whenever the bot was within 0.9 of `(0, groundY, 0)`. That radius covers all four blocks meeting at that corner, so after the spawnEvent respawn landed the bot at `(0.5, -60, -0.5)` every later reset left it there. useChests then tried to place its small chest at `(0, -60, -1)`, the column the bot was standing in, and the server refused it on every retry since each retry's reset took the same no-op path. The trace shows the `block_place` followed by a `block_change` back to air each time.

Compare against the block centre `(0.5, groundY, 0.5)` with a tight tolerance instead. `teleport` now sends the centred coordinates explicitly and waits for that exact point: a periodic position packet fires `move` without the bot having moved, so a radius the bot is already inside would otherwise resolve the teleport before it lands.

This only bites when a respawn lands in one of the three neighbouring blocks and the next test builds there, which is why it has not shown up in other recent runs.