### PR TITLE
Fix resource pack accept sending an all-zero UUID on 1.20.3+

### DIFF
--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -1,9 +1,6 @@
-const UUID = require('uuid-1345')
-
 module.exports = inject
 
 function inject (bot) {
-  let uuid
   let latestHash
   let latestUUID
   let activeResourcePacks = {}
@@ -15,12 +12,11 @@ function inject (bot) {
   }
 
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
-    const uuid = new UUID(data.uuid)
-    // Adding the pack to a set by uuid
-    latestUUID = uuid
-    activeResourcePacks[uuid] = data.url
+    // latestUUID must stay the wire UUID string: a uuid-1345 object serializes to 16 zero bytes.
+    latestUUID = data.uuid
+    activeResourcePacks[data.uuid] = data.url
 
-    bot.emit('resourcePack', data.url, uuid)
+    bot.emit('resourcePack', data.url, data.uuid)
     // The server holds the configuration phase (e.g. a Velocity server transfer)
     // open until the pack is answered, so accept it there to let it complete
     if (bot._client.state === 'configuration') acceptResourcePack()
@@ -33,7 +29,7 @@ function inject (bot) {
     } else {
       // Try to remove uuid from set
       try {
-        delete activeResourcePacks[new UUID(data.uuid)]
+        delete activeResourcePacks[data.uuid]
       } catch (error) {
         console.error('Tried to remove UUID but it was not in the active list.')
       }
@@ -42,9 +38,8 @@ function inject (bot) {
 
   bot._client.on('resource_pack_send', (data) => {
     if (bot.supportFeature('resourcePackUsesUUID')) {
-      uuid = new UUID(data.uuid)
-      bot.emit('resourcePack', uuid, data.url)
-      latestUUID = uuid
+      bot.emit('resourcePack', data.uuid, data.url)
+      latestUUID = data.uuid
     } else {
       bot.emit('resourcePack', data.url, data.hash)
       latestHash = data.hash

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -498,6 +498,41 @@ for (const supportedVersion of mineflayer.testedVersions) {
           done()
         })
       })
+
+      it('accepts a configuration-phase resource pack with the real UUID bytes', function () {
+        // Regression for https://github.com/PrismarineJS/mineflayer/issues/4043: the accept
+        // must carry the pack's real UUID bytes; a uuid-1345 object serializes to 16 zero bytes.
+        // The mock server never reaches the configuration phase, so the plugin is driven directly.
+        if (!registry.supportFeature('resourcePackUsesUUID')) {
+          this.skip()
+          return
+        }
+        const packUuid = '8ef4746b-93b7-3c32-9dcb-b375016c114d'
+        const expectedBytes = Buffer.from(packUuid.replace(/-/g, ''), 'hex')
+        const serializer = mc.createSerializer({ state: 'configuration', isServer: false, version: supportedVersion })
+
+        const client = new EventEmitter()
+        client.state = 'configuration'
+        const writes = []
+        client.write = (name, params) => { writes.push({ name, params }) }
+        const fakeBot = new EventEmitter()
+        fakeBot._client = client
+        fakeBot.supportFeature = registry.supportFeature.bind(registry)
+        require('../lib/plugins/resource_pack')(fakeBot)
+
+        client.emit('add_resource_pack', {
+          uuid: packUuid,
+          url: 'https://example.invalid/pack.zip',
+          hash: '88b406352dc8a335b1050a4bf9577a878c812012',
+          forced: false
+        })
+
+        const accept = writes.find((w) => w.name === 'resource_pack_receive')
+        assert(accept, 'bot should answer the pack during the configuration phase')
+        const buf = serializer.createPacketBuffer({ name: accept.name, params: accept.params })
+        assert(buf.includes(expectedBytes),
+          'resource_pack_receive must carry the pack UUID bytes, not a zero UUID')
+      })
     })
 
     describe('world', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -500,8 +500,8 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
 
       it('accepts a configuration-phase resource pack with the real UUID bytes', function () {
-        // Regression for https://github.com/PrismarineJS/mineflayer/issues/4043: the accept
-        // must carry the pack's real UUID bytes; a uuid-1345 object serializes to 16 zero bytes.
+        // The accept must carry the pack's real UUID bytes; a uuid-1345 object serializes to
+        // 16 zero bytes.
         // The mock server never reaches the configuration phase, so the plugin is driven directly.
         if (!registry.supportFeature('resourcePackUsesUUID')) {
           this.skip()


### PR DESCRIPTION
### Problem

On 1.20.3+ (UUID-based resource packs), `bot.acceptResourcePack()` / `bot.denyResourcePack()` send a **resource_pack_receive with an all-zero UUID**, so the server ignores the response.

The plugin stored `latestUUID = new UUID(data.uuid)` — a `uuid-1345` object. The protocol's `UUID` write path is:

```js
const buf = value.length === 32 ? Buffer.from(value, 'hex') : UUID.parse(value)
```

A `uuid-1345` object has no `.length`, so it falls to `UUID.parse(object)`, which returns 16 zero bytes:

```
uuid string  -> 8ef4746b93b73c329dcbb375016c114d
uuid object  -> 00000000000000000000000000000000
```

This is invisible until a resource pack is actually answered. The common trigger is a **Velocity/BungeeCord server transfer**: the target server offers the pack during the configuration phase and holds that phase open until it receives a valid answer. Because the answer references the null pack, the bot hangs in `configuration` and is eventually kicked (`An internal error occurred in your connection`).

Reproduced live against a public 1.8–1.21 network (Velocity 26.2 proxy): before this change the bot hung in configuration and was kicked when selecting any sub-server; after it, the transfer completes and the bot spawns on the target server.

### Fix

Store the wire value (the UUID string) instead of a `uuid-1345` object in both `add_resource_pack` and `resource_pack_send`, and key `activeResourcePacks` / `remove_resource_pack` by that same string. The `uuid-1345` import is no longer needed.

The `resourcePack` event's uuid argument is now the UUID string rather than a `uuid-1345` object — more usable and consistent with the wire form the object stringified to anyway.

### Test

Adds an internal regression test that injects the plugin with a fake client in the configuration phase, emits `add_resource_pack`, serializes the `resource_pack_receive` the plugin writes, and asserts it carries the pack's real 16 UUID bytes. It fails on `master` (all-zero UUID) and passes with the fix. Driving this through the mock server can't reproduce it, because the server-side connection never enters the configuration phase.

Fixes #4043. Related: #3768, and the resource_pack_receive part of #4044. Supersedes the stale #3842, with a minimal change and a targeted regression test.