### PR TITLE
fix: answer a server teleport at the next tick, like the vanilla packet processor

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -491,6 +491,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot.on('respawn', () => { shouldUsePhysics = false })
   bot.on('login', () => {
     shouldUsePhysics = false
+    // A teleport still queued here belongs to the world the bot just left, and its id means nothing
+    // to the server it is about to talk to.
+    pendingTeleports.length = 0
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = performance.now()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -372,9 +372,10 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   // player position and look (clientbound)
-  // The vanilla client hands every play packet to the client thread, which drains the queue at the
-  // start of a tick (PacketUtils.ensureRunningOnSameThread), so a teleport is answered at most once
-  // per tick however fast the server sends them.
+  // The vanilla client hands every play packet to the client thread, which drains the whole queue at
+  // the start of a tick (PacketUtils.ensureRunningOnSameThread, PacketProcessor.processQueuedPackets).
+  // Every queued teleport is answered there, each with its own accept and position_look, and the
+  // tick's own movement packet follows; the queue only moves the answers off the socket callback.
   const pendingTeleports = []
   bot._client.on('position', (packet) => { pendingTeleports.push(packet) })
 

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -78,6 +78,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   function tickPhysics (now) {
     if (bot._client.state !== 'play') return // do nothing outside of the play state (e.g. server transfer configuration phase)
+    while (pendingTeleports.length) handleTeleport(pendingTeleports.shift())
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -371,7 +372,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   // player position and look (clientbound)
-  bot._client.on('position', (packet) => {
+  // The vanilla client hands every play packet to the client thread, which drains the queue at the
+  // start of a tick (PacketUtils.ensureRunningOnSameThread), so a teleport is answered at most once
+  // per tick however fast the server sends them.
+  const pendingTeleports = []
+  bot._client.on('position', (packet) => { pendingTeleports.push(packet) })
+
+  function handleTeleport (packet) {
     // Is this necessary? Feels like it might wrongly overwrite hitbox size sometimes
     // e.g. when crouching/crawling/swimming. Can someone confirm?
     bot.entity.height = 1.8
@@ -451,7 +458,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSentPitch = bot.entity.pitch
 
     bot.emit('forcedMove')
-  })
+  }
 
   bot.waitForTicks = async function (ticks) {
     if (ticks <= 0) return

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -342,60 +342,69 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
       it('absolute position & relative position (velocity)', (done) => {
+        // The teleport is applied inside a physics tick, so the state it produces has to be read when
+        // forcedMove fires; awaiting the event resumes after that tick's simulation has run on top.
+        const onForcedMove = () => new Promise(resolve => {
+          bot.once('forcedMove', () => resolve({ velocity: bot.entity.velocity.clone(), position: bot.entity.position.clone() }))
+        })
         server.on('playerJoin', async (client) => {
-          await client.write('login', bot.test.generateLoginPacket())
-          const chunk = bot.test.buildChunk()
-          chunk.setBlockType(pos, goldId)
-          await client.write('map_chunk', generateChunkPacket(chunk))
+          try {
+            await client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(pos, goldId)
+            await client.write('map_chunk', generateChunkPacket(chunk))
 
-          await once(bot, 'chunkColumnLoad')
+            await once(bot, 'chunkColumnLoad')
 
-          // --- Test 1: Absolute Position ---
-          const absolutePositionPacket = {
-            x: 1.5,
-            y: 80,
-            z: 1.5,
-            pitch: 0,
-            yaw: 0,
-            teleportId: 1,
-            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+            // --- Test 1: Absolute Position ---
+            const absolutePositionPacket = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              pitch: 0,
+              yaw: 0,
+              teleportId: 1,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+            }
+
+            bot.entity.velocity.y = -1.0 // Give bot some velocity
+
+            const p1 = onForcedMove()
+            client.write('position', absolutePositionPacket)
+            const afterAbsolute = await p1
+
+            // Assertions for absolute teleport
+            assert.strictEqual(afterAbsolute.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
+            assert.deepStrictEqual(afterAbsolute.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
+
+            // --- Test 2: Relative Position ---
+            const relativePositionPacket = {
+              x: 1.0,
+              y: -2.0,
+              z: 0.5,
+              pitch: 0,
+              yaw: 0,
+              teleportId: 2,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: true, y: true, z: true, yaw: false, pitch: false } : 7
+            }
+
+            // Set a known velocity *before* the relative update
+            bot.entity.velocity.y = -1.0
+            const initialPosition = bot.entity.position.clone()
+            const expectedPosition = initialPosition.plus(vec3(1.0, -2.0, 0.5))
+
+            const p2 = onForcedMove()
+            client.write('position', relativePositionPacket)
+            const afterRelative = await p2
+
+            // Assertions for relative teleport
+            assert.notStrictEqual(afterRelative.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
+            assert.deepStrictEqual(afterRelative.position, expectedPosition, 'Position should be updated relatively')
+
+            done()
+          } catch (err) {
+            done(err)
           }
-
-          bot.entity.velocity.y = -1.0 // Give bot some velocity
-
-          const p1 = once(bot, 'forcedMove')
-          client.write('position', absolutePositionPacket)
-          await p1
-
-          // Assertions for absolute teleport
-          assert.strictEqual(bot.entity.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
-          assert.deepStrictEqual(bot.entity.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
-
-          // --- Test 2: Relative Position ---
-          const relativePositionPacket = {
-            x: 1.0,
-            y: -2.0,
-            z: 0.5,
-            pitch: 0,
-            yaw: 0,
-            teleportId: 2,
-            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: true, y: true, z: true, yaw: false, pitch: false } : 7
-          }
-
-          // Set a known velocity *before* the relative update
-          bot.entity.velocity.y = -1.0
-          const initialPosition = bot.entity.position.clone()
-          const expectedPosition = initialPosition.plus(vec3(1.0, -2.0, 0.5))
-
-          const p2 = once(bot, 'forcedMove')
-          client.write('position', relativePositionPacket)
-          await p2
-
-          // Assertions for relative teleport
-          assert.notStrictEqual(bot.entity.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
-          assert.deepStrictEqual(bot.entity.position, expectedPosition, 'Position should be updated relatively')
-
-          done()
         })
       })
       it('gravity + land on solid block + jump', (done) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1614,6 +1614,52 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
         })
       })
+
+      it('answers every teleport queued for a tick, in arrival order', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), registry.blocksByName.stone.id)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            const teleport = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            }
+            client.write('position', teleport)
+            await once(bot, 'forcedMove')
+
+            const replies = []
+            const write = bot._client.write.bind(bot._client)
+            bot._client.write = (name, params) => {
+              if (name === 'position_look') replies.push(params.y)
+              return write(name, params)
+            }
+            try {
+              await new Promise(resolve => bot.once('physicsTick', resolve))
+              replies.length = 0
+              bot._client.emit('position', { ...teleport, y: 90, teleportId: 1 })
+              bot._client.emit('position', { ...teleport, y: 100, teleportId: 2 })
+              await new Promise(resolve => bot.once('physicsTick', resolve))
+              assert.deepStrictEqual(replies, [90, 100], 'each queued teleport gets its own reply on the same tick')
+            } finally {
+              bot._client.write = write
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
     })
 
     describe('onceWithCleanup', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1562,6 +1562,51 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('teleports', () => {
+      it('answers a teleport at the next tick instead of from inside the packet handler', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), registry.blocksByName.stone.id)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            const teleport = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            }
+            client.write('position', teleport)
+            await once(bot, 'forcedMove')
+
+            const writes = []
+            const write = bot._client.write.bind(bot._client)
+            bot._client.write = (name, params) => { writes.push(name); return write(name, params) }
+            try {
+              await new Promise(resolve => bot.once('physicsTick', resolve))
+              writes.length = 0
+              bot._client.emit('position', { ...teleport, y: 90, teleportId: 1 })
+              assert.deepStrictEqual(writes, [], 'the teleport must not be answered from inside the packet handler')
+              await once(bot, 'forcedMove')
+              assert.ok(writes.includes('position_look'), 'the teleport is answered on the next tick')
+            } finally {
+              bot._client.write = write
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('onceWithCleanup', () => {
       it('rejects instead of throwing out of emit when checkCondition throws', async () => {
         // A condition that throws used to unwind whatever was emitting. For a


### PR DESCRIPTION
`ClientPacketListener.handleMovePlayer` starts with `PacketUtils.ensureRunningOnSameThread`, so the vanilla client does not act on a teleport when it arrives: it queues it and runs the handler when the client thread next drains its packet queue, at the top of a tick. mineflayer answered from inside the packet handler instead, microseconds after the bytes arrived.

That difference matters on a server that sends a position packet in response to a movement packet. The round trip becomes network RTT instead of one tick, so the exchange runs at hundreds of packets a second rather than twenty:

```
26503 <position  (0.5, 100, 0.5) id0
26503 >teleport_confirm id0
26503 >position_look (0.5, 100, 0.5)
26504 <position  (0.5, 100, 0.5) id0
26504 >teleport_confirm id0
26504 >position_look (0.5, 100, 0.5)
26505 <position ...
```

Measured against a BedWars server that pins players with a teleport every tick, over the same 30 s window: 923 teleports answered, peaking at 538 in one second, before the change; 59 after it, peaking at 27 (the tick rate). The anticheat kicks for the former.

The handler body moves into `handleTeleport` and the listener only queues; `tickPhysics` drains the queue before anything else, ahead of the entity and chunk guards so the first teleport of a login is still answered while chunks are loading.

Test in `test/internalTest.js` emits a `position` packet mid-tick the way #4070's ping test does and asserts nothing is written from the handler, then that the answer goes out on the next tick. It fails on master with `teleport_confirm`/`position_look` written synchronously.