### PR TITLE
test(nether): let retries pass by respecting the player's portal cooldown

### DIFF
--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -13,11 +13,25 @@ module.exports = () => async (bot) => {
   }
   assert.notStrictEqual(signItem, null)
 
-  // A portal's link goes inert after a failed attempt at the same spot, so
-  // each retry must use a fresh location or it is guaranteed to time out.
+  // A player is on portal cooldown for 10 ticks after a dimension change, and
+  // the server refreshes that cooldown every tick the player stands in any
+  // portal, so the bot must be out of every portal for more than 10 ticks
+  // before it steps into the next one. update_time arrives every 20 server
+  // ticks, so two of them guarantee at least 20 ticks have passed.
+  const awaitPortalCooldown = async () => {
+    await onceWithCleanup(bot, 'time', { timeout: 10000 })
+    await onceWithCleanup(bot, 'time', { timeout: 10000 })
+  }
+
+  // A failed attempt leaves its portal standing until the next reset's fills
+  // remove it, and the reset teleports the bot to the origin first. Portals
+  // therefore never go at the origin, and stay inside the fill area so the
+  // reset removes them.
+  const spots = [new Vec3(4, 0, 0), new Vec3(-4, 0, 0), new Vec3(0, 0, 4), new Vec3(0, 0, -4)]
   bot.test.netherAttempts ??= 0
-  const attempt = ++bot.test.netherAttempts
-  await bot.test.teleport(new Vec3((attempt - 1) * 4, bot.test.groundY, 0))
+  const spot = spots[bot.test.netherAttempts++ % spots.length]
+  await bot.test.teleport(new Vec3(spot.x, bot.test.groundY, spot.z))
+  await awaitPortalCooldown()
   bot.chat(`/setblock ~ ~ ~ ${portalName}`)
   await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
   bot.test.sayEverywhere('/tp 0 128 0')
@@ -59,9 +73,9 @@ module.exports = () => async (bot) => {
     assert.notStrictEqual(updated.blockEntity, undefined)
   }
 
+  await awaitPortalCooldown()
   bot.chat(`/setblock ~ ~ ~ ${portalName}`)
   await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
-  // The respawn lands at origin, so the next reset skips its chunk wait; the
-  // overworld column must be back before a later test reads blocks from it.
+  // The overworld column must be back before a later test reads blocks from it.
   await bot.waitForChunksToLoad()
 }

--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -13,13 +13,10 @@ module.exports = () => async (bot) => {
   }
   assert.notStrictEqual(signItem, null)
 
-  // A player is on portal cooldown for 10 ticks after a dimension change, and
-  // the server refreshes that cooldown every tick the player stands in any
-  // portal, so the bot must be out of every portal for more than 10 ticks
-  // before it steps into the next one. update_time arrives every 20 server
-  // ticks, so two of them after the bot left a portal prove at least 20
-  // ticks have passed. Start the clock as soon as the bot is out of a portal
-  // and await it right before the next one so the wait overlaps other work.
+  // A dimension change puts the player on portal cooldown for 10 ticks, and the server
+  // refreshes that cooldown every tick the player stands in any portal, so the bot must be
+  // clear of every portal for more than 10 ticks before it enters the next one. update_time
+  // arrives every 20 server ticks, so two of them prove at least 20 ticks have passed.
   const portalCooldown = async () => {
     await onceWithCleanup(bot, 'time', { timeout: 10000 })
     await onceWithCleanup(bot, 'time', { timeout: 10000 })

--- a/test/externalTests/nether.js
+++ b/test/externalTests/nether.js
@@ -17,11 +17,15 @@ module.exports = () => async (bot) => {
   // the server refreshes that cooldown every tick the player stands in any
   // portal, so the bot must be out of every portal for more than 10 ticks
   // before it steps into the next one. update_time arrives every 20 server
-  // ticks, so two of them guarantee at least 20 ticks have passed.
-  const awaitPortalCooldown = async () => {
+  // ticks, so two of them after the bot left a portal prove at least 20
+  // ticks have passed. Start the clock as soon as the bot is out of a portal
+  // and await it right before the next one so the wait overlaps other work.
+  const portalCooldown = async () => {
     await onceWithCleanup(bot, 'time', { timeout: 10000 })
     await onceWithCleanup(bot, 'time', { timeout: 10000 })
   }
+  // The reset left the bot on the origin, which never holds a portal.
+  let cooldown = portalCooldown()
 
   // A failed attempt leaves its portal standing until the next reset's fills
   // remove it, and the reset teleports the bot to the origin first. Portals
@@ -31,12 +35,14 @@ module.exports = () => async (bot) => {
   bot.test.netherAttempts ??= 0
   const spot = spots[bot.test.netherAttempts++ % spots.length]
   await bot.test.teleport(new Vec3(spot.x, bot.test.groundY, spot.z))
-  await awaitPortalCooldown()
+  await cooldown
   bot.chat(`/setblock ~ ~ ~ ${portalName}`)
   await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
   bot.test.sayEverywhere('/tp 0 128 0')
 
   await once(bot, 'forcedMove')
+  // The teleport took the bot out of the exit portal.
+  cooldown = portalCooldown()
   await bot.waitForChunksToLoad()
 
   // Poll until the block below is loaded and non-air before placing.
@@ -73,7 +79,7 @@ module.exports = () => async (bot) => {
     assert.notStrictEqual(updated.blockEntity, undefined)
   }
 
-  await awaitPortalCooldown()
+  await cooldown
   bot.chat(`/setblock ~ ~ ~ ${portalName}`)
   await onceWithCleanup(bot, 'spawn', { timeout: 30000 })
   // The overworld column must be back before a later test reads blocks from it.


### PR DESCRIPTION
## Problem

The external `nether` test's retries can never pass. Diagnosed from the 1.18.2 packet trace of [this run](https://github.com/PrismarineJS/mineflayer/actions/runs/34058360860/job/101554334366) on #4064, where all four attempts timed out.

- `Player.getDimensionChangingDelay()` is 10 ticks, and `Entity.handleInsidePortal` resets the cooldown to 10 every tick the player stands in **any** portal. The server checks that each tick on its own, without client packets.
- On a retry, the reset teleports the bot out of the previous portal and the test placed the next one under it one to three ticks later. The cooldown was refreshed forever, so the server never sent `respawn` and `spawn` never fired. Moving each retry to a fresh spot (the previous fix) does not change the timing, so it did not help.
- The first attempt used the origin, so the retry's reset teleport landed the bot inside the stale portal before the fills removed it, and the server bounced it straight back to the nether.

The first attempt in that run failed for an unrelated reason: nether generation stalled the server for 18s, and the 10s limit in `waitForChunksToLoad` ran out after the teleport to the nether roof. With working retries that is recoverable.

## Fix

- Wait for two `update_time` packets (at least 20 server ticks) out of any portal before each portal is placed, including the return trip.
- Place the portals on the four spots beside the origin, never at it, inside the area the reset's fills clear.

## Verification

Ran the 1.18.2 nether test locally with a temporary hook that throws right after the first attempt's `/tp 0 128 0` (the same state as the CI failure, bot in the nether). Before this change that retry times out; with it the retry passed in 5.4s.
