### PR TITLE
fix: placeEntity's use_item carries the fields the version declares

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -119,7 +119,6 @@ function inject (bot, { hideErrors }) {
 
   function activateItem (offHand = false) {
     bot.usingHeldItem = true
-    sequence++
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
       bot._client.write('block_place', {
@@ -131,15 +130,23 @@ function inject (bot, { hideErrors }) {
         cursorZ: -1
       })
     } else if (bot.supportFeature('useItemWithOwnPacket')) {
-      bot._client.write('use_item', {
-        hand: offHand ? 1 : 0,
-        sequence,
-        rotation: {
-          x: toNotchianYaw(bot.entity.yaw),
-          y: toNotchianPitch(bot.entity.pitch)
-        }
-      })
+      writeUseItem(offHand)
     }
+  }
+
+  // The use_item packet on its own, without activateItem's usingHeldItem bookkeeping: placing a
+  // boat uses the held item but does not start a continuous use. Shares the sequence counter,
+  // which the server echoes back to acknowledge the prediction.
+  function writeUseItem (offHand = false) {
+    sequence++
+    bot._client.write('use_item', {
+      hand: offHand ? 1 : 0,
+      sequence, // 1.19+
+      rotation: { // 1.21.3+
+        x: toNotchianYaw(bot.entity.yaw),
+        y: toNotchianPitch(bot.entity.pitch)
+      }
+    })
   }
 
   function deactivateItem () {
@@ -896,6 +903,7 @@ function inject (bot, { hideErrors }) {
   bot.activateEntityAt = activateEntityAt
   bot.consume = consume
   bot.activateItem = activateItem
+  bot._writeUseItem = writeUseItem
   bot.deactivateItem = deactivateItem
 
   // not really in the public API

--- a/lib/plugins/place_entity.js
+++ b/lib/plugins/place_entity.js
@@ -36,9 +36,7 @@ function inject (bot) {
 
     if (type === 'boat') {
       if (bot.supportFeature('useItemWithOwnPacket')) {
-        bot._client.write('use_item', {
-          hand: options.offhand ? 1 : 0
-        })
+        bot._writeUseItem(options.offhand)
       } else {
         bot._client.write('block_place', {
           location: { x: -1, y: -1, z: -1 },

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1369,6 +1369,44 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('placeEntity', () => {
+      it('builds a use_item packet this version can serialize', async () => {
+        if (!bot.supportFeature('useItemWithOwnPacket')) return // 1.8 sends block_place instead
+        const Item = require('prismarine-item')(supportedVersion)
+        const boat = registry.itemsByName.oak_boat ?? registry.itemsByName.boat
+        if (!boat) return
+
+        const [client] = await once(server, 'playerJoin')
+        await client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(vec3(1, 65, 1), registry.blocksByName.gold_block.id)
+        await client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+
+        client.write('held_item_slot', { slot: 0 })
+        await sleep(100)
+        const changed = once(bot, 'heldItemChanged')
+        client.write('set_slot', { windowId: 0, slot: 36, item: Item.toNotch(new Item(boat.id, 1)) })
+        await changed
+
+        // Record what is handed to write, so a packet that cannot be serialized is still visible.
+        const written = []
+        const write = bot._client.write.bind(bot._client)
+        bot._client.write = (name, params) => { written.push({ name, params }); return write(name, params) }
+        // Only the packets matter; nothing here places the entity, so do not wait for the spawn.
+        bot._placeEntityWithOptions(bot.blockAt(vec3(1, 65, 1)), vec3(0, 1, 0), { forceLook: 'ignore' }).catch(() => {})
+        await sleep(50)
+        bot._client.write = write
+
+        const useItem = written.find(p => p.name === 'use_item')
+        assert.ok(useItem, 'placeEntity sends use_item for a boat')
+        assert.doesNotThrow(
+          () => bot._client.serializer.proto.createPacketBuffer('packet_use_item', useItem.params),
+          'the use_item packet placeEntity builds has to serialize on this version'
+        )
+      })
+    })
+
     describe('windows', () => {
       const Item = require('prismarine-item')(supportedVersion)
       const pWindows = require('prismarine-windows')(supportedVersion)


### PR DESCRIPTION
Placing a boat sends an extra `use_item` after the block placement, and it was built by hand with a single field:

```js
bot._client.write("use_item", { hand: options.offhand ? 1 : 0 })
```

`use_item` gained `sequence` in 1.19 and `rotation` (a `vec2f`) in 1.21.1, so:

- **1.21.1 and later** — `rotation` serializes from `undefined` and throws `SizeOf error for undefined : Cannot read properties of undefined (reading 'x')` in `Object.vec2f`. The throw happens inside `Serializer._transform`, which errors the write stream and closes the socket with no `kicked` or `error` event on the bot, so `bot.placeEntity` with a boat silently ends the session and the bot looks frozen rather than disconnected.
- **1.19 through 1.20.6** — `sequence` serializes as 0, so every boat placement claims prediction id 0 and the server's acknowledgement never matches.

`activateItem` already builds this packet correctly for every version, so the write moves into a shared `writeUseItem` that owns the `sequence` increment. `activateItem` keeps its `bot.usingHeldItem = true`, which `placeEntity` deliberately does not take: placing a boat uses the item once rather than starting a continuous use, and `usingHeldItem` is only cleared by a held-item change, `set_cooldown` or `deactivateItem`, so setting it there would leave the bot flagged as "using an item" (and therefore not sprinting) indefinitely. The now-dead `sequence++` on the pre-1.9 `block_place` path is dropped; nothing reads it there.

Test `builds a use_item packet this version can serialize` puts a boat in the held slot, runs `_placeEntityWithOptions`, records what is handed to `_client.write` (so a packet that cannot be serialized is still visible), and asserts the recorded `use_item` round-trips through the version's serializer. On master it passes on 1.8.8 through 1.20.6 and fails on 1.21.1, 1.21.3, 1.21.4, 1.21.5, 1.21.6, 1.21.8, 1.21.9, 1.21.11 and 26.1; with the fix all 28 pass. Internal suite 784 passing, `standard` clean.

Found by diffing every `_client.write("name", { ... })` literal in `lib/` against the 26.1 schema; this was the only live call site whose keys did not match a branch the version actually takes.