### PR TITLE
fix: send held_item_slot only when the slot differs from the slot the server holds

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -709,9 +709,23 @@ function inject (bot, { hideErrors }) {
     confirmTransaction(packet.windowId, packet.action, packet.accepted)
   })
 
+  // Slot the server holds as this client's selection; 0 after every login
+  let carriedIndex = 0
+  // A serverbound held_item_slot goes out iff bot.quickBarSlot differs from
+  // carriedIndex, whichever side selected the slot
+  bot._ensureHasSentCarriedItem = () => {
+    if (bot.quickBarSlot === carriedIndex) return
+    carriedIndex = bot.quickBarSlot
+    bot._client.write('held_item_slot', { slotId: carriedIndex })
+  }
+  bot._client.on('login', () => { carriedIndex = 0 })
+  // A server-sent slot outside the hotbar is ignored
   bot._client.on('held_item_slot', (packet) => {
-    // held item change
-    bot.setQuickBarSlot(packet.slot)
+    if (packet.slot < 0 || packet.slot >= 9) return
+    const changed = packet.slot !== bot.quickBarSlot
+    bot.quickBarSlot = packet.slot
+    bot._ensureHasSentCarriedItem()
+    if (changed) updateHeldItem()
   })
 
   function prepareWindow (window) {

--- a/lib/plugins/simple_inventory.js
+++ b/lib/plugins/simple_inventory.js
@@ -53,9 +53,7 @@ function inject (bot) {
     assert.ok(slot < 9)
     if (bot.quickBarSlot === slot) return
     bot.quickBarSlot = slot
-    bot._client.write('held_item_slot', {
-      slotId: slot
-    })
+    bot._ensureHasSentCarriedItem()
     bot.updateHeldItem()
   }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1369,6 +1369,69 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('held_item_slot', () => {
+      function collectHeldItemSlots (client) {
+        const sent = []
+        client.on('packet', (data, meta) => {
+          if (meta.name === 'held_item_slot') sent.push(data.slotId)
+        })
+        return sent
+      }
+
+      it('applies a server-sent slot equal to the carried one without echoing it', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const sent = collectHeldItemSlots(client)
+            client.write('login', bot.test.generateLoginPacket())
+            client.write('held_item_slot', { slot: 0 })
+            await sleep(300)
+            assert.strictEqual(bot.quickBarSlot, 0)
+            assert.deepStrictEqual(sent, [])
+            bot.setQuickBarSlot(3)
+            await sleep(300)
+            assert.deepStrictEqual(sent, [3])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('sends a server-sent slot that differs from the carried one, once per login', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const sent = collectHeldItemSlots(client)
+            const changes = []
+            bot.on('heldItemChanged', () => changes.push(bot.quickBarSlot))
+            client.write('login', bot.test.generateLoginPacket())
+            client.write('held_item_slot', { slot: 3 })
+            await sleep(300)
+            assert.strictEqual(bot.quickBarSlot, 3)
+            assert.deepStrictEqual(sent, [3])
+            assert.deepStrictEqual(changes, [3])
+            client.write('held_item_slot', { slot: 3 })
+            bot.setQuickBarSlot(3)
+            await sleep(300)
+            assert.deepStrictEqual(sent, [3])
+            assert.deepStrictEqual(changes, [3])
+            client.write('login', bot.test.generateLoginPacket())
+            client.write('held_item_slot', { slot: 3 })
+            await sleep(300)
+            assert.deepStrictEqual(sent, [3, 3])
+            assert.deepStrictEqual(changes, [3])
+            client.write('held_item_slot', { slot: 0 })
+            await sleep(300)
+            assert.strictEqual(bot.quickBarSlot, 0)
+            assert.deepStrictEqual(sent, [3, 3, 0])
+            assert.deepStrictEqual(changes, [3, 0])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('windows', () => {
       const Item = require('prismarine-item')(supportedVersion)
       const pWindows = require('prismarine-windows')(supportedVersion)


### PR DESCRIPTION
Invariants of the held slot:

- A clientbound `held_item_slot` sets `bot.quickBarSlot` and emits `heldItemChanged` when the slot changes. A slot outside 0-8 is ignored.
- A serverbound `held_item_slot` is written iff `bot.quickBarSlot` differs from the slot the server last set or was last told, whichever side selected it. That record is 0 after every clientbound `login`.
- `bot.quickBarSlot` starts null on master, so the `held_item_slot 0` every server sends at login was echoed back; it is not any more. A server-sent slot that differs from the record is still answered, once.

Vanilla reference: `ClientPacketListener.handleSetHeldSlot` only assigns the selected slot (`Inventory.isHotbarSlot` gate); `MultiPlayerGameMode.ensureHasSentCarriedItem` writes `ServerboundSetCarriedItemPacket` on the next tick iff the selected slot differs from `carriedIndex`, and `handleLogin` builds a `MultiPlayerGameMode` whose `carriedIndex` starts at 0. 1.8.9 `PlayerControllerMP.syncCurrentPlayItem` / `NetHandlerPlayClient.handleHeldItemChange` are the same shape.

Tests (`held_item_slot`, every tested version): a server-sent slot equal to the carried one produces no serverbound packet and still sets `bot.quickBarSlot`; a differing one is sent once per login and again after a re-login; `bot.setQuickBarSlot` to the slot the server already holds sends nothing.
