### PR TITLE
fix: clear a chest's lid open count when its block is replaced; make useChests await its fill commands

### DIFF
--- a/lib/plugins/block_actions.js
+++ b/lib/plugins/block_actions.js
@@ -22,6 +22,13 @@ function inject (bot) {
   // Stores how many players have currently open a container at a certain position
   const openCountByPos = {}
 
+  // The server drops the closing block event of a container that is no
+  // longer there, so a replaced container must not keep its open count.
+  bot.on('blockUpdate', (oldBlock, newBlock) => {
+    if (!newBlock || oldBlock?.name === newBlock.name) return
+    delete openCountByPos[newBlock.position]
+  })
+
   function parseChestMetadata (chestBlock) {
     const chestTypes = ['single', 'right', 'left']
 

--- a/test/externalTests/plugins/testCommon.js
+++ b/test/externalTests/plugins/testCommon.js
@@ -36,6 +36,7 @@ function inject (bot, wrap) {
   bot.test.fly = fly
   bot.test.teleport = teleport
   bot.test.resetState = resetState
+  bot.test.awaitCommandsProcessed = awaitCommandsProcessed
   bot.test.setInventorySlot = setInventorySlot
   bot.test.placeBlock = placeBlock
   bot.test.runExample = runExample
@@ -93,13 +94,7 @@ function inject (bot, wrap) {
     // The marker echo only proves the fills executed: command feedback is
     // sent immediately while block changes flush at tick end, so the client
     // can still hold pre-fill blocks after the echo.
-    const marker = 'superflat-reset-done'
-    const echo = onceWithCleanup(bot, 'messagestr', {
-      timeout: 5000,
-      checkCondition: (message) => message.includes(marker)
-    })
-    bot.chat(marker)
-    await echo
+    await awaitCommandsProcessed('superflat-reset-done')
     const staleBlock = () => {
       for (let y = groundY + 4; y >= groundY - 1; y--) {
         const realY = y + bot.test.groundY - 4
@@ -137,6 +132,21 @@ function inject (bot, wrap) {
         onceWithCleanup(bot.world, 'chunkColumnLoad', { timeout: 500 })
       ]).catch(() => {})
     }
+  }
+
+  // Chat and commands run in order on the server's main thread, so the echo
+  // of a message sent after a batch of commands proves the batch has executed.
+  // Command feedback is sent immediately while block changes flush at tick
+  // end, so a caller reading blocks a command just changed still has to wait
+  // for them; but block interaction packets are not ordered behind commands
+  // on 1.21.9+, so this must precede acting on such a block.
+  async function awaitCommandsProcessed (marker) {
+    const echo = onceWithCleanup(bot, 'messagestr', {
+      timeout: 5000,
+      checkCondition: (message) => message.includes(marker)
+    })
+    bot.chat(marker)
+    await echo
   }
 
   async function placeBlock (slot, position) {

--- a/test/externalTests/useChests.js
+++ b/test/externalTests/useChests.js
@@ -161,7 +161,7 @@ module.exports = () => async (bot) => {
   // Write the slots server side. Filling them by clicking leaves the result at
   // the mercy of the client's predicted state, which from 1.17 is not confirmed
   // per click, and a lost move is invisible until an assertion reads the slot.
-  function fillChest (pos) {
+  async function fillChest (pos) {
     const at = `${pos.x} ${pos.y} ${pos.z}`
     for (const { slot, name, count } of layout) {
       const item = bot.registry.itemsByName[name]
@@ -174,6 +174,7 @@ module.exports = () => async (bot) => {
         bot.chat(`/replaceitem block ${at} container.${slot} ${name} ${count}`)
       }
     }
+    await bot.test.awaitCommandsProcessed('chest-filled')
   }
 
   // Each left/right click resolves differently depending on whether the cursor
@@ -255,7 +256,7 @@ module.exports = () => async (bot) => {
     bot.chat(`/setblock ${largeChestLocations[1].x} ${largeChestLocations[1].y} ${largeChestLocations[1].z} chest`)
   }
 
-  fillChest(largeChestLocations[0])
+  await fillChest(largeChestLocations[0])
   const window = await bot.openContainer(bot.blockAt(largeChestLocations[0]))
   // Which half of a double chest the window lists first depends on the version.
   for (const { name, count } of layout) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -706,6 +706,35 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('block actions', () => {
+      it('emits chestLidMove again once an open chest has been replaced', async () => {
+        const pos = vec3(1, 65, 1)
+        const chestId = bot.registry.blocksByName.chest.id
+        const location = { x: pos.x, y: pos.y, z: pos.z }
+        const [client] = await once(server, 'playerJoin')
+        client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(pos, chestId)
+        client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+        const chestStateId = bot.blockAt(pos).stateId
+
+        const opened = onceWithCleanup(bot, 'chestLidMove', { timeout: 2000 })
+        client.write('block_action', { location, byte1: 1, byte2: 1, blockId: chestId })
+        await opened
+
+        // Breaking the chest while it is open never yields a closing block
+        // action, so the open count must not survive the block change.
+        client.write('block_change', { location, type: 0 })
+        client.write('block_change', { location, type: chestStateId })
+        const reopened = onceWithCleanup(bot, 'chestLidMove', { timeout: 2000 })
+        client.write('block_action', { location, byte1: 1, byte2: 1, blockId: chestId })
+        const [block, isOpen] = await reopened
+        assert.ok(block.position.equals(pos))
+        assert.strictEqual(isOpen, 1)
+      })
+    })
+
     describe('entities', () => {
       it('entity id changes on login', (done) => {
         const loginPacket = bot.test.generateLoginPacket()


### PR DESCRIPTION
Fixes the `useChests` failure on 1.21.11 in https://github.com/PrismarineJS/mineflayer/actions/runs/34038030872/job/101499603931 (release PR #4058, which only touches the changelog).

## What happened

Two stacked problems, visible in the uploaded packet trace:

1. **First attempt: a race in the test.** `fillChest` fires three `/item replace` commands and opens the chest immediately. On 1.21.9+ block interaction packets run from the server's `PacketProcessor` queue at the start of the next tick, while chat commands wait on the main task queue and only run while the tick has time left. Under CI load the window snapshot arrived with only the first replace applied, and the mycelium assertion failed.
2. **Every retry: stale open count in `block_actions.js`.** The aborted attempt left the double chest open, so `openCountByPos` held `1` for that position. The harness reset's `/fill` replaced the chest with air, and the server drops a container's closing block event once the block is no longer a chest, so the count was never cleared. On each retry the server's open block action carried the same count, `chestLidMove` was never emitted, and `once(chest, 'close')` timed out three times.

The second problem is a user-facing bug too: any chest broken while open never emits `chestLidMove` at that position again.

## Changes

- `lib/plugins/block_actions.js`: drop the open count on a `blockUpdate` that changes the block's name.
- `test/externalTests/plugins/testCommon.js`: extract the superflat reset's marker echo into `bot.test.awaitCommandsProcessed(marker)`.
- `test/externalTests/useChests.js`: `fillChest` awaits that echo before the chest is opened.
- `test/internalTest.js`: regression test that opens a chest, replaces it via `block_change`, and expects `chestLidMove` on the next open. It times out on master and passes with the fix.

## Verification

- New internal test: passes on 1.8.8, 1.12.2, 1.16.5, 1.21.11 and 26.1 with the fix; fails on unpatched master.
- External `useChests`: passes locally on 1.21.11 and 1.8.8.
- `standard` clean.
