### PR TITLE
fix: drop the physics tick backlog after an event-loop stall instead of draining it

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -74,6 +74,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       catchupTicks++
       if (catchupTicks >= PHYSICS_CATCHUP_TICKS) break
     }
+    // Whole ticks past the cap are dropped, never replayed: the accumulator holds less than one tick here.
+    timeAccumulator %= PHYSICS_TIMESTEP
   }
 
   function tickPhysics (now) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -398,6 +398,40 @@ for (const supportedVersion of mineflayer.testedVersions) {
           done()
         })
       })
+      it('drops the tick backlog after an event-loop stall instead of draining it', (done) => {
+        server.on('playerJoin', async (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          const chunk = bot.test.buildChunk()
+          chunk.setBlockType(pos, goldId)
+          await client.write('map_chunk', generateChunkPacket(chunk))
+          await client.write('position', {
+            x: 1.5,
+            y: 66,
+            z: 1.5,
+            dx: 0,
+            dy: 0,
+            dz: 0,
+            pitch: 0,
+            yaw: 0,
+            teleportId: 1,
+            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+          })
+          await once(bot, 'physicsTick')
+          await sleep(300)
+          // No physics tick can run during the stall (30 ticks' worth).
+          const stallUntil = Date.now() + 1500
+          while (Date.now() < stallUntil) { /* busy wait */ }
+          let ticks = 0
+          const count = () => ticks++
+          bot.on('physicsTick', count)
+          await sleep(500)
+          bot.off('physicsTick', count)
+          // 10 ticks at 20 tps plus one burst of at most maxCatchupTicks (4).
+          assert.ok(ticks <= 18, `${ticks} physics ticks in the 500 ms after a 1.5 s stall`)
+          assert.ok(ticks >= 8, `only ${ticks} physics ticks in 500 ms`)
+          done()
+        })
+      })
       it('gravity + land on solid block + jump', (done) => {
         let y = 80
         let landed = false


### PR DESCRIPTION
Invariants of the physics loop:

- At most `maxCatchupTicks` (default 4) physics ticks run per timer interval.
- Whole ticks beyond that cap are dropped: `timeAccumulator` holds less than one tick when `doPhysics` returns.
- The tick rate after a stall is one capped burst, then 20 tps; a backlog is never replayed over later intervals.

Vanilla reference: `Minecraft.runTick` runs at most 10 of the ticks `DeltaTracker.advanceGameTime` reports, and that method keeps only the fractional residual.

Test (`physics › drops the tick backlog after an event-loop stall instead of draining it`): after a 1.5 s synchronous stall, the following 500 ms contain between 8 and 18 `physicsTick` events. Passes on every tested version with the change; fails on master.