### PR TITLE
health: send player_loaded when the vanilla client would

### DIFF
--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -35,6 +35,9 @@ function inject (bot, options) {
     chunksAnnounced = false
     bot._client.write('player_loaded', {})
   }
+  // Every clientbound login and respawn starts a level whose chunks the server announces once.
+  bot._client.on('login', sendPlayerLoadedWhenReady)
+  bot._client.on('respawn', sendPlayerLoadedWhenReady)
   bot._client.on('game_state_change', (packet) => {
     if (packet.reason === 13 || packet.reason === 'level_chunks_load_start') {
       chunksAnnounced = true

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -15,10 +15,9 @@ function inject (bot, options) {
     bot.emit('spawn')
   }
 
-  // The vanilla client (LevelLoadStatusManager) sends player_loaded once the server has announced
-  // the chunks are coming (game event LEVEL_CHUNKS_LOAD_START, sent on join and on respawn) and the
-  // chunk the player stands in has arrived, or the player is outside the build height, a spectator
-  // or dead. Until then the server keeps the player invulnerable and ignores interactions.
+  // player_loaded is sent at most once per level_chunks_load_start game event (join and every
+  // respawn), never before it, and only once the column under the bot is loaded unless the bot
+  // is outside the build height, a spectator or dead.
   let awaitingLoad = false
   let chunksAnnounced = false
   function sendPlayerLoadedWhenReady () {

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -11,9 +11,39 @@ function inject (bot, options) {
   // 1.21.4+ servers ignore block and item interactions until the client has
   // sent player_loaded (or 60 ticks have passed)
   function spawn () {
-    if (bot.supportFeature('sendsPlayerLoadedPacket')) bot._client.write('player_loaded', {})
+    sendPlayerLoadedWhenReady()
     bot.emit('spawn')
   }
+
+  // The vanilla client (LevelLoadStatusManager) sends player_loaded once the server has announced
+  // the chunks are coming (game event LEVEL_CHUNKS_LOAD_START, sent on join and on respawn) and the
+  // chunk the player stands in has arrived, or the player is outside the build height, a spectator
+  // or dead. Until then the server keeps the player invulnerable and ignores interactions.
+  let awaitingLoad = false
+  let chunksAnnounced = false
+  function sendPlayerLoadedWhenReady () {
+    if (!bot.supportFeature('sendsPlayerLoadedPacket')) return
+    awaitingLoad = true
+    checkLoaded()
+  }
+  function checkLoaded () {
+    if (!awaitingLoad || !chunksAnnounced) return
+    const pos = bot.entity?.position
+    if (!pos || !Number.isFinite(pos.x)) return
+    const outsideBuildHeight = pos.y < bot.game.minY || pos.y >= bot.game.minY + bot.game.height
+    if (!(outsideBuildHeight || bot.game.gameMode === 'spectator' || !bot.isAlive || bot.blockAt(pos) !== null)) return
+    awaitingLoad = false
+    chunksAnnounced = false
+    bot._client.write('player_loaded', {})
+  }
+  bot._client.on('game_state_change', (packet) => {
+    if (packet.reason === 13 || packet.reason === 'level_chunks_load_start') {
+      chunksAnnounced = true
+      checkLoaded()
+    }
+  })
+  bot.on('chunkColumnLoad', checkLoaded)
+  bot.on('forcedMove', checkLoaded)
 
   bot._client.once('update_health', (packet) => {
     if (packet.health > 0) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -530,6 +530,34 @@ for (const supportedVersion of mineflayer.testedVersions) {
         assert.strictEqual(loaded, 1, 'once after the chunk arrives')
         bot._client.write = originalWrite
       })
+
+      it('is sent again after a login that keeps the bot alive (server transfer)', async function () {
+        if (!bot.supportFeature('sendsPlayerLoadedPacket')) {
+          this.skip()
+          return
+        }
+        let loaded = 0
+        const originalWrite = bot._client.write.bind(bot._client)
+        bot._client.write = (name, params) => {
+          if (name === 'player_loaded') loaded++
+          return originalWrite(name, params)
+        }
+        const client = (await once(server, 'playerJoin'))[0]
+        const chunk = generateChunkPacket(bot.test.buildChunk())
+        for (let login = 1; login <= 2; login++) {
+          await client.write('login', bot.test.generateLoginPacket())
+          await client.write('update_health', { health: 20, food: 20, foodSaturation: 5 })
+          const p = once(bot, 'forcedMove')
+          await client.write('position', { x: 1.5, y: 66, z: 1.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, flags: {}, teleportId: 0 })
+          await p
+          await client.write('game_state_change', { reason: 13, gameMode: 0 })
+          await client.write('map_chunk', chunk)
+          await once(bot, 'chunkColumnLoad')
+          await sleep(50)
+          assert.strictEqual(loaded, login, `once per login, after login ${login}`)
+        }
+        bot._client.write = originalWrite
+      })
     })
 
     describe('world', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -500,6 +500,38 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('player_loaded', () => {
+      it('is sent once the chunks are announced and the bot\'s chunk has arrived', async function () {
+        if (!bot.supportFeature('sendsPlayerLoadedPacket')) {
+          this.skip()
+          return
+        }
+        let loaded = 0
+        const originalWrite = bot._client.write.bind(bot._client)
+        bot._client.write = (name, params) => {
+          if (name === 'player_loaded') loaded++
+          return originalWrite(name, params)
+        }
+        const client = (await once(server, 'playerJoin'))[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        await client.write('update_health', { health: 20, food: 20, foodSaturation: 5 })
+        await once(bot, 'spawn')
+        const p1 = once(bot, 'forcedMove')
+        await client.write('position', { x: 1.5, y: 66, z: 1.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, flags: {}, teleportId: 0 })
+        await p1
+        await sleep(100)
+        assert.strictEqual(loaded, 0, 'not before the server announces the chunks')
+        await client.write('game_state_change', { reason: 13, gameMode: 0 })
+        await sleep(100)
+        assert.strictEqual(loaded, 0, 'not before the chunk the bot stands in arrives')
+        await client.write('map_chunk', generateChunkPacket(bot.test.buildChunk()))
+        await once(bot, 'chunkColumnLoad')
+        await sleep(50)
+        assert.strictEqual(loaded, 1, 'once after the chunk arrives')
+        bot._client.write = originalWrite
+      })
+    })
+
     describe('world', () => {
       const pos = vec3(1, 65, 1)
       const goldId = 41


### PR DESCRIPTION
`player_loaded` (1.21.4+) was written on the first `update_health`, before any chunk had arrived. The vanilla client sends it from `LevelLoadStatusManager`: only after the server's `LEVEL_CHUNKS_LOAD_START` game event (sent from `PlayerList.sendLevelInfo` on join and on respawn) and once the chunk section the player stands in is loaded, or the player is outside the build height, a spectator, or dead. The server keeps the player invulnerable and ignores block/item interactions until it receives the packet (or 60 ticks pass), so sending it early ends that grace period before the bot's world exists locally.

The bot now waits for the game event and for the column at `bot.entity.position` (`chunkColumnLoad` / `forcedMove` re-check), then sends it once; the `spawn` event timing is unchanged. Test added in `internalTest.js` (`player_loaded` describe) for 1.21.4+.