### PR TITLE
Send the client_command respawn after win_game with the actionId field

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -123,7 +123,7 @@ function inject (bot, options) {
 
   bot._client.on('game_state_change', (packet) => {
     if ((packet.reason === 4 || packet.reason === 'win_game') && packet.gameMode === 1) {
-      bot._client.write('client_command', { action: 0 })
+      bot._client.write('client_command', bot.supportFeature('respawnIsPayload') ? { payload: 0 } : { actionId: 0 })
     }
     if ((packet.reason === 3) || (packet.reason === 'change_game_mode')) {
       bot.game.gameMode = parseGameMode(packet.gameMode)


### PR DESCRIPTION
The packet field is `actionId` (`payload` on 1.8), as `health.js` already sends; the `action` key was ignored and the varint happened to encode as 0.

Split from #4066 (the interaction-parity audit).