### PR TITLE
entities: read the 1.21.2+ entity_teleport layout (velocity, float rotation, relative flags)

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -337,6 +337,24 @@ function inject (bot) {
   bot._client.on('entity_teleport', (packet) => {
     // entity teleport
     const entity = fetchEntity(packet.entityId)
+    if (packet.flags !== undefined) {
+      // 1.21.2+: same layout as the player position packet, each part absolute or relative per flag
+      const { position: pos, velocity: vel, yaw, pitch } = entity
+      pos.set(
+        packet.flags.x ? pos.x + packet.x : packet.x,
+        packet.flags.y ? pos.y + packet.y : packet.y,
+        packet.flags.z ? pos.z + packet.z : packet.z
+      )
+      vel.set(
+        packet.flags.dx ? vel.x + packet.dx : packet.dx,
+        packet.flags.dy ? vel.y + packet.dy : packet.dy,
+        packet.flags.dz ? vel.z + packet.dz : packet.dz
+      )
+      entity.yaw = conv.fromNotchianYaw((packet.flags.yaw ? conv.toNotchianYaw(yaw) : 0) + packet.yaw)
+      entity.pitch = conv.fromNotchianPitch((packet.flags.pitch ? conv.toNotchianPitch(pitch) : 0) + packet.pitch)
+      bot.emit('entityMoved', entity)
+      return
+    }
     if (bot.supportFeature('fixedPointPosition')) {
       entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32)
     }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -334,27 +334,9 @@ function inject (bot) {
     bot.emit('entityMoved', entity)
   })
 
-  bot._client.on('entity_teleport', (packet) => {
+  function handleEntityTeleportLegacy (packet) {
     // entity teleport
     const entity = fetchEntity(packet.entityId)
-    if (packet.flags !== undefined) {
-      // 1.21.2+: same layout as the player position packet, each part absolute or relative per flag
-      const { position: pos, velocity: vel, yaw, pitch } = entity
-      pos.set(
-        packet.flags.x ? pos.x + packet.x : packet.x,
-        packet.flags.y ? pos.y + packet.y : packet.y,
-        packet.flags.z ? pos.z + packet.z : packet.z
-      )
-      vel.set(
-        packet.flags.dx ? vel.x + packet.dx : packet.dx,
-        packet.flags.dy ? vel.y + packet.dy : packet.dy,
-        packet.flags.dz ? vel.z + packet.dz : packet.dz
-      )
-      entity.yaw = conv.fromNotchianYaw((packet.flags.yaw ? conv.toNotchianYaw(yaw) : 0) + packet.yaw)
-      entity.pitch = conv.fromNotchianPitch((packet.flags.pitch ? conv.toNotchianPitch(pitch) : 0) + packet.pitch)
-      bot.emit('entityMoved', entity)
-      return
-    }
     if (bot.supportFeature('fixedPointPosition')) {
       entity.position.set(packet.x / 32, packet.y / 32, packet.z / 32)
     }
@@ -364,7 +346,28 @@ function inject (bot) {
     entity.yaw = conv.fromNotchianYawByte(packet.yaw)
     entity.pitch = conv.fromNotchianPitchByte(packet.pitch)
     bot.emit('entityMoved', entity)
-  })
+  }
+
+  // 1.21.2+: same layout as the player position packet, each part absolute or relative per flag
+  function handleEntityTeleportRelative (packet) {
+    const entity = fetchEntity(packet.entityId)
+    const { position: pos, velocity: vel, yaw, pitch } = entity
+    pos.set(
+      packet.flags.x ? pos.x + packet.x : packet.x,
+      packet.flags.y ? pos.y + packet.y : packet.y,
+      packet.flags.z ? pos.z + packet.z : packet.z
+    )
+    vel.set(
+      packet.flags.dx ? vel.x + packet.dx : packet.dx,
+      packet.flags.dy ? vel.y + packet.dy : packet.dy,
+      packet.flags.dz ? vel.z + packet.dz : packet.dz
+    )
+    entity.yaw = conv.fromNotchianYaw((packet.flags.yaw ? conv.toNotchianYaw(yaw) : 0) + packet.yaw)
+    entity.pitch = conv.fromNotchianPitch((packet.flags.pitch ? conv.toNotchianPitch(pitch) : 0) + packet.pitch)
+    bot.emit('entityMoved', entity)
+  }
+
+  bot._client.on('entity_teleport', bot.supportFeature('entityTeleportHasRelativeFlags') ? handleEntityTeleportRelative : handleEntityTeleportLegacy)
 
   // 1.21.3 - merges the packets above
   bot._client.on('sync_entity_position', (packet) => {


### PR DESCRIPTION
Since 1.21.2 `ClientboundTeleportEntityPacket` carries the same fields as the player position packet: position, delta movement, f32 yaw/pitch and a set of relative flags. minecraft-data described the old layout until PrismarineJS/minecraft-data#1273, which makes the packet parse again on 1.21.3 through 26.1 (fixes the `Chunk size is 67 but only 33 was read` partial reads from #3759).

With that data fix the handler gets a `flags` object, so this applies each part as absolute or relative the same way the `position` handler does, and converts the float rotation instead of the byte rotation. `entity_teleport` is a hot packet, so the handler is chosen once at inject time from the `entityTeleportHasRelativeFlags` feature (added in the same minecraft-data PR), the same way `player_info` picks its handler. Without the data fix the feature resolves to false and the old byte path is unchanged, so this is safe to merge in either order.

Verified with the patched data on a 1.21.4 Velocity/ViaVersion network (Jartex), where these packets previously flooded the log with partial reads: no parse errors, and teleported entities land on the coordinates from the packet.
