### PR TITLE
game: send the client brand once per connection, as the vanilla client does

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -111,8 +111,11 @@ function inject (bot, options) {
     bot.emit('login')
     bot.emit('game')
 
+    // The brand is sent once per connection: from 1.20.2 node-minecraft-protocol sends it on the
+    // first entry into the configuration state, where the vanilla client sends it after
+    // login_acknowledged. Before the configuration state the client sends it on joining the world.
     // varint length-prefixed string as data
-    bot._client.writeChannel(brandChannel, options.brand)
+    if (!bot.supportFeature('hasConfigurationState')) bot._client.writeChannel(brandChannel, options.brand)
   })
 
   bot._client.on('respawn', (packet) => {


### PR DESCRIPTION
On 1.20.2+ the client brand goes out twice.

node-minecraft-protocol already sends it correctly, on the first entry into the configuration state, which is where the vanilla client sends it (`ClientHandshakePacketListenerImpl`: `login_acknowledged` → `BrandPayload` → `ClientInformation`). `game.js` then writes it again on every `login` packet, so a fresh connection sends two, and every Velocity backend transfer — which re-enters configuration and sends a second `login` — sends another. Vanilla sends none of those: `BrandPayload` appears only in the handshake listener, never in `ClientPacketListener`, and re-entering configuration from play sends nothing.

Before the configuration state existed the client did send the brand on joining the world (1.19.4 `ClientPacketListener.handleLogin`), so the write stays for those versions — the same shape `settings.js` already uses for Client Information:

```js
bot._client.on('login', () => {
  if (!bot.supportFeature('hasConfigurationState')) setSettings({})
})
```

Measured against a live 26.1 server (JartexNetwork, Velocity), tracing every outgoing packet from before the socket opened.

Fresh connection, before:
```
> login_acknowledged [login]
> custom_payload [configuration] vanilla
> settings [configuration]
> select_known_packs [configuration]
> finish_configuration [configuration]
< login
> custom_payload [play] vanilla        <- extra
```

After: the `[play]` one is gone, one brand total.

Backend transfer, before: `< start_configuration … < login` then `> custom_payload [play] vanilla`. After: no brand at all, and the transfer still completes.

`npm run mocha_test`: 763 passing / 73 pending / 4 failing, and unmodified master at the same commit gives 763 / 73 / 4 as well — the failures are the pre-existing flaky `world switchWorld respawn`, which times out on a different random subset of pre-1.20.2 versions on each run (mine: 1.10.2, 1.11.2, 1.18.2, 1.19.3; master's: 1.14.4, 1.15.2, 1.16.5, 1.19.2). Those are all versions where this change is a no-op.