### PR TITLE
fix: answer ping at the start of the next tick, before movement packets

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -139,10 +139,37 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
 
-  // mimic the vanilla 1.17 client to prevent anticheat kicks
+  // Pongs are written in ping order; each ping is answered exactly once.
+  // In the play state a pong is written only at the start of a physics tick,
+  // before every packet of that tick, or by the one-tick fallback timer.
+  // Outside the play state the pong is written immediately.
+  const pendingPongs = []
+  let pongTimer = null
+
+  function flushPongs () {
+    clearTimeout(pongTimer)
+    pongTimer = null
+    while (pendingPongs.length > 0) {
+      bot._client.write('pong', { id: pendingPongs.shift() })
+    }
+  }
+
   bot._client.on('ping', (data) => {
-    bot._client.write('pong', {
-      id: data.id
-    })
+    if (bot._client.state !== 'play') {
+      bot._client.write('pong', { id: data.id })
+      return
+    }
+    pendingPongs.push(data.id)
+    // A queued pong waits at most one tick (50 ms) for a physics tick.
+    if (pongTimer === null) pongTimer = setTimeout(flushPongs, 50)
+  })
+
+  // Must run before every other physicsTick listener.
+  bot.prependListener('physicsTick', flushPongs)
+
+  bot.on('end', () => {
+    clearTimeout(pongTimer)
+    pongTimer = null
+    pendingPongs.length = 0
   })
 }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -613,6 +613,95 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('pong is written at the next tick boundary, after the movement packet of the tick that received the ping', function (done) {
+        if (bot.supportFeature('transactionPacketExists')) {
+          this.skip()
+          return
+        }
+        const movementPackets = ['position', 'position_look', 'look', 'flying']
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), 41)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            client.write('position', {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            })
+            await once(bot, 'forcedMove')
+
+            // Falling takes a few ticks to leave the teleport height.
+            await bot.waitForTicks(4)
+
+            const seen = []
+            client.on('packet', (data, meta) => seen.push({ name: meta.name, data }))
+
+            // The ping is processed inside a tick: after the simulation, before
+            // the movement packet carrying this tick's position.
+            const { tickY, pingedAt } = await new Promise(resolve => {
+              bot.once('physicsTick', () => {
+                bot._client.emit('ping', { id: 123 })
+                resolve({ tickY: bot.entity.position.y, pingedAt: Date.now() })
+              })
+            })
+            assert.ok(tickY < 80, 'bot must be falling so every tick writes a movement packet')
+
+            const [pong] = await onceWithCleanup(client, 'pong', { timeout: 200 })
+            const pongedAt = Date.now()
+            assert.strictEqual(pong.id, 123)
+            assert.ok(pongedAt - pingedAt <= 200, `pong took ${pongedAt - pingedAt} ms`)
+
+            await sleep(100)
+            const pongs = seen.filter(p => p.name === 'pong')
+            assert.strictEqual(pongs.length, 1, 'each ping is answered exactly once')
+            const pongIndex = seen.indexOf(pongs[0])
+            const before = seen[pongIndex - 1]
+            assert.ok(before !== undefined, 'a movement packet precedes the pong')
+            assert.ok(movementPackets.includes(before.name), `packet before pong is ${before.name}`)
+            assert.strictEqual(before.data.y, tickY, 'the pong follows the movement packet of the tick that received the ping')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('pong is written within one tick when physics is not ticking', function (done) {
+        if (bot.supportFeature('transactionPacketExists')) {
+          this.skip()
+          return
+        }
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            await once(bot, 'login')
+            const pongs = []
+            client.on('pong', (data) => pongs.push(data))
+            const pingedAt = Date.now()
+            client.write('ping', { id: 123 })
+            const [pong] = await onceWithCleanup(client, 'pong', { timeout: 200 })
+            const pongedAt = Date.now()
+            assert.strictEqual(pong.id, 123)
+            assert.ok(pongedAt - pingedAt <= 200, `pong took ${pongedAt - pingedAt} ms`)
+            await sleep(100)
+            assert.strictEqual(pongs.length, 1, 'each ping is answered exactly once')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
       it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
         server.on('playerJoin', (client) => {
           const clicks = []


### PR DESCRIPTION
Invariants of the ping answer:

- In the play state a `pong` is written at the start of a physics tick, before that tick's movement packets.
- A ping is answered within one tick even when physics is not ticking.
- Pongs are written in ping order, one per ping.

Vanilla reference: `ClientPacketListener.handlePing` calls `PacketUtils.ensureRunningOnSameThread`, so the pong is written while `Minecraft.runTick` drains its task queue, before the tick loop that runs `LocalPlayer.tick` and `sendPosition`.

Tests (`pong is written ...`): with the bot falling, the pong follows the movement packet of the tick that received the ping and is answered once; with no chunk loaded it is still answered within one tick. Pass on every tested version.