### PR TITLE
Match the vanilla client's interaction packets: entity interact, digging, placing, sequences, resource packs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2037,6 +2037,8 @@ Attack a player or a mob.
  * `entity` is a type of entity. To get a specific entity use [bot.nearestEntity()](#botnearestentitymatch--entity---return-true-) or [bot.entities](#botentities).
  * `swing` Default to `true`. If false the bot does not swing its arm when attacking.
 
+Throws if `entity` is the bot itself, an item or an experience orb: the server kicks a client that attacks those.
+
 #### bot.swingArm([hand], showHand)
 
 Play an arm swing animation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2052,7 +2052,9 @@ Mount a vehicle. To get back out, use `bot.dismount`.
 
 #### bot.dismount()
 
-Dismounts from the vehicle you are in.
+This function returns a `Promise`, with `void` as its argument once the dismount has been sent.
+
+Dismounts from the vehicle you are in. On 1.21.3+ this holds the sneak control for one physics tick, which is how vanilla leaves a vehicle.
 
 #### bot.moveVehicle(left,forward)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   mount: (entity: Entity) => void
 
-  dismount: () => void
+  dismount: () => Promise<void>
 
   moveVehicle: (left: number, forward: number) => void
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,7 +42,8 @@ const plugins = {
   anvil: require('./plugins/anvil'),
   place_entity: require('./plugins/place_entity'),
   generic_place: require('./plugins/generic_place'),
-  particle: require('./plugins/particle')
+  particle: require('./plugins/particle'),
+  sequence: require('./plugins/sequence')
 }
 
 const minecraftData = require('minecraft-data')

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -130,7 +130,8 @@ function inject (bot) {
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: bot.targetDigFace // default face is 1 (top)
+      face: bot.targetDigFace, // default face is 1 (top)
+      sequence: bot._nextSequence()
     })
     waitTimeout = setTimeout(finishDigging, waitTime)
     bot.targetDigBlock = block
@@ -149,7 +150,8 @@ function inject (bot) {
         bot._client.write('block_dig', {
           status: 2, // finish digging
           location: bot.targetDigBlock.position,
-          face: bot.targetDigFace // always the same as the start face
+          face: bot.targetDigFace, // always the same as the start face
+          sequence: bot._nextSequence()
         })
       }
       bot.targetDigBlock = null
@@ -178,7 +180,8 @@ function inject (bot) {
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
-        face: cancellationDiggingFace
+        face: cancellationDiggingFace,
+        sequence: 0
       })
       const block = bot.targetDigBlock
       bot.targetDigBlock = null

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -6,14 +6,19 @@ const { Vec3 } = require('vec3')
 module.exports = inject
 
 function inject (bot) {
-  let swingInterval = null
   let waitTimeout = null
+  let abortDigging = null // closure of the dig in progress, takes the abort face
 
   let diggingTask = createDoneTask()
 
   bot.targetDigBlock = null
   bot.targetDigFace = null
   bot.lastDigTime = null
+
+  // Vanilla swings every tick while it keeps destroying a block
+  bot.on('physicsTick', () => {
+    if (bot.targetDigBlock) bot.swingArm()
+  })
 
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
@@ -29,17 +34,17 @@ function inject (bot) {
       throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
     }
 
-    bot.targetDigFace = 1 // Default (top)
+    let targetDigFace = 1 // Default (top)
 
     if (forceLook !== 'ignore') {
       if (digFace?.x || digFace?.y || digFace?.z) {
         // Determine the block face the bot should mine
         if (digFace.x) {
-          bot.targetDigFace = digFace.x > 0 ? BlockFaces.EAST : BlockFaces.WEST
+          targetDigFace = digFace.x > 0 ? BlockFaces.EAST : BlockFaces.WEST
         } else if (digFace.y) {
-          bot.targetDigFace = digFace.y > 0 ? BlockFaces.TOP : BlockFaces.BOTTOM
+          targetDigFace = digFace.y > 0 ? BlockFaces.TOP : BlockFaces.BOTTOM
         } else if (digFace.z) {
-          bot.targetDigFace = digFace.z > 0 ? BlockFaces.SOUTH : BlockFaces.NORTH
+          targetDigFace = digFace.z > 0 ? BlockFaces.SOUTH : BlockFaces.NORTH
         }
         await bot.lookAt(
           block.position.offset(0.5, 0.5, 0.5).offset(digFace.x * 0.5, digFace.y * 0.5, digFace.z * 0.5),
@@ -107,7 +112,7 @@ function inject (bot) {
             }
           }
           await bot.lookAt(closest.targetPos, forceLook)
-          bot.targetDigFace = closest.face
+          targetDigFace = closest.face
         } else if (closerBlocks.length === 0 && block.shapes.length === 0) {
           // no other blocks were detected and the block has no shapes.
           // The block in question is replaceable (like tall grass) so we can just dig it
@@ -124,27 +129,36 @@ function inject (bot) {
 
     // In vanilla the client will cancel digging the current block once the other block is at the crosshair.
     // Todo: don't wait until lookAt is at middle of the block, but at the edge of it.
-    if (bot.targetDigBlock) bot.stopDigging()
+    // The abort for a retarget carries the new block's face
+    if (bot.targetDigBlock) abortDigging(targetDigFace)
 
     diggingTask = createTask()
+    bot.targetDigBlock = block
+    bot.targetDigFace = targetDigFace
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: bot.targetDigFace, // default face is 1 (top)
+      face: targetDigFace,
       sequence: bot._nextSequence()
     })
-    waitTimeout = setTimeout(finishDigging, waitTime)
-    bot.targetDigBlock = block
     bot.swingArm()
 
-    swingInterval = setInterval(() => {
-      bot.swingArm()
-    }, 350)
+    const eventName = `blockUpdate:${block.position}`
+    bot.on(eventName, onBlockUpdate)
+
+    if (waitTime === 0) {
+      // Instant break (creative or a zero hardness block): vanilla sends only
+      // START_DESTROY_BLOCK and predicts the break locally
+      bot.targetDigBlock = null
+      bot.targetDigFace = null
+      bot.lastDigTime = performance.now()
+      bot._updateBlockState(block.position, 0)
+    } else {
+      waitTimeout = setTimeout(finishDigging, waitTime)
+    }
 
     function finishDigging () {
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       if (bot.targetDigBlock) {
         bot._client.write('block_dig', {
@@ -160,27 +174,14 @@ function inject (bot) {
       bot._updateBlockState(block.position, 0)
     }
 
-    const eventName = `blockUpdate:${block.position}`
-    bot.on(eventName, onBlockUpdate)
-
-    const currentBlock = block
-    bot.stopDigging = () => {
-      if (!bot.targetDigBlock) return
-
-      // Replicate the odd vanilla cancellation face value.
-      // When the cancellation is because of a new dig request on another block it's the same as the new dig start face. In all other cases it's 0.
-      const stoppedBecauseOfNewDigRequest = !currentBlock.position.equals(bot.targetDigBlock.position)
-      const cancellationDiggingFace = !stoppedBecauseOfNewDigRequest ? bot.targetDigFace : 0
-
+    abortDigging = (face) => {
       bot.removeListener(eventName, onBlockUpdate)
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
-        face: cancellationDiggingFace,
+        face,
         sequence: 0
       })
       const block = bot.targetDigBlock
@@ -188,7 +189,6 @@ function inject (bot) {
       bot.targetDigFace = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
-      bot.stopDigging = noop
       diggingTask.cancel(new Error('Digging aborted'))
     }
 
@@ -198,9 +198,7 @@ function inject (bot) {
       // All block update listeners receive (null, null) when the world is unloaded. So newBlock can be null.
       if (newBlock?.type !== 0) return
       bot.removeListener(eventName, onBlockUpdate)
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       bot.targetDigBlock = null
       bot.targetDigFace = null
@@ -210,6 +208,11 @@ function inject (bot) {
     }
 
     await diggingTask.promise
+  }
+
+  // A user abort sends face DOWN like vanilla stopDestroyBlock
+  function stopDigging () {
+    if (bot.targetDigBlock) abortDigging(0)
   }
 
   bot.on('death', () => {
@@ -260,11 +263,7 @@ function inject (bot) {
 
   bot._getBlockAtEyeLevel = () => bot.entity.position && bot.blockAt(bot.entity.position.offset(0, bot.entity.eyeHeight, 0))
   bot.dig = dig
-  bot.stopDigging = noop
+  bot.stopDigging = stopDigging
   bot.canDigBlock = canDigBlock
   bot.digTime = digTime
-}
-
-function noop (err) {
-  if (err) throw err
 }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -15,7 +15,7 @@ function inject (bot) {
   bot.targetDigFace = null
   bot.lastDigTime = null
 
-  // Vanilla swings every tick while it keeps destroying a block
+  // A dig in progress swings the arm once per physics tick
   bot.on('physicsTick', () => {
     if (bot.targetDigBlock) bot.swingArm()
   })
@@ -129,7 +129,7 @@ function inject (bot) {
 
     // In vanilla the client will cancel digging the current block once the other block is at the crosshair.
     // Todo: don't wait until lookAt is at middle of the block, but at the edge of it.
-    // The abort for a retarget carries the new block's face
+    // An abort caused by retargeting must carry the new block's face
     if (bot.targetDigBlock) abortDigging(targetDigFace)
 
     diggingTask = createTask()
@@ -147,8 +147,8 @@ function inject (bot) {
     bot.on(eventName, onBlockUpdate)
 
     if (waitTime === 0) {
-      // Instant break (creative or a zero hardness block): vanilla sends only
-      // START_DESTROY_BLOCK and predicts the break locally
+      // An instant break (creative or zero hardness) must not send STOP_DESTROY_BLOCK;
+      // the block is cleared locally
       bot.targetDigBlock = null
       bot.targetDigFace = null
       bot.lastDigTime = performance.now()
@@ -210,7 +210,7 @@ function inject (bot) {
     await diggingTask.promise
   }
 
-  // A user abort sends face DOWN like vanilla stopDestroyBlock
+  // A user abort must carry face DOWN
   function stopDigging () {
     if (bot.targetDigBlock) abortDigging(0)
   }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -841,8 +841,8 @@ function inject (bot) {
   }
 
   function attack (target, swing = true) {
-    // The server kicks (multiplayer.disconnect.invalid_entity_attacked) for
-    // an attack on the player itself, an item or an experience orb
+    // The server kicks a client that attacks itself, an item or an experience orb
+    // (multiplayer.disconnect.invalid_entity_attacked)
     if (target.id === bot.entity.id || target.name?.toLowerCase() === 'item' || target.name === 'experience_orb') {
       throw new Error(`attack: cannot attack ${target.name} entity ${target.id}`)
     }
@@ -893,8 +893,8 @@ function inject (bot) {
       return
     }
     if (bot.supportFeature('newPlayerInputPacket')) {
-      // The server dismounts a riding player whose shift key is down
-      // (Player.rideTick); player_input's jump flag is never read for this
+      // Only the shift key in player_input dismounts (Player.rideTick); the jump
+      // flag is never read for this
       bot.setControlState('sneak', true)
       try {
         await bot.waitForTicks(1)

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -836,8 +836,7 @@ function inject (bot) {
   }
 
   function useOn (target) {
-    // TODO: check if not crouching will make make this action always use the item
-    useEntity(target, 0)
+    bot._interactEntity(target, bot._entityHitVector(target))
   }
 
   function attack (target, swing = true) {
@@ -851,9 +850,9 @@ function inject (bot) {
       if (swing) {
         swingArm()
       }
-      useEntity(target, 1)
+      attackEntity(target)
     } else {
-      useEntity(target, 1)
+      attackEntity(target)
       if (swing) {
         swingArm()
       }
@@ -861,8 +860,7 @@ function inject (bot) {
   }
 
   function mount (target) {
-    // TODO: check if crouching will make make this action always mount
-    useEntity(target, 0)
+    bot._interactEntity(target, bot._entityHitVector(target))
   }
 
   function moveVehicle (left, forward) {
@@ -910,30 +908,19 @@ function inject (bot) {
     }
   }
 
-  function useEntity (target, leftClick, x, y, z) {
-    const sneaking = bot.getControlState('sneak')
-    if (leftClick && bot.supportFeature('attackUsesOwnPacket')) {
+  // An attack carries no hit location, only the sneak state; 26.1 moved it to its own packet.
+  function attackEntity (target) {
+    if (bot.supportFeature('attackUsesOwnPacket')) {
       bot._client.write('attack', {
         entityId: target.id
       })
-    } else if (x && y && z) {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        x,
-        y,
-        z,
-        sneaking,
-        location: new Vec3(x, y, z)
-      })
-    } else {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        sneaking,
-        location: new Vec3(0, 0, 0)
-      })
+      return
     }
+    bot._client.write('use_entity', {
+      target: target.id,
+      mouse: 1,
+      sneaking: bot.getControlState('sneak')
+    })
   }
 
   function fetchEntity (id) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -887,23 +887,26 @@ function inject (bot) {
     }
   }
 
-  function dismount () {
-    if (bot.vehicle) {
-      if (bot.supportFeature('newPlayerInputPacket')) {
-        bot._client.write('player_input', {
-          inputs: {
-            jump: true
-          }
-        })
-      } else {
-        bot._client.write('steer_vehicle', {
-          sideways: 0.0,
-          forward: 0.0,
-          jump: 0x02
-        })
+  async function dismount () {
+    if (!bot.vehicle) {
+      bot.emit('error', new Error('dismount: not mounted'))
+      return
+    }
+    if (bot.supportFeature('newPlayerInputPacket')) {
+      // The server dismounts a riding player whose shift key is down
+      // (Player.rideTick); player_input's jump flag is never read for this
+      bot.setControlState('sneak', true)
+      try {
+        await bot.waitForTicks(1)
+      } finally {
+        bot.setControlState('sneak', false)
       }
     } else {
-      bot.emit('error', new Error('dismount: not mounted'))
+      bot._client.write('steer_vehicle', {
+        sideways: 0.0,
+        forward: 0.0,
+        jump: 0x02 // unmount flag
+      })
     }
   }
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -841,6 +841,11 @@ function inject (bot) {
   }
 
   function attack (target, swing = true) {
+    // The server kicks (multiplayer.disconnect.invalid_entity_attacked) for
+    // an attack on the player itself, an item or an experience orb
+    if (target.id === bot.entity.id || target.name?.toLowerCase() === 'item' || target.name === 'experience_orb') {
+      throw new Error(`attack: cannot attack ${target.name} entity ${target.id}`)
+    }
     // arm animation comes before the use_entity packet on 1.8
     if (bot.supportFeature('armAnimationBeforeUse')) {
       if (swing) {

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -123,7 +123,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { action: 0 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -81,7 +81,7 @@ function inject (bot) {
       })
     }
 
-    // Vanilla swings after the use_item_on succeeds
+    // The swing must follow use_item_on
     if (options.swingArm) {
       bot.swingArm(options.swingArm, options.showHand)
     }

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -39,10 +39,6 @@ function inject (bot) {
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
 
-    if (options.swingArm) {
-      bot.swingArm(options.swingArm, options.showHand)
-    }
-
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {
         location: pos,
@@ -83,6 +79,11 @@ function inject (bot) {
         sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
+    }
+
+    // Vanilla swings after the use_item_on succeeds
+    if (options.swingArm) {
+      bot.swingArm(options.swingArm, options.showHand)
     }
 
     return pos

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -80,7 +80,7 @@ function inject (bot) {
         cursorY: dy,
         cursorZ: dz,
         insideBlock: false,
-        sequence: 0, // 1.19.0
+        sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -244,29 +244,34 @@ function inject (bot, { hideErrors }) {
   }
 
   async function activateEntity (entity) {
-    // TODO: tell the server that we are not sneaking while doing this
-    await bot.lookAt(entity.position.offset(0, 1, 0), false)
-    bot._client.write('use_entity', {
-      target: entity.id,
-      mouse: 0, // interact with entity
-      sneaking: false,
-      hand: 0, // interact with the main hand
-      location: new Vec3(0, 0, 0)
-    })
+    const hit = new Vec3(0, (entity.height ?? 0) / 2, 0)
+    await bot.lookAt(entity.position.plus(hit), false)
+    interactEntity(entity, hit)
   }
 
   async function activateEntityAt (entity, position) {
-    // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(position, false)
+    interactEntity(entity, position.minus(entity.position))
+  }
+
+  // Vanilla right click: interact_at with the hit point relative to the
+  // entity, followed by interact when the first is not consumed
+  function interactEntity (entity, hit) {
+    const sneaking = bot.getControlState('sneak')
     bot._client.write('use_entity', {
       target: entity.id,
-      mouse: 2, // interact with entity at
-      sneaking: false,
-      hand: 0, // interact with the main hand
-      x: position.x - entity.position.x,
-      y: position.y - entity.position.y,
-      z: position.z - entity.position.z,
-      location: position.subtract(entity.position)
+      mouse: 2, // interact at
+      x: hit.x,
+      y: hit.y,
+      z: hit.z,
+      hand: 0, // main hand
+      sneaking
+    })
+    bot._client.write('use_entity', {
+      target: entity.id,
+      mouse: 0, // interact
+      hand: 0, // main hand
+      sneaking
     })
   }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -257,10 +257,21 @@ function inject (bot, { hideErrors }) {
     interactEntity(entity, position.minus(entity.position))
   }
 
-  // interact_at (hit point relative to the entity) must precede interact, and
-  // both must carry the same sneak state
+  // 26.1+ has a single interact packet carrying the hit point; earlier
+  // versions send interact_at (hit point relative to the entity) followed by
+  // interact, and both must carry the same sneak state
+  const useEntityHasLocation = bot.registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
   function interactEntity (entity, hit) {
     const sneaking = bot.getControlState('sneak')
+    if (useEntityHasLocation) {
+      bot._client.write('use_entity', {
+        target: entity.id,
+        hand: 0, // main hand
+        location: hit,
+        sneaking
+      })
+      return
+    }
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 2, // interact at

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -117,7 +117,7 @@ function inject (bot, { hideErrors }) {
   }
 
   function activateItem (offHand = false) {
-    // Vanilla only sends use_item for a non-empty hand
+    // use_item must not be sent for an empty hand
     if (!(offHand ? bot.inventory.slots[45] : bot.heldItem)) return
     bot.usingHeldItem = true
 
@@ -195,7 +195,7 @@ function inject (bot, { hideErrors }) {
   async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
-    // Default to the centre of the clicked face, where the crosshair hits
+    // The cursor must lie on the clicked face
     cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
@@ -257,8 +257,8 @@ function inject (bot, { hideErrors }) {
     interactEntity(entity, position.minus(entity.position))
   }
 
-  // Vanilla right click: interact_at with the hit point relative to the
-  // entity, followed by interact when the first is not consumed
+  // interact_at (hit point relative to the entity) must precede interact, and
+  // both must carry the same sneak state
   function interactEntity (entity, hit) {
     const sneaking = bot.getControlState('sneak')
     bot._client.write('use_entity', {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -246,10 +246,30 @@ function inject (bot, { hideErrors }) {
     bot.swingArm()
   }
 
+  // Where the line from the eye to the entity's middle enters its bounding box, relative to the
+  // entity. Falls back to the middle itself for an entity of unknown size.
+  function hitVector (entity) {
+    const middle = new Vec3(0, (entity.height ?? 0) / 2, 0)
+    const width = entity.width ?? 0
+    const height = entity.height ?? 0
+    if (width <= 0 || height <= 0) return middle
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0).minus(entity.position)
+    const dir = middle.minus(eye)
+    const half = width / 2
+    let near = 0
+    for (const [from, to, o, d] of [[-half, half, eye.x, dir.x], [0, height, eye.y, dir.y], [-half, half, eye.z, dir.z]]) {
+      if (d === 0) continue
+      const t1 = (from - o) / d
+      const t2 = (to - o) / d
+      near = Math.max(near, Math.min(t1, t2))
+    }
+    if (!(near > 0) || near > 1) return middle
+    return eye.plus(dir.scaled(near))
+  }
+
   async function activateEntity (entity) {
-    const hit = new Vec3(0, (entity.height ?? 0) / 2, 0)
-    await bot.lookAt(entity.position.plus(hit), false)
-    interactEntity(entity, hit)
+    await bot.lookAt(entity.position.offset(0, (entity.height ?? 0) / 2, 0), false)
+    interactEntity(entity, hitVector(entity))
   }
 
   async function activateEntityAt (entity, position) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -27,7 +27,6 @@ function inject (bot, { hideErrors }) {
   const windows = require('prismarine-windows')(bot.version)
 
   let eatingTask = createDoneTask()
-  let sequence = 0
 
   let nextActionNumber = 0 // < 1.17
   let stateId = -1
@@ -119,7 +118,6 @@ function inject (bot, { hideErrors }) {
 
   function activateItem (offHand = false) {
     bot.usingHeldItem = true
-    sequence++
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
       bot._client.write('block_place', {
@@ -133,7 +131,7 @@ function inject (bot, { hideErrors }) {
     } else if (bot.supportFeature('useItemWithOwnPacket')) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
-        sequence,
+        sequence: bot._nextSequence(),
         rotation: {
           x: toNotchianYaw(bot.entity.yaw),
           y: toNotchianPitch(bot.entity.pitch)
@@ -236,7 +234,7 @@ function inject (bot, { hideErrors }) {
         cursorY: cursorPos.y,
         cursorZ: cursorPos.z,
         insideBlock: false,
-        sequence: 0, // 1.19.0+
+        sequence: bot._nextSequence(), // 1.19.0+
         worldBorderHit: false // 1.21.3+
       })
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -117,6 +117,8 @@ function inject (bot, { hideErrors }) {
   }
 
   function activateItem (offHand = false) {
+    // Vanilla only sends use_item for a non-empty hand
+    if (!(offHand ? bot.inventory.slots[45] : bot.heldItem)) return
     bot.usingHeldItem = true
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
@@ -193,7 +195,8 @@ function inject (bot, { hideErrors }) {
   async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
-    cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
+    // Default to the centre of the clicked face, where the crosshair hits
+    cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
     // place block message

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -936,6 +936,8 @@ function inject (bot, { hideErrors }) {
   bot.deactivateItem = deactivateItem
 
   // not really in the public API
+  bot._interactEntity = interactEntity
+  bot._entityHitVector = hitVector
   bot.clickWindow = clickWindow
   bot.putSelectedItemRange = putSelectedItemRange
   bot.putAway = putAway

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -280,13 +280,17 @@ function inject (bot, { hideErrors }) {
   // 26.1+ has a single interact packet carrying the hit point; earlier
   // versions send interact_at (hit point relative to the entity) followed by
   // interact, and both must carry the same sneak state
-  const useEntityHasLocation = bot.registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
+  const useEntityFields = bot.registry.protocol.play.toServer.types.packet_use_entity[1]
+  const useEntityHasLocation = useEntityFields.some(field => field.name === 'location')
+  // 26.1 declares the hand as a mapper; every earlier version takes the id.
+  const handType = useEntityFields.find(field => field.name === 'hand')?.type
+  const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
   function interactEntity (entity, hit) {
     const sneaking = bot.getControlState('sneak')
     if (useEntityHasLocation) {
       bot._client.write('use_entity', {
         target: entity.id,
-        hand: 0, // main hand
+        hand: mainHand,
         location: hit,
         sneaking
       })
@@ -298,13 +302,13 @@ function inject (bot, { hideErrors }) {
       x: hit.x,
       y: hit.y,
       z: hit.z,
-      hand: 0, // main hand
+      hand: mainHand,
       sneaking
     })
     bot._client.write('use_entity', {
       target: entity.id,
       mouse: 0, // interact
-      hand: 0, // main hand
+      hand: mainHand,
       sneaking
     })
   }

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -11,7 +11,12 @@ function inject (bot) {
     SUCCESSFULLY_LOADED: 0,
     DECLINED: 1,
     FAILED_DOWNLOAD: 2,
-    ACCEPTED: 3
+    ACCEPTED: 3,
+    // 1.20.3+ (added together with the pack UUID)
+    DOWNLOADED: 4,
+    INVALID_URL: 5,
+    FAILED_RELOAD: 6,
+    DISCARDED: 7
   }
 
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
@@ -54,45 +59,27 @@ function inject (bot) {
     if (bot._client.state === 'configuration') acceptResourcePack()
   })
 
-  function acceptResourcePack () {
+  function sendResourcePackResult (result) {
+    const packet = { result }
     if (bot.supportFeature('resourcePackUsesHash')) {
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.ACCEPTED,
-        hash: latestHash
-      })
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED,
-        hash: latestHash
-      })
+      packet.hash = latestHash
     } else if (bot.supportFeature('resourcePackUsesUUID')) {
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.ACCEPTED
-      })
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
-      })
-    } else {
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.ACCEPTED
-      })
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
-      })
+      packet.uuid = latestUUID
     }
+    bot._client.write('resource_pack_receive', packet)
+  }
+
+  // Vanilla reports ACCEPTED, then DOWNLOADED (1.20.3+), then SUCCESSFULLY_LOADED
+  function acceptResourcePack () {
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.ACCEPTED)
+    if (bot.supportFeature('resourcePackUsesUUID')) {
+      sendResourcePackResult(TEXTURE_PACK_RESULTS.DOWNLOADED)
+    }
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED)
   }
 
   function denyResourcePack () {
-    if (bot.supportFeature('resourcePackUsesUUID')) {
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.DECLINED
-      })
-    }
-    bot._client.write('resource_pack_receive', {
-      result: TEXTURE_PACK_RESULTS.DECLINED
-    })
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.DECLINED)
   }
 
   bot.acceptResourcePack = acceptResourcePack

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -12,7 +12,7 @@ function inject (bot) {
     DECLINED: 1,
     FAILED_DOWNLOAD: 2,
     ACCEPTED: 3,
-    // 1.20.3+ (added together with the pack UUID)
+    // 1.20.3+
     DOWNLOADED: 4,
     INVALID_URL: 5,
     FAILED_RELOAD: 6,
@@ -69,7 +69,7 @@ function inject (bot) {
     bot._client.write('resource_pack_receive', packet)
   }
 
-  // Vanilla reports ACCEPTED, then DOWNLOADED (1.20.3+), then SUCCESSFULLY_LOADED
+  // Results must be sent in the order ACCEPTED, DOWNLOADED (1.20.3+), SUCCESSFULLY_LOADED
   function acceptResourcePack () {
     sendResourcePackResult(TEXTURE_PACK_RESULTS.ACCEPTED)
     if (bot.supportFeature('resourcePackUsesUUID')) {

--- a/lib/plugins/sequence.js
+++ b/lib/plugins/sequence.js
@@ -1,0 +1,15 @@
+module.exports = inject
+
+// Block prediction sequence shared by dig start/stop, use_item_on and use_item
+// (vanilla BlockStatePredictionHandler): pre-incremented, so the first value
+// sent is 1. Abort / release / drop actions send 0 and do not consume a value.
+function inject (bot) {
+  const hasSequence = bot.registry.isNewerOrEqualTo('1.19')
+  let sequence = 0
+
+  bot._nextSequence = () => {
+    if (!hasSequence) return 0
+    sequence++
+    return sequence
+  }
+}

--- a/lib/plugins/sequence.js
+++ b/lib/plugins/sequence.js
@@ -1,8 +1,7 @@
 module.exports = inject
 
-// Block prediction sequence shared by dig start/stop, use_item_on and use_item
-// (vanilla BlockStatePredictionHandler): pre-incremented, so the first value
-// sent is 1. Abort / release / drop actions send 0 and do not consume a value.
+// One sequence counter for dig start/stop, use_item_on and use_item. Sent values
+// start at 1; abort, release and drop actions send 0 and must not consume a value.
 function inject (bot) {
   const hasSequence = bot.registry.isNewerOrEqualTo('1.19')
   let sequence = 0

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1589,6 +1589,34 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('entity interaction', () => {
+      it('activateEntity sends interact_at at mid height then interact, with the sneak state', (done) => {
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          bot.setControlState('sneak', true)
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.95 }
+          await bot.activateEntity(entity)
+          await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
+          try {
+            assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), [
+              { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: 0, sneaking: true },
+              { target: 7, mouse: 0, hand: 0, sneaking: true },
+              { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
+              { target: 7, mouse: 0, hand: 0, sneaking: true }
+            ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -557,6 +560,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           teleportId: 0
         }
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           bot.once('respawn', () => {
             assert.ok(bot.world.getColumn(0, 0) !== undefined)
             bot.once('respawn', () => {
@@ -1492,6 +1496,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
         const testYaw = 1.5
         const testPitch = -0.3
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           await client.write('login', bot.test.generateLoginPacket())
           await client.write('position', {
             x: 0,
@@ -1540,6 +1545,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       it('accepts with the vanilla status sequence', (done) => {
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1569,6 +1575,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       it('denies with a single DECLINED', (done) => {
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1595,6 +1602,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
     describe('entity interaction', () => {
       it('activateEntity sends interact_at at mid height then interact, with the sneak state', (done) => {
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1623,6 +1631,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
     describe('activateBlock', () => {
       it('defaults the cursor to the centre of the clicked face and swings after use_item_on', (done) => {
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1650,6 +1659,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('does nothing with an empty hand', (done) => {
         const Item = require('prismarine-item')(registry)
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1677,6 +1687,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('swings the arm after use_item_on', (done) => {
         const Item = require('prismarine-item')(registry)
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -1705,6 +1716,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       // Loads a chunk with two dirt blocks and returns the captured writes list
       async function setup (client, gameMode) {
+        await bot.test.pluginsLoaded
         const dirtId = registry.blocksByName.dirt.id
         const loaded = once(bot, 'chunkColumnLoad')
         client.write('login', bot.test.generateLoginPacket())
@@ -1793,6 +1805,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('rejects targets the server kicks for and attacks the rest', (done) => {
         server.on('playerJoin', async (client) => {
           try {
+            await bot.test.pluginsLoaded
             const loggedIn = once(bot, 'login')
             await client.write('login', bot.test.generateLoginPacket())
             await loggedIn
@@ -1817,6 +1830,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       it('holds sneak for one tick on 1.21.3+ and sends the steer_vehicle unmount flag before', (done) => {
         server.on('playerJoin', async (client) => {
           try {
+            await bot.test.pluginsLoaded
             const loggedIn = once(bot, 'login')
             await client.write('login', bot.test.generateLoginPacket())
             await loggedIn
@@ -1848,6 +1862,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
         }
         const Item = require('prismarine-item')(registry)
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1527,6 +1527,68 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('resource pack', () => {
+      function packetHas (name) {
+        const fields = registry.protocol?.play?.toServer?.types?.packet_resource_pack_receive?.[1] ??
+          registry.protocol?.configuration?.toServer?.types?.packet_resource_pack_receive?.[1]
+        return fields?.some(f => f.name === name)
+      }
+      const packUuid = '8ef4746b-93b7-3c32-9dcb-b375016c114d'
+
+      it('accepts with the vanilla status sequence', (done) => {
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          if (packetHas('uuid')) {
+            bot._client.emit('add_resource_pack', { uuid: packUuid, url: 'http://example.com/pack.zip', forced: false })
+          } else {
+            bot._client.emit('resource_pack_send', { url: 'http://example.com/pack.zip', hash: 'abc' })
+          }
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          bot.acceptResourcePack()
+          try {
+            assert.ok(writes.every(w => w.name === 'resource_pack_receive'))
+            assert.deepStrictEqual(writes.map(w => w.params.result), packetHas('uuid') ? [3, 4, 0] : [3, 0])
+            for (const { params } of writes) {
+              if (packetHas('uuid')) assert.ok(params.uuid, 'accept must carry the pack uuid')
+              else assert.strictEqual(params.uuid, undefined)
+              if (packetHas('hash')) assert.strictEqual(params.hash, 'abc')
+              else assert.strictEqual(params.hash, undefined)
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('denies with a single DECLINED', (done) => {
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          if (packetHas('uuid')) {
+            bot._client.emit('add_resource_pack', { uuid: packUuid, url: 'http://example.com/pack.zip', forced: false })
+          }
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          bot.denyResourcePack()
+          try {
+            assert.strictEqual(writes.length, 1)
+            assert.strictEqual(writes[0].name, 'resource_pack_receive')
+            assert.strictEqual(writes[0].params.result, 1)
+            if (packetHas('uuid')) assert.ok(writes[0].params.uuid, 'deny must carry the pack uuid')
+            else assert.strictEqual(writes[0].params.uuid, undefined)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1608,7 +1608,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await loggedIn
           bot.lookAt = async () => {}
           const writes = []
-          // serializing catches params that do not match this version's packet shape
+          // Every write must match this version's packet shape.
           bot._client.write = (name, params) => {
             bot._client.serializer.createPacketBuffer({ name, params })
             writes.push({ name, params })
@@ -1753,7 +1753,6 @@ for (const supportedVersion of mineflayer.testedVersions) {
       // Sequence value expected for the nth prediction packet
       const seq = n => hasSequence ? n : 0
 
-      // Loads a chunk with two dirt blocks and returns the captured writes list
       async function setup (client, gameMode) {
         await bot.test.pluginsLoaded
         const dirtId = registry.blocksByName.dirt.id

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1637,6 +1637,39 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('useOn and mount send the same interact pair as activateEntity', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          bot.useOn(entity)
+          bot.mount(entity)
+          try {
+            const useEntityHasLocation = registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
+            // One right click is interact_at then interact before 26.1, and a single located
+            // interact from 26.1 on; either way both actions send the same thing.
+            const perClick = useEntityHasLocation ? 1 : 2
+            const sent = writes.filter(w => w.name === 'use_entity')
+            assert.strictEqual(sent.length, 2 * perClick)
+            assert.deepStrictEqual(sent.slice(0, perClick), sent.slice(perClick))
+            const hit = sent[0].params.location ?? vec3(sent[0].params.x, sent[0].params.y, sent[0].params.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(sent.every(w => w.params.mouse !== 1), 'a right click never sends the attack action')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
       it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
         server.on('playerJoin', async (client) => {
           await bot.test.pluginsLoaded

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1527,6 +1527,43 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('block prediction sequence', () => {
+      it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
+        const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]
+        if (!useItemFields?.some(f => f.name === 'sequence')) {
+          this.skip()
+          return
+        }
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push([name, params.sequence]) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+
+          bot.activateItem()
+          bot.deactivateItem()
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore' })
+          bot.activateItem()
+
+          try {
+            assert.deepStrictEqual(writes, [
+              ['use_item', 1],
+              ['block_dig', 0],
+              ['block_place', 2],
+              ['use_item', 3]
+            ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('onceWithCleanup', () => {
       it('rejects instead of throwing out of emit when checkCondition throws', async () => {
         // A condition that throws used to unwind whatever was emitting. For a

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1522,6 +1522,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await sleep(100)
           bot.entity.yaw = testYaw
           bot.entity.pitch = testPitch
+          const Item = require('prismarine-item')(registry)
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
           bot.activateItem()
         })
       })
@@ -1609,6 +1612,59 @@ for (const supportedVersion of mineflayer.testedVersions) {
               { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
               { target: 7, mouse: 0, hand: 0, sneaking: true }
             ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
+    describe('activateBlock', () => {
+      it('defaults the cursor to the centre of the clicked face and swings after use_item_on', (done) => {
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          const block = { position: vec3(1, 65, 1) }
+          await bot.activateBlock(block)
+          await bot.activateBlock(block, vec3(-1, 0, 0))
+          try {
+            const scale = bot.supportFeature('blockPlaceHasHandAndFloatCursor') || bot.supportFeature('blockPlaceHasInsideBlock') ? 1 : 16
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_place', 'arm_animation', 'block_place', 'arm_animation'])
+            const cursor = ({ params }) => [params.cursorX / scale, params.cursorY / scale, params.cursorZ / scale, params.direction]
+            assert.deepStrictEqual(cursor(writes[0]), [0.5, 1, 0.5, 1])
+            assert.deepStrictEqual(cursor(writes[2]), [0, 0.5, 0.5, 4])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
+    describe('activateItem', () => {
+      it('does nothing with an empty hand', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.activateItem()
+          bot.activateItem(true)
+          try {
+            assert.deepStrictEqual(writes, [])
+            assert.strictEqual(bot.usingHeldItem, false)
+            bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+            bot.activateItem()
+            assert.deepStrictEqual(writes, [bot.supportFeature('useItemWithOwnPacket') ? 'use_item' : 'block_place'])
+            assert.strictEqual(bot.usingHeldItem, true)
             done()
           } catch (err) {
             done(err)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1600,7 +1600,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
 
     describe('entity interaction', () => {
-      it('activateEntity sends interact_at at mid height then interact, with the sneak state', (done) => {
+      it('activateEntity sends the vanilla interact packets at mid height, with the sneak state', (done) => {
         server.on('playerJoin', async (client) => {
           await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
@@ -1608,18 +1608,28 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await loggedIn
           bot.lookAt = async () => {}
           const writes = []
-          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          // serializing catches params that do not match this version's packet shape
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
           bot.setControlState('sneak', true)
           const entity = { id: 7, position: vec3(3, 64, 3), height: 1.95 }
           await bot.activateEntity(entity)
           await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
           try {
-            assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), [
-              { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: 0, sneaking: true },
-              { target: 7, mouse: 0, hand: 0, sneaking: true },
-              { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
-              { target: 7, mouse: 0, hand: 0, sneaking: true }
-            ])
+            const useEntityHasLocation = registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
+            assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), useEntityHasLocation
+              ? [
+                  { target: 7, hand: 0, location: vec3(0, 0.975, 0), sneaking: true },
+                  { target: 7, hand: 0, location: vec3(0.5, 1, 0), sneaking: true }
+                ]
+              : [
+                  { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: 0, sneaking: true },
+                  { target: 7, mouse: 0, hand: 0, sneaking: true },
+                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
+                  { target: 7, mouse: 0, hand: 0, sneaking: true }
+                ])
             done()
           } catch (err) {
             done(err)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1789,6 +1789,30 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('attack', () => {
+      it('rejects targets the server kicks for and attacks the rest', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const loggedIn = once(bot, 'login')
+            await client.write('login', bot.test.generateLoginPacket())
+            await loggedIn
+            const writes = []
+            bot._client.write = (name, params) => { writes.push(name) }
+            assert.throws(() => bot.attack(bot.entity), /cannot attack/)
+            assert.throws(() => bot.attack({ id: 11, name: 'item' }), /cannot attack/)
+            assert.throws(() => bot.attack({ id: 12, name: 'experience_orb' }), /cannot attack/)
+            assert.deepStrictEqual(writes, [])
+            bot.attack({ id: 13, name: 'zombie' })
+            assert.strictEqual(writes.length, 2)
+            assert.ok(writes.includes('arm_animation'))
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1813,6 +1813,32 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('dismount', () => {
+      it('holds sneak for one tick on 1.21.3+ and sends the steer_vehicle unmount flag before', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const loggedIn = once(bot, 'login')
+            await client.write('login', bot.test.generateLoginPacket())
+            await loggedIn
+            const events = []
+            bot.setControlState = (control, state) => { events.push([control, state]) }
+            bot.waitForTicks = async (ticks) => { events.push(['tick', ticks]) }
+            bot._client.write = (name, params) => { events.push([name, params]) }
+            bot.vehicle = { id: 21 }
+            await bot.dismount()
+            if (bot.supportFeature('newPlayerInputPacket')) {
+              assert.deepStrictEqual(events, [['sneak', true], ['tick', 1], ['sneak', false]])
+            } else {
+              assert.deepStrictEqual(events, [['steer_vehicle', { sideways: 0, forward: 0, jump: 2 }]])
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1695,6 +1695,100 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('digging', () => {
+      const blockPos = vec3(1, 65, 1)
+      const otherPos = vec3(2, 65, 1)
+      const BlockFace = require('prismarine-world').iterators.BlockFace
+      const hasSequence = registry.protocol?.play?.toServer?.types?.packet_block_dig?.[1]?.some(f => f.name === 'sequence')
+      // Sequence value expected for the nth prediction packet
+      const seq = n => hasSequence ? n : 0
+
+      // Loads a chunk with two dirt blocks and returns the captured writes list
+      async function setup (client, gameMode) {
+        const dirtId = registry.blocksByName.dirt.id
+        const loaded = once(bot, 'chunkColumnLoad')
+        client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(blockPos, dirtId)
+        chunk.setBlockType(otherPos, dirtId)
+        client.write('map_chunk', generateChunkPacket(chunk))
+        await loaded
+        bot.entity.position = vec3(1.5, 66, 1.5)
+        bot.entity.eyeHeight = 1.62
+        bot.entity.onGround = true
+        bot.entity.effects = {}
+        bot.game.gameMode = gameMode
+        const writes = []
+        bot._client.write = (name, params) => { writes.push({ name, params }) }
+        return writes
+      }
+      const digPackets = writes => writes.filter(w => w.name === 'block_dig').map(({ params }) => [params.status, params.face, params.sequence])
+
+      it('instant break sends only START_DESTROY_BLOCK and resolves on the block update', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'creative')
+            const block = bot.blockAt(blockPos)
+            assert.strictEqual(bot.digTime(block), 0)
+            const completed = once(bot, 'diggingCompleted')
+            await bot.dig(block, 'ignore')
+            await completed
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_dig', 'arm_animation'])
+            assert.deepStrictEqual(digPackets(writes), [[0, BlockFace.TOP, seq(1)]])
+            assert.strictEqual(bot.blockAt(blockPos).type, 0)
+            assert.strictEqual(bot.targetDigBlock, null)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('swings every physics tick while digging', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'survival')
+            const block = bot.blockAt(blockPos)
+            assert.ok(bot.digTime(block) > 0)
+            const dig = bot.dig(block, 'ignore')
+            bot.emit('physicsTick')
+            bot.emit('physicsTick')
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_dig', 'arm_animation', 'arm_animation', 'arm_animation'])
+            await dig
+            writes.length = 0
+            bot.emit('physicsTick')
+            assert.deepStrictEqual(writes, [])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('aborts with face DOWN from stopDigging and with the new face on a retarget', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'survival')
+            const first = bot.dig(bot.blockAt(blockPos), true, vec3(-1, 0, 0))
+            const second = bot.dig(bot.blockAt(otherPos), true, vec3(0, 0, 1))
+            await assert.rejects(first, /Digging aborted/)
+            bot.stopDigging()
+            await assert.rejects(second, /Digging aborted/)
+            assert.deepStrictEqual(digPackets(writes), [
+              [0, BlockFace.WEST, seq(1)],
+              [1, BlockFace.SOUTH, 0],
+              [0, BlockFace.SOUTH, seq(2)],
+              [1, BlockFace.BOTTOM, 0]
+            ])
+            assert.strictEqual(bot.targetDigBlock, null)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1673,6 +1673,28 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('generic place', () => {
+      it('swings the arm after use_item_on', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore', swingArm: 'right' })
+          try {
+            assert.deepStrictEqual(writes, ['block_place', 'arm_animation'])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('block prediction sequence', () => {
       it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
         const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1636,6 +1636,35 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
         })
       })
+
+      it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          // Straight along +x, so the ray enters the box at half its width on the near side.
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          await bot.activateEntity(entity)
+          try {
+            const first = writes.find(w => w.name === 'use_entity').params
+            const hit = first.location ?? vec3(first.x, first.y, first.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
+            assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
     })
 
     describe('activateBlock', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1618,17 +1618,20 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await bot.activateEntity(entity)
           await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
           try {
-            const useEntityHasLocation = registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
+            const fields = registry.protocol.play.toServer.types.packet_use_entity[1]
+            const useEntityHasLocation = fields.some(field => field.name === 'location')
+            const handType = fields.find(field => field.name === 'hand')?.type
+            const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
             assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), useEntityHasLocation
               ? [
-                  { target: 7, hand: 0, location: vec3(0, 0.975, 0), sneaking: true },
-                  { target: 7, hand: 0, location: vec3(0.5, 1, 0), sneaking: true }
+                  { target: 7, hand: mainHand, location: vec3(0, 0.975, 0), sneaking: true },
+                  { target: 7, hand: mainHand, location: vec3(0.5, 1, 0), sneaking: true }
                 ]
               : [
-                  { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: 0, sneaking: true },
-                  { target: 7, mouse: 0, hand: 0, sneaking: true },
-                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
-                  { target: 7, mouse: 0, hand: 0, sneaking: true }
+                  { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 0, hand: mainHand, sneaking: true }
                 ])
             done()
           } catch (err) {


### PR DESCRIPTION
Audit of the interaction plugins against the vanilla 1.21.4 client (`MultiPlayerGameMode`, `Minecraft.startUseItem/startAttack/continueAttack`, `BlockStatePredictionHandler`, `DownloadedPackSource`) and the server's handlers. One commit per fix:

- **Entity activation** (`activateEntity`, `activateEntityAt`): send `use_entity` interact_at followed by interact, as `startUseItem` does, and with the bot's real sneak state instead of `sneaking: false` (the server applies `setShiftKeyDown(packet.isUsingSecondaryAction())`, so the old value silently un-sneaked the player).
- **`bot.useOn` and `bot.mount`** sent a lone interact with the hit location fixed at the entity's feet; a right click on an entity is always interact_at then interact. Both now go through the same sender as `activateEntity`, and `use_entity` no longer has a second, divergent implementation in `entities.js`.
- **`bot.attack`** throws for the bot itself, item entities and experience orbs: a vanilla client can never target them and the server kicks with `multiplayer.disconnect.invalid_entity_attacked`.
- **`bot.dismount`** on 1.21.3+ sent `player_input { jump }`, which the server never reads; vanilla dismounts through the shift key (`Player.rideTick`). It now holds the sneak control for one physics tick (returns a Promise; older versions keep `steer_vehicle`).
- **Placing**: `use_item_on` first, then the arm swing (vanilla swings only after the use succeeded).
- **Digging**: swing every physics tick while destroying (vanilla `continueAttack`), send only START for instant breaks (creative / zero-hardness; vanilla never sends STOP there), and a user-initiated `stopDigging` aborts with face DOWN like `stopDestroyBlock`, while a retarget keeps the new face.
- **Sequence numbers**: one pre-incremented counter shared by dig start/stop, `use_item_on` and `use_item` (`BlockStatePredictionHandler`), first value 1; abort/release use 0. Previously `block_dig` omitted it, `block_place` hardcoded 0 and `use_item` had its own counter.
- **`activateBlock`** defaults the cursor to the centre of the clicked face (the old (0.5, 0.5, 0.5) is inside the block, impossible for a real client); **`activateItem`** no-ops with an empty hand like vanilla.
- **Resource packs**: vanilla reports ACCEPTED → DOWNLOADED (1.20.3+) → SUCCESSFULLY_LOADED; the missing 1.20.3+ statuses are added. `denyResourcePack` wrote a second DECLINED without the pack UUID after the UUID branch, which throws a serialization error on 1.20.3+; it now sends one.
- `game.js` win-game respawn used `action` where the field is `actionId`.

Tests added in `internalTest.js` for the packet sequences (entity interaction, digging incl. instant break and abort faces, placement order, sequence counter, resource pack statuses, attack rejection). Docs updated for `bot.attack` and `bot.dismount`.