### PR TITLE
fix: make bot.controlState's properties enumerable

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -293,6 +293,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   for (const control of Object.keys(controlState)) {
     Object.defineProperty(bot.controlState, control, {
+      enumerable: true,
       get () {
         return controlState[control]
       },


### PR DESCRIPTION
Object.keys, spreading, JSON.stringify and console.log see all seven controls, which is what `docs/api.md` already describes `bot.controlState` as ("An object whose keys are the main control states"). Reading a control still returns the live value; writing one still goes through `bot.setControlState`.

The accessors are installed with `Object.defineProperty` and no descriptor, so they default to `enumerable: false`: today `Object.keys(bot.controlState)` is `[]`, `{ ...bot.controlState }` is `{}`, and logging the object prints `{}`, while `bot.controlState.forward` reads correctly. Cloning or logging control state therefore silently loses it.