### PR TITLE
Send Client Information once, when the vanilla client does

### DIFF
--- a/lib/plugins/settings.js
+++ b/lib/plugins/settings.js
@@ -21,9 +21,7 @@ const viewDistanceToBits = {
 }
 
 function inject (bot, options) {
-  function setSettings (settings) {
-    extend(bot.settings, settings)
-
+  function clientInformation () {
     // chat
     const chatBits = chatToBits[bot.settings.chat]
     assert.ok(chatBits != null, `invalid chat setting: ${bot.settings.chat}`)
@@ -52,8 +50,7 @@ function inject (bot, options) {
           bot.settings.skinParts.showRightPants << 5 |
           bot.settings.skinParts.showHat << 6
 
-    // write the packet
-    bot._client.write('settings', {
+    return {
       locale: bot.settings.locale || 'en_US',
       viewDistance: viewDistanceBits,
       chatFlags: chatBits,
@@ -63,7 +60,14 @@ function inject (bot, options) {
       enableTextFiltering: bot.settings.enableTextFiltering,
       enableServerListing: bot.settings.enableServerListing,
       particleStatus: bot.settings.particleStatus
-    })
+    }
+  }
+
+  function setSettings (settings) {
+    extend(bot.settings, settings)
+
+    // write the packet
+    bot._client.write('settings', clientInformation())
   }
 
   bot.settings = {
@@ -92,8 +96,12 @@ function inject (bot, options) {
     particleStatus: 'all'
   }
 
+  // On 1.20.2+ node-minecraft-protocol sends Client Information during the configuration
+  // phase; give it the bot's settings so the server is never told two different things.
+  options.clientSettings = options.clientSettings ?? clientInformation()
+
   bot._client.on('login', () => {
-    setSettings({})
+    if (!bot.supportFeature('hasConfigurationState')) setSettings({})
   })
 
   bot.setSettings = setSettings

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -535,6 +535,32 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('settings', () => {
+      it('sends Client Information after login only without a configuration phase', async function () {
+        // 1.20.2+ sends it during the configuration phase instead, from options.clientSettings.
+        const hasConfigState = bot.supportFeature('hasConfigurationState')
+        const sent = []
+        const originalWrite = bot._client.write.bind(bot._client)
+        bot._client.write = (name, params) => {
+          if (name === 'settings' && bot._client.state === 'play') sent.push(params)
+          return originalWrite(name, params)
+        }
+        try {
+          const client = (await once(server, 'playerJoin'))[0]
+          await client.write('login', bot.test.generateLoginPacket())
+          await once(bot, 'login')
+          assert.strictEqual(sent.length, hasConfigState ? 0 : 1)
+
+          // A later change still goes out, on every version.
+          bot.setSettings({ viewDistance: 'short' })
+          assert.strictEqual(sent.length, hasConfigState ? 1 : 2)
+          assert.strictEqual(sent[sent.length - 1].viewDistance, 8)
+        } finally {
+          bot._client.write = originalWrite
+        }
+      })
+    })
+
     describe('world', () => {
       const pos = vec3(1, 65, 1)
       const goldId = 41


### PR DESCRIPTION
Up to 1.20.1 the vanilla client sends Client Information after login. From 1.20.2 it sends it during the configuration phase, and again only when a setting changes.

node-minecraft-protocol already sends Client Information during the configuration phase, but from its own defaults (view distance 10). mineflayer then re-sent it after login with the bot's settings (view distance 12). Every connection told the server two different things.

This passes the bot's settings to node-minecraft-protocol as `clientSettings`, so the configuration-phase packet carries them, and only re-sends after login on versions without a configuration phase.

`setSettings` is unchanged from the caller's side: a later `bot.setSettings(...)` still writes the packet, on every version.

Scope notes:
- The client brand change that was here has been dropped — see the comment below.
- The `locale` / `enableServerListing` value fixes were split out, since they're about what's in the packet rather than when it's sent.