### PR TITLE
fix: track the container stateId per window

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -30,11 +30,10 @@ function inject (bot, { hideErrors }) {
   let sequence = 0
 
   let nextActionNumber = 0 // < 1.17
-  let stateId = -1
-  if (bot.supportFeature('stateIdUsed')) {
-    const listener = packet => { stateId = packet.stateId }
-    bot._client.on('window_items', listener)
-    bot._client.on('set_slot', listener)
+  // windowId -> stateId of the last window_items or set_slot applied to that window
+  const stateIds = new Map()
+  function recordStateId (window, packet) {
+    if (packet.stateId !== undefined) stateIds.set(window.id, packet.stateId)
   }
   const windowClickQueue = []
   let windowItems
@@ -435,6 +434,7 @@ function inject (bot, { hideErrors }) {
       windowId: window.id
     })
     copyInventory(window)
+    if (window !== bot.inventory) stateIds.delete(window.id)
     lastClosedWindow = window
     bot.currentWindow = null
     bot.emit('windowClose', window)
@@ -629,7 +629,7 @@ function inject (bot, { hideErrors }) {
     if (bot.supportFeature('stateIdUsed')) { // 1.17.1 +
       bot._client.write('window_click', {
         windowId: window.id,
-        stateId,
+        stateId: stateIds.get(window.id) ?? -1,
         slot,
         mouseButton,
         mode,
@@ -726,6 +726,7 @@ function inject (bot, { hideErrors }) {
         const item = Item.fromNotch(windowItems.items[i])
         window.updateSlot(i, item)
       }
+      recordStateId(window, windowItems)
       // consume the buffer so a later window reusing this id cannot open
       // with stale contents
       windowItems = null
@@ -751,6 +752,7 @@ function inject (bot, { hideErrors }) {
   bot._client.on('close_window', (packet) => {
     // close window
     const oldWindow = bot.currentWindow
+    if (oldWindow) stateIds.delete(oldWindow.id)
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })
@@ -762,6 +764,7 @@ function inject (bot, { hideErrors }) {
     // close window when switch subserver
     windowItems = null
     lastClosedWindow = null
+    stateIds.clear()
     const oldWindow = bot.currentWindow
     if (!oldWindow) return
     bot.currentWindow = null
@@ -773,6 +776,7 @@ function inject (bot, { hideErrors }) {
   bot._client.on('respawn', () => {
     windowItems = null
     lastClosedWindow = null
+    stateIds.clear()
   })
   bot._setSlot = (slotId, newItem, window = bot.inventory) => {
     // set slot
@@ -794,6 +798,7 @@ function inject (bot, { hideErrors }) {
       }
       return
     }
+    recordStateId(window, packet)
     const newItem = Item.fromNotch(packet.item)
     bot._setSlot(packet.slot, newItem, window)
   })
@@ -841,6 +846,7 @@ function inject (bot, { hideErrors }) {
     }
 
     // set window items
+    recordStateId(window, packet)
     for (let i = 0; i < packet.items.length; ++i) {
       const item = Item.fromNotch(packet.items[i])
       window.updateSlot(i, item)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1447,6 +1447,40 @@ for (const supportedVersion of mineflayer.testedVersions) {
           client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
         })
       })
+
+      it('clicks carry the stateId of the window they click, not the last one synced', function (done) {
+        if (!bot.supportFeature('stateIdUsed')) {
+          this.skip()
+          return
+        }
+        const clicks = []
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.on('window_click', (packet) => {
+            clicks.push(packet)
+            if (clicks.length < 2) return
+            try {
+              assert.deepStrictEqual(clicks.map(c => [c.windowId, c.stateId]), [[1, 5], [0, 9]])
+              done()
+            } catch (err) {
+              done(err)
+            }
+          })
+
+          bot.once('windowOpen', async () => {
+            // a player-inventory sync while the container is open
+            client.write('set_slot', { windowId: 0, stateId: 9, slot: 36, item: Item.toNotch(null) })
+            await sleep(50)
+            await bot.clickWindow(0, 0, 0)
+            bot.closeWindow(bot.currentWindow)
+            await sleep(50)
+            await bot.clickWindow(36, 0, 0)
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', { ...windowItemsPacket(1, emptyItems(chestData.slots)), stateId: 5 })
+        })
+      })
     })
 
     describe('tablist', () => {


### PR DESCRIPTION
Invariants of the container state id:

- Each window keeps the stateId of the last `window_items` or `set_slot` applied to that window.
- A `window_click` carries the stateId of the window it clicks; a window that has never been synced sends -1.
- A packet routed to the player inventory updates the player inventory's id, never an open container's.
- Entries are dropped when the window closes and on login and respawn.
- `_syncWindow` still sends -1 on purpose.

Vanilla reference: `AbstractContainerMenu` holds its own `stateId`; `ClientPacketListener.handleContainerContent` and `handleContainerSetSlot` apply containerId 0 to `player.inventoryMenu` and anything else to the open `containerMenu`; `MultiPlayerGameMode.handleInventoryMouseClick` sends the clicked menu's `getStateId()`.

Test (`clicks carry the stateId of the window they click, not the last one synced`): a container syncs with stateId 5, a player-inventory `set_slot` with stateId 9 arrives while it is open, and the click on the container carries 5 while a later click on the player inventory carries 9. Fails on master, passes with the change, on every tested version.