### PR TITLE
physics: handle a clientbound teleport from the packet queue, not from the read

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -96,6 +96,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   function cleanup () {
+    clearImmediate(positionDrain)
+    positionDrain = null
+    positionQueue.length = 0
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
   }
@@ -370,8 +373,21 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     bot.entity.pitch = conv.fromNotchianPitch(packet.pitch)
   })
 
-  // player position and look (clientbound)
+  // Vanilla runs handleMovePlayer through PacketUtils.ensureRunningOnSameThread, so a teleport is
+  // applied and answered while Minecraft.runTick drains its packet queue, never from the read that
+  // received it and never between the packets of a tick. Draining on setImmediate reproduces that:
+  // every packet of the current read is processed first, then the teleports are answered together.
+  const positionQueue = []
+  let positionDrain = null
   bot._client.on('position', (packet) => {
+    positionQueue.push(packet)
+    positionDrain ??= setImmediate(drainPositionQueue)
+  })
+  function drainPositionQueue () {
+    positionDrain = null
+    while (positionQueue.length > 0) handlePosition(positionQueue.shift())
+  }
+  function handlePosition (packet) {
     // Is this necessary? Feels like it might wrongly overwrite hitbox size sometimes
     // e.g. when crouching/crawling/swimming. Can someone confirm?
     bot.entity.height = 1.8
@@ -451,7 +467,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSentPitch = bot.entity.pitch
 
     bot.emit('forcedMove')
-  })
+  }
 
   bot.waitForTicks = async function (ticks) {
     if (ticks <= 0) return

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -363,13 +363,19 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
           bot.entity.velocity.y = -1.0 // Give bot some velocity
 
-          const p1 = once(bot, 'forcedMove')
+          // The teleport is applied from the packet queue, so read the state in the forcedMove
+          // listener: awaiting it lets the next tick's gravity run first.
+          const onForcedMove = () => new Promise(resolve => {
+            bot.once('forcedMove', () => resolve({ velocity: bot.entity.velocity.clone(), position: bot.entity.position.clone() }))
+          })
+
+          const p1 = onForcedMove()
           client.write('position', absolutePositionPacket)
-          await p1
+          const afterAbsolute = await p1
 
           // Assertions for absolute teleport
-          assert.strictEqual(bot.entity.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
-          assert.deepStrictEqual(bot.entity.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
+          assert.strictEqual(afterAbsolute.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
+          assert.deepStrictEqual(afterAbsolute.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
 
           // --- Test 2: Relative Position ---
           const relativePositionPacket = {
@@ -387,14 +393,57 @@ for (const supportedVersion of mineflayer.testedVersions) {
           const initialPosition = bot.entity.position.clone()
           const expectedPosition = initialPosition.plus(vec3(1.0, -2.0, 0.5))
 
-          const p2 = once(bot, 'forcedMove')
+          const p2 = onForcedMove()
           client.write('position', relativePositionPacket)
-          await p2
+          const afterRelative = await p2
 
           // Assertions for relative teleport
-          assert.notStrictEqual(bot.entity.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
-          assert.deepStrictEqual(bot.entity.position, expectedPosition, 'Position should be updated relatively')
+          assert.notStrictEqual(afterRelative.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
+          assert.deepStrictEqual(afterRelative.position, expectedPosition, 'Position should be updated relatively')
 
+          done()
+        })
+      })
+      it('answers a teleport from the packet queue, not from the read that carried it', (done) => {
+        server.on('playerJoin', async (client) => {
+          await client.write('login', bot.test.generateLoginPacket())
+          const chunk = bot.test.buildChunk()
+          chunk.setBlockType(pos, goldId)
+          await client.write('map_chunk', generateChunkPacket(chunk))
+          await once(bot, 'chunkColumnLoad')
+
+          // True for as long as the listeners of one clientbound position packet are running.
+          let insidePacketCallback = false
+          bot._client.prependListener('position', () => {
+            insidePacketCallback = true
+            process.nextTick(() => { insidePacketCallback = false })
+          })
+          const movement = new Set(['position', 'position_look', 'look', 'flying', 'teleport_confirm'])
+          const written = []
+          const write = bot._client.write.bind(bot._client)
+          bot._client.write = (name, params) => {
+            if (movement.has(name)) written.push({ name, inline: insidePacketCallback })
+            return write(name, params)
+          }
+
+          const moved = once(bot, 'forcedMove')
+          client.write('position', {
+            x: 1.5,
+            y: 80,
+            z: 1.5,
+            dx: 0, // 1.21.3
+            dy: 0, // 1.21.3
+            dz: 0, // 1.21.3
+            pitch: 0,
+            yaw: 0,
+            teleportId: 3,
+            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+          })
+          await moved
+          bot._client.write = write
+
+          assert.ok(written.some(p => p.name === 'position_look'), 'the teleport is answered')
+          assert.deepStrictEqual(written.filter(p => p.inline), [], 'no movement packet is written from the position packet callback')
           done()
         })
       })
@@ -579,13 +628,16 @@ for (const supportedVersion of mineflayer.testedVersions) {
           })
           await client.write('login', loginPacket)
           await client.write('map_chunk', chunkPacket)
+          // Wait for the teleport itself rather than for a tick: physics only starts ticking once
+          // the position packet has been handled, which no longer happens inside this write.
+          const teleported = once(bot, 'forcedMove')
           await client.write('position', positionPacket)
           await client.write('update_health', {
             health: 20,
             food: 20,
             foodSaturation: 0
           })
-          await bot.waitForTicks(1)
+          await teleported
           await client.write('respawn', respawnPacket)
         })
       })


### PR DESCRIPTION
Vanilla's `ClientPacketListener.handleMovePlayer` starts with `PacketUtils.ensureRunningOnSameThread`, so a teleport is applied and answered while `Minecraft.runTick` drains `packetProcessor.processQueuedPackets()` — never from the network read that carried it, and never between the packets of a tick.

mineflayer answered inline from the socket read. When a server sends several teleports in one read, each reply is written the moment its packet is parsed, so the replies interleave with the movement packet the physics tick is producing, in an order the vanilla client never sends.

This queues the packets and drains them on `setImmediate`: every packet of the current read is handled first, then the teleports are applied and answered together. The reply is still one `teleport_confirm` + `position_look` per teleport, still before the next tick's movement packet, so nothing about the packets themselves changes — only when they are written.

### Tests

- New: `answers a teleport from the packet queue, not from the read that carried it` — a `prependListener` on the clientbound `position` marks the window in which its listeners run, and a `bot._client.write` wrapper records whether each movement packet was written inside it. Asserts the teleport is answered and that nothing is written from that window. Passes on every tested version.
- `absolute position & relative position (velocity)` now reads velocity and position inside the `forcedMove` listener. The values it asserts are the ones set by the teleport; awaiting the event lets the next tick apply gravity before the assertion runs, which is a property of the `await`, not of the handler.
- `switchWorld respawn` waits for `forcedMove` instead of `bot.waitForTicks(1)`. It needs the teleport to have landed, and physics only starts ticking once that packet is handled, so a tick count is the wrong thing to wait on.

`npm run mocha_test` (internal): 784 passing, 0 failing, twice; `standard` clean.

### Where this showed up

On a 1.8 server behind ViaVersion (JartexNetwork BedWars, protocol 26.1) the client-side reply ordering feeds a server setback loop: the server resends `position` with `teleportId: 0` at the bot's own coordinates, the rate climbs, and an anticheat kicks. Standing still in one lobby, a 40 s window took **683** clientbound teleports with the old handler and **1** over 129 s with this one. Being straight about it: that server still storms in other windows, so this is a parity fix and not a cure for that kick — the reason to take it is that it is what the vanilla client does.