### PR TITLE
Track the abilities the server grants

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -106,6 +106,7 @@
       - [bot.game.serverBrand](#botgameserverbrand)
       - [bot.game.minY](#botgameminy)
       - [bot.game.height](#botgameheight)
+      - [bot.abilities](#botabilities)
       - [bot.physicsEnabled](#botphysicsenabled)
       - [bot.player](#botplayer)
       - [bot.players](#botplayers)
@@ -183,6 +184,7 @@
       - ["death"](#death)
       - ["health"](#health)
       - ["breath"](#breath)
+      - ["abilities" (abilities)](#abilities-abilities)
       - ["entityAttributes" (entity)](#entityattributes-entity)
       - ["entitySwingArm" (entity)](#entityswingarm-entity)
       - ["entityHurt" (entity)](#entityhurt-entity)
@@ -906,6 +908,23 @@ minimum y of the world
 
 world height
 
+#### bot.abilities
+
+What the server last allowed the player in the abilities packet.
+
+```js
+{
+  invulnerable: false,
+  // the server has the player in flight; physics stops applying gravity
+  flying: false,
+  // the player is allowed to start flying
+  mayFly: false,
+  instantBuild: false,
+  flyingSpeed: 0.05,
+  walkingSpeed: 0.1
+}
+```
+
 #### bot.physicsEnabled
 
 Enable physics, default true.
@@ -1320,6 +1339,10 @@ Fires when your hp or food change.
 #### "breath"
 
 Fires when your oxygen level change.
+
+#### "abilities" (abilities)
+
+Fires when the server sends the abilities packet, with the new [bot.abilities](#botabilities).
 
 #### "entityAttributes" (entity)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,7 @@ export interface BotEvents {
   death: () => Promise<void> | void
   health: () => Promise<void> | void
   breath: () => Promise<void> | void
+  abilities: (abilities: Abilities) => Promise<void> | void
   entitySwingArm: (entity: Entity) => Promise<void> | void
   entityHurt: (entity: Entity, source: Entity) => Promise<void> | void
   entityDead: (entity: Entity) => Promise<void> | void
@@ -198,6 +199,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
   oxygenLevel: number
   physics: PhysicsOptions
   physicsEnabled: boolean
+  abilities: Abilities
   time: Time
   quickBarSlot: number
   inventory: Window<StorageEvents>
@@ -533,6 +535,15 @@ export interface Experience {
   level: number
   points: number
   progress: number
+}
+
+export interface Abilities {
+  invulnerable: boolean
+  flying: boolean
+  mayFly: boolean
+  instantBuild: boolean
+  flyingSpeed: number
+  walkingSpeed: number
 }
 
 export interface PhysicsOptions {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,6 +2,7 @@ const mc = require('minecraft-protocol')
 const { EventEmitter } = require('events')
 const pluginLoader = require('./plugin_loader')
 const plugins = {
+  abilities: require('./plugins/abilities'),
   bed: require('./plugins/bed'),
   title: require('./plugins/title'),
   block_actions: require('./plugins/block_actions'),

--- a/lib/plugins/abilities.js
+++ b/lib/plugins/abilities.js
@@ -1,0 +1,36 @@
+module.exports = inject
+
+// ClientboundPlayerAbilitiesPacket's flag bits.
+const FLAG_INVULNERABLE = 1
+const FLAG_FLYING = 2
+const FLAG_MAY_FLY = 4
+const FLAG_INSTANT_BUILD = 8
+
+function inject (bot) {
+  // Abilities' defaults, until the server says otherwise.
+  bot.abilities = {
+    invulnerable: false,
+    flying: false,
+    mayFly: false,
+    instantBuild: false,
+    flyingSpeed: 0.05,
+    walkingSpeed: 0.1
+  }
+
+  bot._client.on('abilities', (packet) => {
+    bot.abilities = {
+      invulnerable: (packet.flags & FLAG_INVULNERABLE) !== 0,
+      flying: (packet.flags & FLAG_FLYING) !== 0,
+      mayFly: (packet.flags & FLAG_MAY_FLY) !== 0,
+      instantBuild: (packet.flags & FLAG_INSTANT_BUILD) !== 0,
+      flyingSpeed: packet.flyingSpeed,
+      walkingSpeed: packet.walkingSpeed
+    }
+    // prismarine-physics reads the flight state off the entity.
+    if (bot.entity) {
+      bot.entity.flying = bot.abilities.flying
+      bot.entity.flyingSpeed = bot.abilities.flyingSpeed
+    }
+    bot.emit('abilities', bot.abilities)
+  })
+}

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -770,6 +770,38 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('abilities', () => {
+      it('tracks what the server allows', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('abilities', (abilities) => {
+            assert.strictEqual(abilities.invulnerable, true)
+            assert.strictEqual(abilities.flying, true)
+            assert.strictEqual(abilities.mayFly, true)
+            assert.strictEqual(abilities.instantBuild, false)
+            assert.strictEqual(abilities.flyingSpeed, 0.05000000074505806)
+            assert.strictEqual(abilities.walkingSpeed, 0.10000000149011612)
+            assert.strictEqual(bot.abilities, abilities)
+            // prismarine-physics reads the flight state off the entity
+            assert.strictEqual(bot.entity.flying, true)
+            done()
+          })
+          client.write('login', bot.test.generateLoginPacket())
+          bot.once('login', () => {
+            // Abilities' own defaults hold until the server sends the packet
+            assert.deepStrictEqual(bot.abilities, {
+              invulnerable: false,
+              flying: false,
+              mayFly: false,
+              instantBuild: false,
+              flyingSpeed: 0.05,
+              walkingSpeed: 0.1
+            })
+            client.write('abilities', { flags: 7, flyingSpeed: 0.05, walkingSpeed: 0.1 })
+          })
+        })
+      })
+    })
+
     describe('entities', () => {
       it('entity id changes on login', (done) => {
         const loginPacket = bot.test.generateLoginPacket()


### PR DESCRIPTION
Closes #1587. Half of #3274.

Nothing in `lib/` reads the clientbound `abilities` packet, so the flight, invulnerability and speeds a server hands out are invisible to a bot. The visible consequence is #3274: the capture there shows a vanilla client hovering after an `abilities` packet with the flying bit while mineflayer keeps falling, and the server's anti-bot check kicks it for exactly that difference.

- `bot.abilities` — `{ invulnerable, flying, mayFly, instantBuild, flyingSpeed, walkingSpeed }`, starting at `Abilities`' own defaults (`0.05` / `0.1`) until the server sends the packet.
- `bot.entity.flying` and `bot.entity.flyingSpeed` carry the flight state to prismarine-physics, which reads them in PrismarineJS/prismarine-physics#142. Until that is released the state is just visible, not acted on; with it the bot hovers like vanilla.
- An `abilities` event fires on each update.

Flag bits are `ClientboundPlayerAbilitiesPacket`'s (1 invulnerable, 2 flying, 4 can-fly, 8 instabuild); the packet's shape is identical from 1.8 through 26.1.

Test in `test/internalTest.js` checks the defaults before the packet and each field after one; it does not pass on master, where `bot.abilities` is undefined. The 21 `switchWorld respawn` failures in the internal suite are already there on master.