### PR TITLE
build: make the mineflayer self-dependency install under pnpm as well as npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 node_modules
 package-lock.json
 yarn.lock
+pnpm-lock.yaml
 /README.md
 versions/
 server_jars/

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^25.2.1",
     "doctoc": "^2.0.1",
     "minecraft-wrap": "^1.3.0",
-    "mineflayer": "file:",
+    "mineflayer": "./",
     "mocha": "^11.0.1",
     "protodef-yaml": "^1.5.3",
     "standard": "^17.0.0",


### PR DESCRIPTION
`pnpm i` currently fails on the `"mineflayer": "file:"` self-dependency: pnpm 12 cannot build a lockfile entry for it (`Empty path after file: scheme`), and `file:.` is normalised to the same thing. `link:.` fixes pnpm but npm rejects it as an unsupported protocol.

A bare `"./"` is accepted by both. npm treats it as a directory dependency and pnpm as a link, and each ends up with `node_modules/mineflayer` symlinked to the package root exactly as before.

| Spec | npm 11.9 | pnpm 12.3 |
|---|---|---|
| `file:` / `file:.` | works | fails |
| `link:.` | rejected | works |
| `./` | works | works |

Also ignores `pnpm-lock.yaml` alongside the `package-lock.json` and `yarn.lock` entries the repo already opts out of.

Verified with a fresh install under both npm and pnpm, `require('mineflayer')` resolving to the repo, lint, and the internal test suite.
