### PR TITLE
test: build only the versions under test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
           for v in ${{ matrix.versions }}; do
             # TRACE is cheap (<1% runtime) and only written by the harness bot,
             # so always record a packet trace for post-mortem analysis.
-            TRACE="trace-${v}.jsonl" DURATIONS="durations/durations-${v}.json" npm run mocha_test -- --retries 3 -g "${v}v" > "test-${v}.log" 2>&1 &
+            # MC_VERSIONS scopes what the test files build at load time; -g scopes what runs.
+            MC_VERSIONS="${v}" TRACE="trace-${v}.jsonl" DURATIONS="durations/durations-${v}.json" npm run mocha_test -- --retries 3 -g "${v}v" > "test-${v}.log" 2>&1 &
             pids="$pids $!"
           done
           for pid in $pids; do

--- a/test/common/versions.js
+++ b/test/common/versions.js
@@ -1,0 +1,12 @@
+const mineflayer = require('../../')
+
+// Each version in this list costs a registry, a chunk implementation and a protocol at file load
+// time, before mocha's --grep can discard anything, so a scoped run must not iterate the rest.
+// MC_VERSIONS is a comma separated list; unset means every tested version.
+const only = process.env.MC_VERSIONS ? process.env.MC_VERSIONS.split(',').map(v => v.trim()) : null
+const versionsUnderTest = mineflayer.testedVersions.filter(v => only === null || only.includes(v))
+if (versionsUnderTest.length === 0) {
+  throw new Error(`MC_VERSIONS=${process.env.MC_VERSIONS} matches none of ${mineflayer.testedVersions.join(', ')}`)
+}
+
+module.exports = { versionsUnderTest }

--- a/test/externalTest.js
+++ b/test/externalTest.js
@@ -35,6 +35,7 @@ const propOverrides = {
 
 const Wrap = require('minecraft-wrap').Wrap
 const download = require('minecraft-wrap').download
+const { versionsUnderTest } = require('./common/versions')
 
 const MC_SERVER_PATH = path.join(__dirname, 'server')
 
@@ -54,7 +55,7 @@ async function pingUntilReady (port, host, version, attempts = 5) {
   }
 }
 
-for (const supportedVersion of mineflayer.testedVersions) {
+for (const supportedVersion of versionsUnderTest) {
   let PORT = 25565
   const registry = require('prismarine-registry')(supportedVersion)
   const version = registry.version

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -10,7 +10,14 @@ const { once, onceWithCleanup } = require('../lib/promise_utils')
 const { EventEmitter } = require('events')
 const { getPort } = require('./common/util')
 
-for (const supportedVersion of mineflayer.testedVersions) {
+// Building a registry, a chunk implementation and a protocol per version is most of this file's load
+// time, so a run restricted to some versions must not pay for the others. MC_VERSIONS is a comma
+// separated list; unset means every tested version.
+const onlyVersions = process.env.MC_VERSIONS ? process.env.MC_VERSIONS.split(',').map(v => v.trim()) : null
+const versionsUnderTest = mineflayer.testedVersions.filter(v => onlyVersions === null || onlyVersions.includes(v))
+if (versionsUnderTest.length === 0) throw new Error(`MC_VERSIONS=${process.env.MC_VERSIONS} matches none of ${mineflayer.testedVersions.join(', ')}`)
+
+for (const supportedVersion of versionsUnderTest) {
   const registry = require('prismarine-registry')(supportedVersion)
   const version = registry.version
   const Chunk = require('prismarine-chunk')(supportedVersion)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -9,13 +9,7 @@ const nbt = require('prismarine-nbt')
 const { once, onceWithCleanup } = require('../lib/promise_utils')
 const { EventEmitter } = require('events')
 const { getPort } = require('./common/util')
-
-// Building a registry, a chunk implementation and a protocol per version is most of this file's load
-// time, so a run restricted to some versions must not pay for the others. MC_VERSIONS is a comma
-// separated list; unset means every tested version.
-const onlyVersions = process.env.MC_VERSIONS ? process.env.MC_VERSIONS.split(',').map(v => v.trim()) : null
-const versionsUnderTest = mineflayer.testedVersions.filter(v => onlyVersions === null || onlyVersions.includes(v))
-if (versionsUnderTest.length === 0) throw new Error(`MC_VERSIONS=${process.env.MC_VERSIONS} matches none of ${mineflayer.testedVersions.join(', ')}`)
+const { versionsUnderTest } = require('./common/versions')
 
 for (const supportedVersion of versionsUnderTest) {
   const registry = require('prismarine-registry')(supportedVersion)


### PR DESCRIPTION
`internalTest.js` and `externalTest.js` each build a registry, a chunk implementation and a protocol for all 28 tested versions at load time. `--grep` only filters after that, so CI's per-version runs, which already pass `-g "${v}v"`, pay for the other 27 twice over.

Invariants:

- `MC_VERSIONS` is a comma separated list read once in `test/common/versions.js`; unset means every tested version, so an unscoped run is unchanged (2352 tests collected across both files either way).
- A value matching no tested version throws at load rather than silently running nothing.
- `-g` still decides what runs; `MC_VERSIONS` only decides what gets built.

Collecting either file drops from 0.81 s to 0.28 s when scoped to one version. CI runs four of these concurrently per job, so that is about 4 s of CPU returned to the four Minecraft servers starting at the same moment.

Locally it also makes a scoped run practical: one test across all 28 versions goes from 14 s sequential to 2.2 s when `testedVersions` is sharded over 14 concurrent mocha processes, and a single version of a single test takes 1.35 s. Per-version spec files under `mocha --parallel --jobs 16` measured 2.3 s, no better, so the files need no restructuring.