### PR TITLE
use_item and use_item_on like the vanilla client: shared prediction sequence, cursor on the clicked face, no empty-hand use, swing after the packet

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,7 +42,8 @@ const plugins = {
   anvil: require('./plugins/anvil'),
   place_entity: require('./plugins/place_entity'),
   generic_place: require('./plugins/generic_place'),
-  particle: require('./plugins/particle')
+  particle: require('./plugins/particle'),
+  sequence: require('./plugins/sequence')
 }
 
 const minecraftData = require('minecraft-data')

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -130,7 +130,8 @@ function inject (bot) {
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: bot.targetDigFace // default face is 1 (top)
+      face: bot.targetDigFace, // default face is 1 (top)
+      sequence: bot._nextSequence()
     })
     waitTimeout = setTimeout(finishDigging, waitTime)
     bot.targetDigBlock = block
@@ -149,7 +150,8 @@ function inject (bot) {
         bot._client.write('block_dig', {
           status: 2, // finish digging
           location: bot.targetDigBlock.position,
-          face: bot.targetDigFace // always the same as the start face
+          face: bot.targetDigFace, // always the same as the start face
+          sequence: bot._nextSequence()
         })
       }
       bot.targetDigBlock = null
@@ -178,7 +180,8 @@ function inject (bot) {
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
-        face: cancellationDiggingFace
+        face: cancellationDiggingFace,
+        sequence: 0
       })
       const block = bot.targetDigBlock
       bot.targetDigBlock = null

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -39,10 +39,6 @@ function inject (bot) {
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
 
-    if (options.swingArm) {
-      bot.swingArm(options.swingArm, options.showHand)
-    }
-
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {
         location: pos,
@@ -83,6 +79,11 @@ function inject (bot) {
         sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
+    }
+
+    // The swing must follow use_item_on
+    if (options.swingArm) {
+      bot.swingArm(options.swingArm, options.showHand)
     }
 
     return pos

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -80,7 +80,7 @@ function inject (bot) {
         cursorY: dy,
         cursorZ: dz,
         insideBlock: false,
-        sequence: 0, // 1.19.0
+        sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -198,7 +198,9 @@ function inject (bot, { hideErrors }) {
     // The cursor must lie on the clicked face
     cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
-    await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
+    // The point the packet reports is the one the vanilla client's crosshair ray hit, so the head
+    // faces it; looking at the block's middle instead claims a hit the rotation cannot produce.
+    await bot.lookAt(block.position.plus(cursorPos), false)
     // place block message
     // TODO: logic below can likely be simplified
     if (bot.supportFeature('blockPlaceHasHeldItem')) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -117,6 +117,8 @@ function inject (bot, { hideErrors }) {
   }
 
   function activateItem (offHand = false) {
+    // use_item must not be sent for an empty hand
+    if (!(offHand ? bot.inventory.slots[45] : bot.heldItem)) return
     bot.usingHeldItem = true
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
@@ -193,7 +195,8 @@ function inject (bot, { hideErrors }) {
   async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
-    cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
+    // The cursor must lie on the clicked face
+    cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
     // place block message

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -27,7 +27,6 @@ function inject (bot, { hideErrors }) {
   const windows = require('prismarine-windows')(bot.version)
 
   let eatingTask = createDoneTask()
-  let sequence = 0
 
   let nextActionNumber = 0 // < 1.17
   let stateId = -1
@@ -119,7 +118,6 @@ function inject (bot, { hideErrors }) {
 
   function activateItem (offHand = false) {
     bot.usingHeldItem = true
-    sequence++
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
       bot._client.write('block_place', {
@@ -133,7 +131,7 @@ function inject (bot, { hideErrors }) {
     } else if (bot.supportFeature('useItemWithOwnPacket')) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
-        sequence,
+        sequence: bot._nextSequence(),
         rotation: {
           x: toNotchianYaw(bot.entity.yaw),
           y: toNotchianPitch(bot.entity.pitch)
@@ -236,7 +234,7 @@ function inject (bot, { hideErrors }) {
         cursorY: cursorPos.y,
         cursorZ: cursorPos.z,
         insideBlock: false,
-        sequence: 0, // 1.19.0+
+        sequence: bot._nextSequence(), // 1.19.0+
         worldBorderHit: false // 1.21.3+
       })
     }

--- a/lib/plugins/sequence.js
+++ b/lib/plugins/sequence.js
@@ -1,0 +1,14 @@
+module.exports = inject
+
+// One sequence counter for dig start/stop, use_item_on and use_item. Sent values
+// start at 1; abort, release and drop actions send 0 and must not consume a value.
+function inject (bot) {
+  const hasSequence = bot.registry.isNewerOrEqualTo('1.19')
+  let sequence = 0
+
+  bot._nextSequence = () => {
+    if (!hasSequence) return 0
+    sequence++
+    return sequence
+  }
+}

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -1347,6 +1350,61 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock', () => {
+      it('defaults the cursor to the centre of the clicked face and swings after use_item_on', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          const block = { position: vec3(1, 65, 1) }
+          await bot.activateBlock(block)
+          await bot.activateBlock(block, vec3(-1, 0, 0))
+          try {
+            const scale = bot.supportFeature('blockPlaceHasHandAndFloatCursor') || bot.supportFeature('blockPlaceHasInsideBlock') ? 1 : 16
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_place', 'arm_animation', 'block_place', 'arm_animation'])
+            const cursor = ({ params }) => [params.cursorX / scale, params.cursorY / scale, params.cursorZ / scale, params.direction]
+            assert.deepStrictEqual(cursor(writes[0]), [0.5, 1, 0.5, 1])
+            assert.deepStrictEqual(cursor(writes[2]), [0, 0.5, 0.5, 4])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
+    describe('activateItem', () => {
+      it('does nothing with an empty hand', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.activateItem()
+          bot.activateItem(true)
+          try {
+            assert.deepStrictEqual(writes, [])
+            assert.strictEqual(bot.usingHeldItem, false)
+            bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+            bot.activateItem()
+            assert.deepStrictEqual(writes, [bot.supportFeature('useItemWithOwnPacket') ? 'use_item' : 'block_place'])
+            assert.strictEqual(bot.usingHeldItem, true)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('heldItemChanged', () => {
       it('emits heldItemChanged when the held slot is updated via set_slot', (done) => {
         const Item = require('prismarine-item')(supportedVersion)
@@ -1595,6 +1653,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await sleep(100)
           bot.entity.yaw = testYaw
           bot.entity.pitch = testPitch
+          const Item = require('prismarine-item')(registry)
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
           bot.activateItem()
         })
       })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1514,6 +1514,44 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('block prediction sequence', () => {
+      it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
+        const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]
+        if (!useItemFields?.some(f => f.name === 'sequence')) {
+          this.skip()
+          return
+        }
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push([name, params.sequence]) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+
+          bot.activateItem()
+          bot.deactivateItem()
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore' })
+          bot.activateItem()
+
+          try {
+            assert.deepStrictEqual(writes, [
+              ['use_item', 1],
+              ['block_dig', 0],
+              ['block_place', 2],
+              ['use_item', 3]
+            ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1633,6 +1633,55 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock rotation', () => {
+      it('faces the point on the clicked face that the packet reports', async () => {
+        const blockPos = vec3(1, 65, 1)
+        const stoneId = registry.blocksByName.stone.id
+        const chunk = bot.test.buildChunk()
+        for (let x = 0; x < 16; x++) for (let z = 0; z < 16; z++) chunk.setBlockType(vec3(x, 64, z), stoneId)
+        chunk.setBlockType(blockPos, stoneId)
+        let sent = null
+        await new Promise(resolve => {
+          server.on('playerJoin', async (client) => {
+            client.write('login', bot.test.generateLoginPacket())
+            client.write('map_chunk', generateChunkPacket(chunk))
+            client.write('position', {
+              x: 1.5,
+              y: 65,
+              z: 4.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              yaw: 0,
+              pitch: 0,
+              flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+              teleportId: 0
+            })
+            client.on('packet', (data, meta) => { if (meta.name === 'block_place') sent = data })
+            await sleep(400)
+            resolve()
+          })
+        })
+
+        // the south face, the one an eye at z = 4.5 can see
+        await bot.activateBlock(bot.blockAt(blockPos), vec3(0, 0, 1))
+        await sleep(200)
+        assert.ok(sent, 'no block_place packet')
+
+        const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0)
+        const aim = (point) => {
+          const d = point.minus(eye)
+          return { yaw: Math.atan2(-d.x, -d.z), pitch: Math.atan2(d.y, Math.sqrt(d.x * d.x + d.z * d.z)) }
+        }
+        const hit = aim(blockPos.offset(0.5, 0.5, 1))
+        const middle = aim(blockPos.offset(0.5, 0.5, 0.5))
+        assert.ok(Math.abs(hit.pitch - middle.pitch) > 0.05, 'the two aims must be far enough apart to tell apart')
+        assert.ok(Math.abs(bot.entity.pitch - hit.pitch) < 0.02,
+          `pitch ${bot.entity.pitch} should face the reported hit at ${hit.pitch}, the block's middle is ${middle.pitch}`)
+        assert.ok(Math.abs(bot.entity.yaw - hit.yaw) < 0.02, `yaw ${bot.entity.yaw} should face the reported hit at ${hit.yaw}`)
+      })
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1462,6 +1462,29 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('generic place', () => {
+      it('swings the arm after use_item_on', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore', swingArm: 'right' })
+          try {
+            assert.deepStrictEqual(writes, ['block_place', 'arm_animation'])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('windows', () => {
       const Item = require('prismarine-item')(supportedVersion)
       const pWindows = require('prismarine-windows')(supportedVersion)


### PR DESCRIPTION
The `use_item` / `use_item_on` packets match what the vanilla client sends (`Minecraft.startUseItem`, `MultiPlayerGameMode.useItemOn` / `useItem`, `BlockStatePredictionHandler`):

- **One block prediction sequence.** Vanilla keeps a single counter in `BlockStatePredictionHandler` that dig start/stop, `use_item_on` and `use_item` all draw from (first value 1); abort, release and drop actions send 0. mineflayer only counted `use_item` and sent 0 elsewhere, so the server's block change acks did not line up. Adds `lib/plugins/sequence.js` (`bot._nextSequence()`; versions before 1.19 have no sequence field, so the value is simply not serialized there) and wires it into `block_dig` start/stop, `use_item_on` (`generic_place`, `activateBlock`) and `use_item`.
- **`activateBlock`'s cursor defaults to the centre of the clicked face** (`0.5 + face * 0.5` per axis): the cursor is where the crosshair hits the block, and the old `(0.5, 0.5, 0.5)` is inside the block, impossible for a real client.
- **`activateItem` no-ops with an empty hand**, like `startUseItem` (`!itemStack.isEmpty()`). The pre-existing `activateItem rotation` test now holds an item.
- **The arm swings after `use_item_on` when placing**, not before: vanilla only swings once `useItemOn` returns a success.

Tests: `shares one pre-incremented counter across use_item and use_item_on, 0 on release`, `defaults the cursor to the centre of the clicked face and swings after use_item_on`, `does nothing with an empty hand`, `swings the arm after use_item_on`.

#4094 (digging) is based on this branch.

Split from #4066 (the interaction-parity audit); absorbs #4090 and #4091.


