### PR TITLE
physics: send the movement input packets the vanilla client sends

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1832,6 +1832,8 @@ You may use bot.lookAt in conjunction with this to control movement. The jumper.
  * `control` - one of ['forward', 'back', 'left', 'right', 'jump', 'sprint', 'sneak']
  * `state` - `true` or `false`
 
+`sprint` is the sprint key: like the vanilla client, the bot only sprints (and tells the server so) while it is moving forward on the ground with more than 6 food, not sneaking, not using an item, not blinded and not in water; sprinting stops against a wall.
+
 #### bot.getControlState(control)
 
 Returns true if a control state is toggled.

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -22,11 +22,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
   const hasConfigurationState = bot.supportFeature('hasConfigurationState') // 1.20.2+
   // 1.21.2+ sends the key set as player_input whenever it changes and tick_end after every tick.
-  // The shift key still goes through entity_action up to 1.21.5; from 1.21.6 the server reads it
-  // from player_input alone.
+  // The server takes the sneak state from entity_action up to 1.21.5 and from player_input after.
   const hasPlayerInputPacket = bot.supportFeature('newPlayerInputPacket')
   const hasTickEndPacket = 'packet_tick_end' in bot.registry.protocol.play.toServer.types
-  const sneakUsesEntityAction = !bot.registry.version['>=']('1.21.6')
+  const sneakUsesEntityAction = bot.supportFeature('sneakUsesEntityAction')
 
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -419,9 +419,22 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   // 1.21.3+
+  // A forced rotation is answered at once with a look carrying onGround false and no collision; the
+  // last-sent record is left alone.
   bot._client.on('player_rotation', (packet) => {
     bot.entity.yaw = conv.fromNotchianYaw(packet.yaw)
     bot.entity.pitch = conv.fromNotchianPitch(packet.pitch)
+    lastSentYaw = bot.entity.yaw
+    lastSentPitch = bot.entity.pitch
+    bot._client.write('look', {
+      x: lastSent.x,
+      y: lastSent.y,
+      z: lastSent.z,
+      yaw: packet.yaw,
+      pitch: packet.pitch,
+      onGround: false,
+      flags: { onGround: false, hasHorizontalCollision: false }
+    })
   })
 
   // player position and look (clientbound)
@@ -436,21 +449,35 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     // Note: 1.20.5+ uses a bitflags object, older versions use a bitmask number
     if (typeof packet.flags === 'object') {
-      // Modern path with bitflags object
-      // Velocity is only set to 0 if the flag is not set, otherwise keep current velocity
-      vel.set(
-        packet.flags.x ? vel.x : 0,
-        packet.flags.y ? vel.y : 0,
-        packet.flags.z ? vel.z : 0
-      )
+      const oldYaw = conv.toNotchianYaw(bot.entity.yaw)
+      const oldPitch = conv.toNotchianPitch(bot.entity.pitch)
       // If flag is set, then the corresponding value is relative, else it is absolute
       pos.set(
         packet.flags.x ? (pos.x + packet.x) : packet.x,
         packet.flags.y ? (pos.y + packet.y) : packet.y,
         packet.flags.z ? (pos.z + packet.z) : packet.z
       )
-      newYaw = (packet.flags.yaw ? conv.toNotchianYaw(bot.entity.yaw) : 0) + packet.yaw
-      newPitch = (packet.flags.pitch ? conv.toNotchianPitch(bot.entity.pitch) : 0) + packet.pitch
+      newYaw = (packet.flags.yaw ? oldYaw : 0) + packet.yaw
+      newPitch = (packet.flags.pitch ? oldPitch : 0) + packet.pitch
+      // The packet carries a velocity only when all three deltas are present.
+      if (Number.isFinite(packet.dx) && Number.isFinite(packet.dy) && Number.isFinite(packet.dz)) {
+        // A dx/dy/dz flag adds the current velocity to the packet's; yawDelta first turns the
+        // current velocity by the rotation change.
+        let v = vel.clone()
+        if (packet.flags.yawDelta) v = rotateVelocity(v, (oldPitch - newPitch) * PI / 180, (oldYaw - newYaw) * PI / 180)
+        vel.set(
+          (packet.flags.dx ? v.x : 0) + packet.dx,
+          (packet.flags.dy ? v.y : 0) + packet.dy,
+          (packet.flags.dz ? v.z : 0) + packet.dz
+        )
+      } else {
+        // Velocity is only set to 0 if the flag is not set, otherwise keep current velocity
+        vel.set(
+          packet.flags.x ? vel.x : 0,
+          packet.flags.y ? vel.y : 0,
+          packet.flags.z ? vel.z : 0
+        )
+      }
     } else {
       // Legacy path with bitmask number
       // Velocity is only set to 0 if the flag is not set, otherwise keep current velocity
@@ -497,7 +524,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       return
     }
 
-    sendPacketPositionAndLook(pos, newYaw, newPitch, bot.entity.onGround)
+    sendTeleportReply(pos, newYaw, newPitch)
 
     shouldUsePhysics = true
     bot.jumpTicks = 0
@@ -506,6 +533,34 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     bot.emit('forcedMove')
   })
+
+  // Vanilla Vec3.xRot then Vec3.yRot, angles in radians.
+  function rotateVelocity (v, pitchDelta, yawDelta) {
+    const cp = Math.cos(pitchDelta)
+    const sp = Math.sin(pitchDelta)
+    const y = v.y * cp + v.z * sp
+    const z = v.z * cp - v.y * sp
+    const cy = Math.cos(yawDelta)
+    const sy = Math.sin(yawDelta)
+    return new Vec3(v.x * cy + z * sy, y, z * cy - v.x * sy)
+  }
+
+  // The reply to a teleport carries onGround false and no collision and leaves the last-sent record
+  // alone, so the next tick compares against what was sent before the teleport.
+  function sendTeleportReply (position, yaw, pitch) {
+    if (!Number.isFinite(position.x) || !Number.isFinite(position.y) || !Number.isFinite(position.z)) return
+    const oldPos = new Vec3(lastSent.x, lastSent.y, lastSent.z)
+    bot._client.write('position_look', {
+      x: position.x,
+      y: position.y,
+      z: position.z,
+      yaw,
+      pitch,
+      onGround: false,
+      flags: { onGround: false, hasHorizontalCollision: false } // 1.21.3+
+    })
+    bot.emit('move', oldPos)
+  }
 
   bot.waitForTicks = async function (ticks) {
     if (ticks <= 0) return

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -21,8 +21,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
   const hasConfigurationState = bot.supportFeature('hasConfigurationState') // 1.20.2+
-  // 1.21.2+ sends the key set as player_input whenever it changes and tick_end after every tick.
-  // The server takes the sneak state from entity_action up to 1.21.5 and from player_input after.
+  // player_input is sent only when the key set changes; tick_end after every tick.
+  // Servers before 1.21.6 ignore the shift bit of player_input; from 1.21.6 entity_action has no shift entries.
   const hasPlayerInputPacket = bot.supportFeature('newPlayerInputPacket')
   const hasTickEndPacket = 'packet_tick_end' in bot.registry.protocol.play.toServer.types
   const sneakUsesEntityAction = bot.supportFeature('sneakUsesEntityAction')
@@ -44,9 +44,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   let lastSentSneak = false
   let lastSentSprinting = false
   let lastSentInputs = null
-  // Ticks since a position was last sent; vanilla re-sends every 20 even when standing still.
+  // Ticks since the last position packet; a position packet goes out before it passes 20.
   let positionReminder = 0
-  // Vanilla sprinting state: the sprint key alone does not sprint (LocalPlayer.aiStep).
+  // Only updateSprinting sets this; the sprint key alone never does.
   let sprinting = false
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
@@ -195,8 +195,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const onGround = bot.entity.onGround
     const hasHorizontalCollision = collidedHorizontally()
 
-    // Vanilla (LocalPlayer.sendPosition) sends the position once it moved more than 2e-4 blocks
-    // since the last one sent, or every 20 ticks regardless.
+    // Vanilla thresholds: 2e-4 blocks of movement or 20 ticks since the last position packet.
     positionReminder++
     const dx = position.x - lastSent.x
     const dy = position.y - lastSent.y
@@ -227,8 +226,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.hasHorizontalCollision = hasHorizontalCollision
   }
 
-  // What vanilla sends from LocalPlayer.tick() before the movement packet: the shift key state, the
-  // key set when it changed, then the sprinting state (sendPosition calls sendIsSprintingIfNeeded).
+  // Packet order must match LocalPlayer.tick: shift key, key set, sprinting state, then the movement packet.
   function sendInputPackets () {
     if (controlState.sneak !== lastSentSneak) {
       lastSentSneak = controlState.sneak
@@ -267,9 +265,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     }
   }
 
-  // LocalPlayer.aiStep: sprinting starts on the ground with the sprint key, a full forward impulse,
-  // more than 6 food (or creative), no item in use and no blindness; it stops when the forward
-  // impulse, the food or a wall collision is against it, or the player sneaks or enters water.
+  // Must mirror LocalPlayer.aiStep: the simulation and start/stop_sprinting both read this state.
   function updateSprinting () {
     const mcData = bot.registry
     const forward = controlState.forward && !controlState.back

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -21,6 +21,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   const positionUpdateSentEveryTick = bot.supportFeature('positionUpdateSentEveryTick')
   const hasConfigurationState = bot.supportFeature('hasConfigurationState') // 1.20.2+
+  // 1.21.2+ sends the key set as player_input whenever it changes and tick_end after every tick.
+  // The shift key still goes through entity_action up to 1.21.5; from 1.21.6 the server reads it
+  // from player_input alone.
+  const hasPlayerInputPacket = bot.supportFeature('newPlayerInputPacket')
+  const hasTickEndPacket = 'packet_tick_end' in bot.registry.protocol.play.toServer.types
+  const sneakUsesEntityAction = !bot.registry.version['>=']('1.21.6')
 
   bot.jumpQueued = false
   bot.jumpTicks = 0 // autojump cooldown
@@ -36,6 +42,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
   let lastSentYaw = null
   let lastSentPitch = null
+  let lastSentSneak = false
+  let lastSentSprinting = false
+  let lastSentInputs = null
+  // Ticks since a position was last sent; vanilla re-sends every 20 even when standing still.
+  let positionReminder = 0
+  // Vanilla sprinting state: the sprint key alone does not sprint (LocalPlayer.aiStep).
+  let sprinting = false
   let doPhysicsTimer = null
   let lastPhysicsFrameTime = null
   let shouldUsePhysics = false
@@ -49,9 +62,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     yaw: 0,
     pitch: 0,
     onGround: false,
+    hasHorizontalCollision: false,
     time: 0,
     flags: { onGround: false, hasHorizontalCollision: false }
   }
+
+  const collidedHorizontally = () => bot.entity.isCollidedHorizontally === true
 
   // This function should be executed each tick (every 0.05 seconds)
   // How it works: https://gafferongames.com/post/fix_your_timestep/
@@ -81,12 +97,15 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
-      physics.simulatePlayer(new PlayerState(bot, controlState), world).apply(bot)
+      updateSprinting()
+      physics.simulatePlayer(new PlayerState(bot, { ...controlState, sprint: sprinting }), world).apply(bot)
       bot.emit('physicsTick')
       bot.emit('physicTick') // Deprecated, only exists to support old plugins. May be removed in the future
     }
     if (shouldUsePhysics) {
+      sendInputPackets()
       updatePosition(now)
+      if (hasTickEndPacket) bot._client.write('tick_end', {})
     }
   }
 
@@ -108,7 +127,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.y = position.y
     lastSent.z = position.z
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision: collidedHorizontally() } // 1.21.3+
     bot._client.write('position', lastSent)
     bot.emit('move', oldPos)
   }
@@ -119,7 +138,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.yaw = yaw
     lastSent.pitch = pitch
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision: collidedHorizontally() } // 1.21.3+
     bot._client.write('look', lastSent)
     bot.emit('move', oldPos)
   }
@@ -134,7 +153,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSent.yaw = yaw
     lastSent.pitch = pitch
     lastSent.onGround = onGround
-    lastSent.flags = { onGround, hasHorizontalCollision: undefined } // 1.21.3+
+    lastSent.flags = { onGround, hasHorizontalCollision: collidedHorizontally() } // 1.21.3+
     bot._client.write('position_look', lastSent)
     bot.emit('move', oldPos)
   }
@@ -175,33 +194,97 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     const pitch = Math.fround(conv.toNotchianPitch(lastSentPitch))
     const position = bot.entity.position
     const onGround = bot.entity.onGround
+    const hasHorizontalCollision = collidedHorizontally()
 
-    // Only send a position update if necessary, select the appropriate packet
-    const positionUpdated = lastSent.x !== position.x || lastSent.y !== position.y || lastSent.z !== position.z ||
-      // Send a position update every second, even if no other update was made
-      // This function rounds to the nearest 50ms (or PHYSICS_INTERVAL_MS) and checks if a second has passed.
-      (Math.round((now - lastSent.time) / PHYSICS_INTERVAL_MS) * PHYSICS_INTERVAL_MS) >= 1000
+    // Vanilla (LocalPlayer.sendPosition) sends the position once it moved more than 2e-4 blocks
+    // since the last one sent, or every 20 ticks regardless.
+    positionReminder++
+    const dx = position.x - lastSent.x
+    const dy = position.y - lastSent.y
+    const dz = position.z - lastSent.z
+    const positionUpdated = dx * dx + dy * dy + dz * dz > 4e-8 || positionReminder >= 20
     const lookUpdated = lastSent.yaw !== yaw || lastSent.pitch !== pitch
 
     if (positionUpdated && lookUpdated) {
       sendPacketPositionAndLook(position, yaw, pitch, onGround)
-      lastSent.time = now // only reset if positionUpdated is true
     } else if (positionUpdated) {
       sendPacketPosition(position, onGround)
-      lastSent.time = now // only reset if positionUpdated is true
     } else if (lookUpdated) {
       sendPacketLook(yaw, pitch, onGround)
-    } else if (positionUpdateSentEveryTick || onGround !== lastSent.onGround) {
+    } else if (positionUpdateSentEveryTick || onGround !== lastSent.onGround || hasHorizontalCollision !== lastSent.hasHorizontalCollision) {
       // For versions < 1.12, one player packet should be sent every tick
       // for the server to update health correctly
-      // For versions >= 1.12, onGround !== lastSent.onGround should be used, but it doesn't ever trigger outside of login
       bot._client.write('flying', {
-        onGround: bot.entity.onGround,
-        flags: { onGround: bot.entity.onGround, hasHorizontalCollision: undefined } // 1.21.3+
+        onGround,
+        flags: { onGround, hasHorizontalCollision } // 1.21.3+
       })
     }
+    if (positionUpdated) {
+      positionReminder = 0
+      lastSent.time = now
+    }
 
-    lastSent.onGround = bot.entity.onGround // onGround is always set
+    lastSent.onGround = onGround // onGround is always set
+    lastSent.hasHorizontalCollision = hasHorizontalCollision
+  }
+
+  // What vanilla sends from LocalPlayer.tick() before the movement packet: the shift key state, the
+  // key set when it changed, then the sprinting state (sendPosition calls sendIsSprintingIfNeeded).
+  function sendInputPackets () {
+    if (controlState.sneak !== lastSentSneak) {
+      lastSentSneak = controlState.sneak
+      if (sneakUsesEntityAction) {
+        bot._client.write('entity_action', {
+          entityId: bot.entity.id,
+          actionId: controlState.sneak ? 0 : 1,
+          jumpBoost: 0
+        })
+      }
+    }
+    if (hasPlayerInputPacket) {
+      const inputs = {
+        forward: controlState.forward,
+        backward: controlState.back,
+        left: controlState.left,
+        right: controlState.right,
+        jump: controlState.jump,
+        shift: controlState.sneak,
+        sprint: controlState.sprint
+      }
+      if (lastSentInputs === null || Object.keys(inputs).some(k => inputs[k] !== lastSentInputs[k])) {
+        lastSentInputs = inputs
+        bot._client.write('player_input', { inputs })
+      }
+    }
+    if (sprinting !== lastSentSprinting) {
+      lastSentSprinting = sprinting
+      bot._client.write('entity_action', {
+        entityId: bot.entity.id,
+        actionId: bot.supportFeature('entityActionUsesStringMapper')
+          ? (sprinting ? 'start_sprinting' : 'stop_sprinting')
+          : (sprinting ? 3 : 4),
+        jumpBoost: 0
+      })
+    }
+  }
+
+  // LocalPlayer.aiStep: sprinting starts on the ground with the sprint key, a full forward impulse,
+  // more than 6 food (or creative), no item in use and no blindness; it stops when the forward
+  // impulse, the food or a wall collision is against it, or the player sneaks or enters water.
+  function updateSprinting () {
+    const mcData = bot.registry
+    const forward = controlState.forward && !controlState.back
+    const enoughFood = bot.food === undefined || bot.food > 6 || bot.game.gameMode === 'creative'
+    const slow = controlState.sneak || bot.usingHeldItem
+    const blind = getEffectLevel(mcData, 'Blindness', bot.entity.effects ?? {}) > 0
+    if (!sprinting) {
+      if (controlState.sprint && forward && enoughFood && !slow && !blind && bot.entity.onGround && !bot.entity.isInWater) sprinting = true
+    }
+    if (sprinting) {
+      const vel = bot.entity.velocity
+      const blocked = collidedHorizontally() && vel.x * vel.x + vel.z * vel.z < 0.06 * 0.06
+      if (!forward || !enoughFood || slow || blind || blocked || bot.entity.isInWater) sprinting = false
+    }
   }
 
   bot.physics = physics
@@ -251,30 +334,6 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     controlState[control] = state
     if (control === 'jump' && state) {
       bot.jumpQueued = true
-    } else if (control === 'sprint') {
-      bot._client.write('entity_action', {
-        entityId: bot.entity.id,
-        actionId: bot.supportFeature('entityActionUsesStringMapper')
-          ? (state ? 'start_sprinting' : 'stop_sprinting')
-          : (state ? 3 : 4),
-        jumpBoost: 0
-      })
-    } else if (control === 'sneak') {
-      if (bot.supportFeature('newPlayerInputPacket')) {
-        // In 1.21.6+, sneak is handled via player_input packet
-        bot._client.write('player_input', {
-          inputs: {
-            shift: state
-          }
-        })
-      } else {
-        // Legacy entity_action approach for older versions
-        bot._client.write('entity_action', {
-          entityId: bot.entity.id,
-          actionId: state ? 0 : 1,
-          jumpBoost: 0
-        })
-      }
     }
   }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -432,6 +432,68 @@ for (const supportedVersion of mineflayer.testedVersions) {
           })
         })
       })
+      it('sends the 1.21.2+ input packets like vanilla', async function () {
+        if (!bot.supportFeature('newPlayerInputPacket')) {
+          this.skip()
+          return
+        }
+        const sneakViaEntityAction = !bot.registry.version['>=']('1.21.6')
+        const sent = []
+        const originalWrite = bot._client.write.bind(bot._client)
+        bot._client.write = (name, params) => {
+          sent.push({ name, params })
+          return originalWrite(name, params)
+        }
+        const joined = once(server, 'playerJoin')
+        const client = (await joined)[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        await client.write('update_health', { health: 20, food: 20, foodSaturation: 5 })
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(pos, goldId)
+        await client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+        const p1 = once(bot, 'forcedMove')
+        await client.write('position', { x: 1.5, y: 66, z: 1.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, flags: {}, teleportId: 0 })
+        await p1
+        await bot.waitForTicks(3)
+        assert.ok(sent.some(p => p.name === 'tick_end'), 'tick_end is sent every tick')
+        assert.ok(!sent.some(p => p.name === 'player_input' && p.params.inputs.shift), 'no shift before sneaking')
+
+        sent.length = 0
+        bot.setControlState('sneak', true)
+        await bot.waitForTicks(2)
+        const shift = sent.find(p => p.name === 'player_input')
+        assert.ok(shift, 'player_input on sneak')
+        assert.deepStrictEqual(shift.params.inputs, { forward: false, backward: false, left: false, right: false, jump: false, shift: true, sprint: false })
+        const pressShift = sent.find(p => p.name === 'entity_action')
+        if (sneakViaEntityAction) {
+          assert.strictEqual(pressShift.params.actionId, 0, 'PRESS_SHIFT_KEY entity_action up to 1.21.5')
+          assert.ok(sent.indexOf(pressShift) < sent.indexOf(shift), 'entity_action before player_input')
+        } else {
+          assert.strictEqual(pressShift, undefined, 'no entity_action for the shift key from 1.21.6')
+        }
+
+        // Sprint key while sneaking: the key set changes but the bot does not sprint.
+        sent.length = 0
+        bot.setControlState('sprint', true)
+        bot.setControlState('forward', true)
+        await bot.waitForTicks(2)
+        assert.ok(sent.some(p => p.name === 'player_input' && p.params.inputs.sprint && p.params.inputs.forward), 'player_input with sprint + forward')
+        assert.ok(!sent.some(p => p.name === 'entity_action' && (p.params.actionId === 3 || p.params.actionId === 'start_sprinting')), 'no start_sprinting while sneaking')
+
+        sent.length = 0
+        bot.setControlState('sneak', false)
+        await bot.waitForTicks(3)
+        assert.ok(sent.some(p => p.name === 'entity_action' && (p.params.actionId === 3 || p.params.actionId === 'start_sprinting')), 'start_sprinting once the sneak key is released')
+
+        sent.length = 0
+        bot.setControlState('forward', false)
+        await bot.waitForTicks(3)
+        assert.ok(sent.some(p => p.name === 'entity_action' && (p.params.actionId === 4 || p.params.actionId === 'stop_sprinting')), 'stop_sprinting without a forward impulse')
+        bot.clearControlStates()
+        bot._client.write = originalWrite
+      })
+
       it('no movement packets during a server transfer configuration phase', function (done) {
         // Regression test for https://github.com/PrismarineJS/mineflayer/issues/3776
         // While the client is in the configuration phase (Velocity/BungeeCord server

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -437,7 +437,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           this.skip()
           return
         }
-        const sneakViaEntityAction = !bot.registry.version['>=']('1.21.6')
+        const sneakViaEntityAction = bot.supportFeature('sneakUsesEntityAction')
         const sent = []
         const originalWrite = bot._client.write.bind(bot._client)
         bot._client.write = (name, params) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -473,7 +473,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           assert.strictEqual(pressShift, undefined, 'no entity_action for the shift key from 1.21.6')
         }
 
-        // Sprint key while sneaking: the key set changes but the bot does not sprint.
+        // Sneaking blocks sprinting; the key set still changes.
         sent.length = 0
         bot.setControlState('sprint', true)
         bot.setControlState('forward', true)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -398,6 +398,81 @@ for (const supportedVersion of mineflayer.testedVersions) {
           done()
         })
       })
+      it('applies the 1.21.2+ teleport velocity with its delta flags', async function () {
+        if (!registry.protocol.play.toClient.types.packet_position[1].some(field => field.name === 'dx')) {
+          this.skip()
+          return
+        }
+        const client = (await once(server, 'playerJoin'))[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(pos, goldId)
+        await client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+        const teleport = (extra) => {
+          const p = once(bot, 'forcedMove')
+          client.write('position', { x: 1.5, y: 80, z: 1.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, teleportId: 1, flags: {}, ...extra })
+          return p
+        }
+        bot.entity.velocity.set(0.25, 0.5, 0)
+        await teleport({ dx: 0.5, dz: 0.125 })
+        assert.deepStrictEqual(bot.entity.velocity, vec3(0.5, 0, 0.125), 'absolute velocity from the packet')
+        bot.entity.velocity.set(0.25, 0.5, 0)
+        await teleport({ dx: 0.5, dy: 0.5, flags: { dx: true, dy: true } })
+        assert.deepStrictEqual(bot.entity.velocity, vec3(0.75, 1, 0), 'flagged axes add to the current velocity')
+        await teleport({ yaw: 0 })
+        bot.entity.velocity.set(1, 0, 0)
+        await teleport({ yaw: 90, flags: { yawDelta: true, dx: true, dz: true } })
+        assert.ok(Math.abs(bot.entity.velocity.x) < 1e-6 && Math.abs(bot.entity.velocity.z - 1) < 1e-6, `yawDelta turns the velocity with the rotation change: ${bot.entity.velocity}`)
+      })
+
+      it('answers a teleport with an ungrounded position_look and repeats the position next tick', async function () {
+        const client = (await once(server, 'playerJoin'))[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(pos, goldId)
+        await client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+        // Both teleports land in open air, so the bot falls and every tick carries a position.
+        const base = { x: 4.5, y: 80, z: 4.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, teleportId: 1, flags: bot.supportFeature('positionPacketHasBitflags') ? {} : 0 }
+        const settled = once(bot, 'forcedMove')
+        await client.write('position', base)
+        await settled
+        await sleep(300)
+        const moves = []
+        const onPacket = (data, meta) => { if (['position', 'position_look', 'look', 'flying'].includes(meta.name)) moves.push({ name: meta.name, data }) }
+        client.on('packet', onPacket)
+        const p = once(bot, 'forcedMove')
+        await client.write('position', { ...base, x: 6.5, z: 6.5, yaw: 90, teleportId: 2 })
+        await p
+        await sleep(200)
+        client.off('packet', onPacket)
+        // The reply is the first packet carrying the teleported position; a tick of the fall can
+        // reach the server first.
+        const reply = moves.find(m => m.data.x === 6.5)
+        assert.ok(reply, `no packet carried the teleported position: ${JSON.stringify(moves.map(m => m.name))}`)
+        assert.strictEqual(reply.name, 'position_look')
+        assert.strictEqual(reply.data.onGround ?? reply.data.flags?.onGround, false, 'reply is not grounded')
+        if (reply.data.flags && 'hasHorizontalCollision' in reply.data.flags) assert.strictEqual(reply.data.flags.hasHorizontalCollision, false)
+      })
+
+      it('answers a forced rotation with an ungrounded look', async function () {
+        if (!registry.protocol.play.toClient.types.packet_player_rotation) {
+          this.skip()
+          return
+        }
+        const client = (await once(server, 'playerJoin'))[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        const looks = []
+        client.on('packet', (data, meta) => { if (meta.name === 'look') looks.push(data) })
+        await client.write('player_rotation', { yaw: 90, pitch: 10 })
+        await sleep(100)
+        assert.strictEqual(looks.length, 1, 'one look')
+        assert.strictEqual(looks[0].yaw, 90)
+        assert.strictEqual(looks[0].pitch, 10)
+        assert.strictEqual(looks[0].onGround ?? looks[0].flags?.onGround, false)
+      })
+
       it('gravity + land on solid block + jump', (done) => {
         let y = 80
         let landed = false


### PR DESCRIPTION
Compared `lib/plugins/physics.js` against the 1.21.4 client (`LocalPlayer.tick()` / `sendPosition()` / `aiStep()`, Mojang mappings) and made the bot send what the client sends, in the same order per tick: shift key state, `player_input` when the key set changed, `start/stop_sprinting` when the sprinting state changed, the movement packet, then `tick_end`.

**Bug fixed**: on 1.21.3, 1.21.4 and 1.21.5 `bot.setControlState('sneak', true)` only sent `player_input { shift }`. Those servers set the sneak state from `entity_action` PRESS_SHIFT_KEY (`ServerGamePacketListenerImpl.handlePlayerCommand`) and ignore the shift bit of `player_input` (it is only stored as `lastClientInput`; the server started reading it in 1.21.6, `handlePlayerInput` → `setShiftKeyDown`). The vanilla client sends both packets on those versions and only `player_input` from 1.21.6, so the bot never sneaked server-side there: no crouch hitbox, no sneak-placing against interactable blocks, no sneak interactions.

Which packet carries the sneak state is decided by the `sneakUsesEntityAction` feature from PrismarineJS/minecraft-data#1275 (`1.8` through `1.21.5`). On a minecraft-data release without it the feature is `false`, so no `entity_action` is sent for the shift key on any version, the same as before this PR; the sneak fix for 1.21.3–1.21.5 takes effect once that data ships. The range ends at 1.21.5 on purpose: the 1.21.6+ `entity_action` string mapper has no shift entries, so a missing feature must never route the shift key there.

**Parity changes** (1.21.2+ unless stated):
- `player_input` carries the whole key set (`forward/backward/left/right/jump/shift/sprint`) and is sent whenever it changes, not just for sneak; `tick_end` is sent after every physics tick (the server uses it to reset `knownMovement`, which gates sweep attacks and is what anticheats key their tick boundaries on).
- Sprinting follows `LocalPlayer.aiStep` instead of the sprint key: it starts on the ground with a full forward impulse, more than 6 food (or creative), no item in use, no blindness and not in water; it stops when the forward impulse, food or a wall collision is against it or the player sneaks or enters water. `start/stop_sprinting` follow that state. The local simulation is fed the same state, so the bot no longer moves at sprint speed backwards, sideways or with an empty hunger bar (all versions).
- Movement packets carry `hasHorizontalCollision` from the simulation instead of `undefined`, and a status-only (`flying`) packet is sent when it flips, like `sendPosition` does.
- A position is sent once it moved more than 2e-4 blocks since the last one or after 20 ticks (`positionReminder`), instead of on any change / after 1 s of wall time.

Docs: `bot.setControlState` describes when `sprint` actually sprints. Test: `sends the 1.21.2+ input packets like vanilla` in `internalTest.js` checks the packet set and ordering for sneak, the sprint key while sneaking (key set changes, no sprint), sprint after releasing sneak, stop when forward is released, and `tick_end`; it asserts `entity_action` PRESS_SHIFT_KEY up to 1.21.5 and its absence from 1.21.6.

Verified live on a Paper 1.21.4 Velocity network (Jartex) by tracing the bot's outgoing packets while walking.
