### PR TITLE
fix: send the action ids a protocol maps to names

### DIFF
--- a/lib/plugins/bed.js
+++ b/lib/plugins/bed.js
@@ -70,7 +70,7 @@ function inject (bot) {
     } else {
       bot._client.write('entity_action', {
         entityId: bot.entity.id,
-        actionId: 2,
+        actionId: bot.supportFeature('entityActionUsesStringMapper') ? 'leave_bed' : 2,
         jumpBoost: 0
       })
     }

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -46,7 +46,7 @@ function inject (bot) {
         resolve()
       }, timeoutMs)
       pendingStatsRequests.push(request)
-      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 1 } : { actionId: 1 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 1 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'request_stats' : 1 })
     })
   }
 

--- a/lib/plugins/creative.js
+++ b/lib/plugins/creative.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const { Vec3 } = require('vec3')
 const { sleep, onceWithCleanup } = require('../promise_utils')
 const { once } = require('../promise_utils')
+const { mapsIdsToNames } = require('../protocol_ids')
 
 module.exports = inject
 
@@ -46,7 +47,7 @@ function inject (bot) {
         resolve()
       }, timeoutMs)
       pendingStatsRequests.push(request)
-      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 1 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'request_stats' : 1 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 1 } : { actionId: mapsIdsToNames(bot.registry, 'packet_client_command', 'actionId') ? 'request_stats' : 1 })
     })
   }
 

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -123,7 +123,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { action: 0 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -1,4 +1,5 @@
 const nbt = require('prismarine-nbt')
+const { mapsIdsToNames } = require('../protocol_ids')
 module.exports = inject
 
 const difficultyNames = ['peaceful', 'easy', 'normal', 'hard']
@@ -123,7 +124,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: mapsIdsToNames(bot.registry, 'packet_client_command', 'actionId') ? 'perform_respawn' : 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -41,7 +41,7 @@ function inject (bot, options) {
 
   const respawn = () => {
     if (bot.isAlive) return
-    bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: 0 })
+    bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0 })
   }
 
   bot.respawn = respawn

--- a/lib/plugins/health.js
+++ b/lib/plugins/health.js
@@ -1,3 +1,4 @@
+const { mapsIdsToNames } = require('../protocol_ids')
 module.exports = inject
 
 function inject (bot, options) {
@@ -41,7 +42,7 @@ function inject (bot, options) {
 
   const respawn = () => {
     if (bot.isAlive) return
-    bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: bot.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0 })
+    bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: mapsIdsToNames(bot.registry, 'packet_client_command', 'actionId') ? 'perform_respawn' : 0 })
   }
 
   bot.respawn = respawn

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -252,7 +252,7 @@ function inject (bot, { hideErrors }) {
       target: entity.id,
       mouse: 0, // interact with entity
       sneaking: false,
-      hand: 0, // interact with the main hand
+      hand: bot.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0, // main hand
       location: new Vec3(0, 0, 0)
     })
   }
@@ -264,7 +264,7 @@ function inject (bot, { hideErrors }) {
       target: entity.id,
       mouse: 2, // interact with entity at
       sneaking: false,
-      hand: 0, // interact with the main hand
+      hand: bot.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0, // main hand
       x: position.x - entity.position.x,
       y: position.y - entity.position.y,
       z: position.z - entity.position.z,

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const { Vec3 } = require('vec3')
 const { once, sleep, createDoneTask, createTask, withTimeout } = require('../promise_utils')
 const { toNotchianYaw, toNotchianPitch } = require('../conversions')
+const { mapsIdsToNames } = require('../protocol_ids')
 
 module.exports = inject
 
@@ -245,6 +246,8 @@ function inject (bot, { hideErrors }) {
     bot.swingArm()
   }
 
+  const mainHand = mapsIdsToNames(bot.registry, 'packet_use_entity', 'hand') ? 'main_hand' : 0
+
   async function activateEntity (entity) {
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(entity.position.offset(0, 1, 0), false)
@@ -252,7 +255,7 @@ function inject (bot, { hideErrors }) {
       target: entity.id,
       mouse: 0, // interact with entity
       sneaking: false,
-      hand: bot.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0, // main hand
+      hand: mainHand, // main hand
       location: new Vec3(0, 0, 0)
     })
   }
@@ -264,7 +267,7 @@ function inject (bot, { hideErrors }) {
       target: entity.id,
       mouse: 2, // interact with entity at
       sneaking: false,
-      hand: bot.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0, // main hand
+      hand: mainHand, // main hand
       x: position.x - entity.position.x,
       y: position.y - entity.position.y,
       z: position.z - entity.position.z,

--- a/lib/protocol_ids.js
+++ b/lib/protocol_ids.js
@@ -1,0 +1,12 @@
+/**
+ * Some serverbound action ids are described as a protodef `mapper` on newer protocols, where the
+ * field takes the name rather than the number: 26.1 does it for `client_command.actionId` and
+ * `use_entity.hand`. Writing the number there throws in the serializer and the packet is dropped, so
+ * every writer has to ask the schema which shape this version wants.
+ */
+function mapsIdsToNames (registry, packet, field) {
+  const type = registry.protocol?.play?.toServer?.types?.[packet]?.[1]?.find(f => f.name === field)?.type
+  return Array.isArray(type) && type[0] === 'mapper'
+}
+
+module.exports = { mapsIdsToNames }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1530,62 +1530,74 @@ for (const supportedVersion of mineflayer.testedVersions) {
     describe('string mapped action ids', () => {
       // 26.1 maps client_command's actionId and use_entity's hand to strings, and 1.21.6+ maps
       // entity_action's actionId; a numeric id fails to serialize there and never reaches the server.
-      function onJoin (name, act, check) {
-        server.on('playerJoin', async (client) => {
-          client.on('packet', (data, meta) => { if (meta.name === name) check(data) })
-          await client.write('login', bot.test.generateLoginPacket())
-          const chunk = bot.test.buildChunk()
-          chunk.setBlockType(vec3(0, 64, 0), registry.blocksByName.stone.id)
-          await client.write('map_chunk', generateChunkPacket(chunk))
-          await client.write('position', {
-            x: 0,
-            y: 66,
-            z: 0,
-            dx: 0,
-            dy: 0,
-            dz: 0,
-            yaw: 0,
-            pitch: 0,
-            flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
-            teleportId: 0
+      const fields = (name) => registry.protocol?.play?.toServer?.types?.[name]?.[1] ?? []
+      const has = (name, field) => fields(name).some(f => f.name === field)
+
+      // Resolves with the first matching packet the server sees. Asserting inside the packet listener
+      // would throw on the read path and wedge the connection instead of failing the test.
+      function packetFrom (name, act, want = () => true) {
+        return new Promise((resolve, reject) => {
+          server.on('playerJoin', async (client) => {
+            try {
+              client.on('packet', (data, meta) => { if (meta.name === name && want(data)) resolve(data) })
+              await client.write('login', bot.test.generateLoginPacket())
+              const chunk = bot.test.buildChunk()
+              chunk.setBlockType(vec3(0, 64, 0), registry.blocksByName.stone.id)
+              await client.write('map_chunk', generateChunkPacket(chunk))
+              await client.write('position', {
+                x: 0,
+                y: 66,
+                z: 0,
+                dx: 0,
+                dy: 0,
+                dz: 0,
+                yaw: 0,
+                pitch: 0,
+                flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+                teleportId: 0
+              })
+              await sleep(200)
+              await act()
+            } catch (err) {
+              reject(err)
+            }
           })
-          await sleep(200)
-          await act()
         })
       }
 
-      it('respawns with an action id the protocol accepts', (done) => {
-        onJoin('client_command', () => {
+      it('respawns with an action id the protocol accepts', async () => {
+        const packet = await packetFrom('client_command', () => {
           bot.isAlive = false
           bot.respawn()
-        }, (data) => {
-          assert.strictEqual(data.actionId ?? data.payload, registry.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0)
-          done()
         })
+        const mapped = fields('packet_client_command').some(f => f.name === 'actionId' && f.type[0] === 'mapper')
+        assert.strictEqual(packet.actionId ?? packet.payload, mapped ? 'perform_respawn' : 0)
       })
 
-      it('interacts with an entity using a hand the protocol accepts', (done) => {
-        onJoin('use_entity', () => {
+      it('interacts with an entity using a hand the protocol accepts', async () => {
+        const packet = await packetFrom('use_entity', () => {
           const Entity = require('prismarine-entity')(registry)
           const target = new Entity(42)
           target.position = vec3(1, 66, 0)
           target.height = 1.8
           bot.entities[target.id] = target
           return bot.activateEntity(target)
-        }, (data) => {
-          assert.strictEqual(data.hand, registry.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0)
-          done()
         })
+        // Before 1.9 the packet carries no hand at all; getting it at the server is the whole assertion.
+        if (has('packet_use_entity', 'hand')) {
+          const mapped = fields('packet_use_entity').some(f => f.name === 'hand' && f.type[0] === 'mapper')
+          assert.strictEqual(packet.hand, mapped ? 'main_hand' : 0)
+        }
       })
 
-      it('leaves a bed with an action id the protocol accepts', (done) => {
-        onJoin('entity_action', () => {
+      it('leaves a bed with an action id the protocol accepts', async () => {
+        const mapped = registry.supportFeature('entityActionUsesStringMapper')
+        const sneakOrSprint = new Set(mapped ? ['start_sprinting', 'stop_sprinting'] : [0, 1, 3, 4])
+        const packet = await packetFrom('entity_action', () => {
           bot.isSleeping = true
           return bot.wake()
-        }, (data) => {
-          assert.strictEqual(data.actionId, registry.supportFeature('entityActionUsesStringMapper') ? 'leave_bed' : 2)
-          done()
-        })
+        }, (data) => !sneakOrSprint.has(data.actionId))
+        assert.strictEqual(packet.actionId, mapped ? 'leave_bed' : 2)
       })
     })
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1527,6 +1527,68 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('string mapped action ids', () => {
+      // 26.1 maps client_command's actionId and use_entity's hand to strings, and 1.21.6+ maps
+      // entity_action's actionId; a numeric id fails to serialize there and never reaches the server.
+      function onJoin (name, act, check) {
+        server.on('playerJoin', async (client) => {
+          client.on('packet', (data, meta) => { if (meta.name === name) check(data) })
+          await client.write('login', bot.test.generateLoginPacket())
+          const chunk = bot.test.buildChunk()
+          chunk.setBlockType(vec3(0, 64, 0), registry.blocksByName.stone.id)
+          await client.write('map_chunk', generateChunkPacket(chunk))
+          await client.write('position', {
+            x: 0,
+            y: 66,
+            z: 0,
+            dx: 0,
+            dy: 0,
+            dz: 0,
+            yaw: 0,
+            pitch: 0,
+            flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+            teleportId: 0
+          })
+          await sleep(200)
+          await act()
+        })
+      }
+
+      it('respawns with an action id the protocol accepts', (done) => {
+        onJoin('client_command', () => {
+          bot.isAlive = false
+          bot.respawn()
+        }, (data) => {
+          assert.strictEqual(data.actionId ?? data.payload, registry.supportFeature('clientCommandUsesStringMapper') ? 'perform_respawn' : 0)
+          done()
+        })
+      })
+
+      it('interacts with an entity using a hand the protocol accepts', (done) => {
+        onJoin('use_entity', () => {
+          const Entity = require('prismarine-entity')(registry)
+          const target = new Entity(42)
+          target.position = vec3(1, 66, 0)
+          target.height = 1.8
+          bot.entities[target.id] = target
+          return bot.activateEntity(target)
+        }, (data) => {
+          assert.strictEqual(data.hand, registry.supportFeature('useEntityUsesStringMapper') ? 'main_hand' : 0)
+          done()
+        })
+      })
+
+      it('leaves a bed with an action id the protocol accepts', (done) => {
+        onJoin('entity_action', () => {
+          bot.isSleeping = true
+          return bot.wake()
+        }, (data) => {
+          assert.strictEqual(data.actionId, registry.supportFeature('entityActionUsesStringMapper') ? 'leave_bed' : 2)
+          done()
+        })
+      })
+    })
+
     describe('onceWithCleanup', () => {
       it('rejects instead of throwing out of emit when checkCondition throws', async () => {
         // A condition that throws used to unwind whatever was emitting. For a


### PR DESCRIPTION
On 26.1 `client_command.actionId` and `use_entity.hand` are `mapper` fields:

```json
"packet_client_command": ["container", [{"name": "actionId", "type": ["mapper", {"type": "varint", "mappings": {"0": "perform_respawn", "1": "request_stats", "2": "request_gamerule_values"}}]}]]
"packet_use_entity":     ["container", [{"name": "target", ...}, {"name": "hand", "type": ["mapper", {"type": "varint", "mappings": {"0": "main_hand", "1": "off_hand"}}]}, ...]]
```

Writing the numeric id there throws inside the serializer:

```
Error: SizeOf error for undefined : 0 is not in the mappings value
    at Object.packet_use_entity ...
```

The packet is dropped on the floor, so on 26.1 the bot cannot respawn (`bot.respawn()`, the death handler, the win_game handler), cannot request stats, and `bot.activateEntity()` does nothing at all — right-clicking an NPC on a 26.1 server looked like the server ignoring us. `entity_action` has been string-mapped since 1.21.6 and `physics.js` already handles it, but `bed.js`'s `wake()` still wrote `actionId: 2`, which both fails to serialize there and means `stop_sprinting` under the new mapping.

`game.js` also wrote `{ action: 0 }`, a field name that does not exist in any protocol version, so the win_game respawn never serialized anywhere.

`lib/protocol_ids.js` asks the schema whether the field is a mapper rather than going through a feature, so this is right whether minecraft-data keeps 26.1's mappers (PrismarineJS/minecraft-data#1279) or drops them (PrismarineJS/minecraft-data#1278), and it needs no unreleased data. `bed.js` keeps `supportFeature('entityActionUsesStringMapper')` to match `physics.js`, which already uses it for the same packet.

Verified live: with this change `bot.activateEntity()` on a 26.1 server's NPC produces `use_entity {target, hand: 'main_hand', location, sneaking}` and the server answers, where before nothing went out.

Tests: three cases in `test/internalTest.js` covering every tested version. They resolve the packet out of the server's read path before asserting — an assertion thrown inside the packet listener wedges the connection and shows up as an `afterEach` timeout — and on 1.8-1.11, whose `use_entity` has no `hand` field at all, the assertion is just that the packet arrives.