### PR TITLE
fix: reset teams and scoreboards on every login

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1141,9 +1141,13 @@ Boolean, whether or not you are in bed.
 
 All scoreboards known to the bot in an object scoreboard name -> scoreboard.
 
+Reset on each login (every server switch on a proxy network); the object is kept and its entries are dropped without `scoreboardDeleted` events.
+
 #### bot.scoreboard
 
 All scoreboards known to the bot in an object scoreboard displaySlot -> scoreboard.
+
+Reset on each login; the object is kept and its slots are dropped.
 
  * `belowName` - scoreboard placed in belowName
  * `sidebar` - scoreboard placed in sidebar
@@ -1154,9 +1158,13 @@ All scoreboards known to the bot in an object scoreboard displaySlot -> scoreboa
 
 All teams known to the bot
 
+Reset on each login (every server switch on a proxy network); the object is kept and its entries are dropped without `teamRemoved` events.
+
 #### bot.teamMap
 
 Mapping of member to team. Uses usernames for players and UUIDs for entities.
+
+Reset on each login; the object is kept and its entries are dropped.
 
 #### bot.controlState
 
@@ -1524,7 +1532,7 @@ Fires when a scoreboard is added.
 
 #### "scoreboardDeleted" (scoreboard)
 
-Fires when a scoreboard is deleted.
+Fires when a scoreboard is deleted. Not fired for scoreboards dropped by a login.
 
 #### "scoreboardTitleChanged" (scoreboard)
 
@@ -1548,7 +1556,7 @@ Fires when a team is added.
 
 #### "teamRemoved" (team)
 
-Fires when a team is removed.
+Fires when a team is removed. Not fired for teams dropped by a login.
 
 #### "teamUpdated" (team)
 

--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -72,4 +72,14 @@ function inject (bot) {
 
   bot.scoreboards = scoreboards
   bot.scoreboard = ScoreBoard.positions
+
+  // No objective or display slot survives a login; the dropped objectives emit no scoreboardDeleted and the objects stay the same.
+  bot._client.on('login', () => {
+    for (const name of Object.keys(scoreboards)) delete scoreboards[name]
+    for (const position of Object.keys(ScoreBoard.positions)) {
+      // The named slots are accessors over the numeric slots and must stay.
+      if (Object.getOwnPropertyDescriptor(ScoreBoard.positions, position).get) continue
+      delete ScoreBoard.positions[position]
+    }
+  })
 }

--- a/lib/plugins/team.js
+++ b/lib/plugins/team.js
@@ -87,4 +87,10 @@ function inject (bot) {
 
   bot.teams = teams
   bot.teamMap = {}
+
+  // No team survives a login; the dropped teams emit no teamRemoved and the objects stay the same.
+  bot._client.on('login', () => {
+    for (const teamName of Object.keys(teams)) delete teams[teamName]
+    for (const member of Object.keys(bot.teamMap)) delete bot.teamMap[member]
+  })
 }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1479,6 +1479,113 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('scoreboard reset on login', () => {
+      function teamAddPacket (teamName, players) {
+        const text = registry.supportFeature('teamUsesChatComponents') ? chatText : (s) => s
+        const mappedMode = registry.version['>=']('1.21.6')
+        const enumRules = registry.version['>=']('1.21.5') && registry.version['<']('1.21.6')
+        return {
+          team: teamName,
+          mode: mappedMode ? 'add' : 0,
+          name: text(teamName),
+          prefix: text(''),
+          suffix: text(''),
+          friendlyFire: 1,
+          flags: { friendly_fire: true, see_friendly_invisible: false },
+          nameTagVisibility: enumRules ? 0 : 'always',
+          collisionRule: enumRules ? 0 : 'always',
+          color: 0,
+          formatting: 0,
+          players
+        }
+      }
+
+      function objectiveAddPacket (name) {
+        const typeField = registry.protocol.play.toClient.types.packet_scoreboard_objective[1].find(f => f.name === 'type')
+        return {
+          name,
+          action: 0,
+          displayText: chatText(name),
+          type: typeField.type[1].fields[0] === 'string' ? 'integer' : 0
+        }
+      }
+
+      function respawnPacket (loginPacket) {
+        if (!bot.supportFeature('usesLoginPacket')) {
+          return { dimension: 0, hashedSeed: [0, 0], gamemode: 0, levelType: 'default' }
+        }
+        // The respawn packet names the world the login packet declared.
+        loginPacket.worldName = 'minecraft:overworld'
+        loginPacket.hashedSeed = [0, 0]
+        loginPacket.entityId = 0
+        const packet = {
+          dimension: bot.supportFeature('dimensionDataInCodec') ? 'minecraft:overworld' : loginPacket.dimension,
+          worldName: loginPacket.worldName,
+          hashedSeed: loginPacket.hashedSeed,
+          gamemode: 0,
+          previousGamemode: 255,
+          isDebug: false,
+          isFlat: false,
+          copyMetadata: true,
+          death: { dimensionName: '', location: { x: 0, y: 0, z: 0 } }
+        }
+        if (!bot.supportFeature('spawnRespawnWorldDataField')) return packet
+        packet.name = loginPacket.worldName
+        packet.dimension = loginPacket.dimension
+        return { worldState: packet }
+      }
+
+      it('clears teams and objectives on login but not on respawn', async () => {
+        const teamPacketName = bot.supportFeature('teamUsesScoreboard') ? 'scoreboard_team' : 'teams'
+        const [client] = await once(server, 'playerJoin')
+        const loginPacket = bot.test.generateLoginPacket()
+        const teams = bot.teams
+        const teamMap = bot.teamMap
+        const scoreboards = bot.scoreboards
+        const positions = bot.scoreboard
+
+        await client.write('login', loginPacket)
+        client.write(teamPacketName, teamAddPacket('red', ['alice']))
+        await once(bot, 'teamCreated')
+        client.write('scoreboard_objective', objectiveAddPacket('kills'))
+        client.write('scoreboard_display_objective', { position: 1, name: 'kills' })
+        await once(bot, 'scoreboardPosition')
+        assert.deepStrictEqual(bot.teams.red.members, ['alice'])
+        assert.strictEqual(bot.teamMap.alice, bot.teams.red)
+        assert.strictEqual(bot.scoreboards.kills.name, 'kills')
+        assert.strictEqual(bot.scoreboard.sidebar, bot.scoreboards.kills)
+        assert.strictEqual(bot.scoreboard[1], bot.scoreboards.kills)
+
+        let removedEvents = 0
+        bot.on('teamRemoved', () => removedEvents++)
+        bot.on('scoreboardDeleted', () => removedEvents++)
+        client.write('login', loginPacket)
+        await once(bot, 'login')
+        assert.strictEqual(bot.teams, teams)
+        assert.strictEqual(bot.teamMap, teamMap)
+        assert.strictEqual(bot.scoreboards, scoreboards)
+        assert.strictEqual(bot.scoreboard, positions)
+        assert.deepStrictEqual(Object.keys(bot.teams), [])
+        assert.deepStrictEqual(Object.keys(bot.teamMap), [])
+        assert.deepStrictEqual(Object.keys(bot.scoreboards), [])
+        assert.strictEqual(bot.scoreboard[1], undefined)
+        assert.strictEqual(bot.scoreboard.sidebar, undefined)
+        assert.strictEqual(bot.scoreboard.list, undefined)
+        assert.strictEqual(bot.scoreboard.belowName, undefined)
+        assert.strictEqual(removedEvents, 0)
+
+        client.write(teamPacketName, teamAddPacket('red', ['bob']))
+        await once(bot, 'teamCreated')
+        assert.deepStrictEqual(bot.teams.red.members, ['bob'])
+        assert.strictEqual(bot.teamMap.alice, undefined)
+
+        client.write('respawn', respawnPacket(loginPacket))
+        await once(bot, 'respawn')
+        assert.deepStrictEqual(bot.teams.red.members, ['bob'])
+        assert.strictEqual(bot.teamMap.bob, bot.teams.red)
+      })
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1


### PR DESCRIPTION
Invariants across a login:

- Every clientbound `login` packet empties `bot.teams`, `bot.teamMap`, `bot.scoreboards` and the display slots of `bot.scoreboard`.
- Those four objects keep their identity; entries are deleted, so references held by user code stay valid.
- No `teamRemoved` or `scoreboardDeleted` event fires for entries dropped by a login.
- A `respawn` packet drops nothing.

Vanilla reference: `ClientPacketListener` owns `private final Scoreboard scoreboard = new Scoreboard()` and a new listener is created for each configuration to play transition, so no team or objective survives a login, while `handleRespawn` keeps the same listener. In 1.8, `NetHandlerPlayClient.handleJoinGame` builds a new `WorldClient` with a fresh `Scoreboard` and `handleRespawn` carries the old one over with `setWorldScoreboard`.

On a proxy network every server switch is a login, so a bot accumulated the teams of every server it had visited and a `teams` packet joining a player to a team name seen on an earlier server inherited that team's members.

Test (`scoreboard reset on login`): a team and an objective are created, a login clears them, and a team created afterwards survives a respawn. Passes on every tested version.