### PR TITLE
increase speed of tests exampleBlockFinder.js and exampleDigger.js

### DIFF
--- a/test/externalTests/exampleBlockFinder.js
+++ b/test/externalTests/exampleBlockFinder.js
@@ -3,7 +3,6 @@ const assert = require('assert')
 module.exports = () => async (bot) => {
   await bot.test.runExample('examples/blockfinder.js', async (name) => {
     assert.strictEqual(name, 'finder')
-    await bot.test.wait(2000)
     await bot.test.tellAndListen(name, 'find dirt', (message) => {
       const matches = message.match(/I found ([0-9]+) (.+?) blocks in (.+?) ms/)
       if (matches.length !== 4 || matches[1] === '0' || matches[2] !== 'dirt' || parseFloat(matches[3]) > 500) {

--- a/test/externalTests/exampleDigger.js
+++ b/test/externalTests/exampleDigger.js
@@ -3,9 +3,12 @@ const assert = require('assert')
 module.exports = () => async (bot) => {
   await bot.test.runExample('examples/digger.js', async (name) => {
     assert.strictEqual(name, 'digger')
-    bot.chat('/op digger') // to counteract spawn protection
-    bot.chat('/give digger dirt 64')
-    await bot.test.wait(2000)
+    bot.chat(`/op ${name}`) // to counteract spawn protection
+    bot.chat(`/give ${name} dirt 64`)
+    await bot.test.tellAndListen(name, 'list', (message) => {
+      assert.match(message, /(?:^|, )dirt x 64(?:, |$)/)
+      return true
+    })
     await bot.test.tellAndListen(name, 'dig', (message) => {
       if (message.startsWith('starting')) {
         return false // continue to listen


### PR DESCRIPTION
removes a redundant two-second delay after the child has already confirmed its chunks are loaded. replaces its two-second guess with an inventory response that synchronizes /op and /give.