### PR TITLE
Report resource packs as ACCEPTED, DOWNLOADED, SUCCESSFULLY_LOADED and deny once

### DIFF
--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -8,7 +8,12 @@ function inject (bot) {
     SUCCESSFULLY_LOADED: 0,
     DECLINED: 1,
     FAILED_DOWNLOAD: 2,
-    ACCEPTED: 3
+    ACCEPTED: 3,
+    // 1.20.3+
+    DOWNLOADED: 4,
+    INVALID_URL: 5,
+    FAILED_RELOAD: 6,
+    DISCARDED: 7
   }
 
   bot._client.on('add_resource_pack', (data) => { // Emits the same as resource_pack_send but sends uuid rather than hash because that's how active packs are tracked
@@ -49,45 +54,27 @@ function inject (bot) {
     if (bot._client.state === 'configuration') acceptResourcePack()
   })
 
-  function acceptResourcePack () {
+  function sendResourcePackResult (result) {
+    const packet = { result }
     if (bot.supportFeature('resourcePackUsesHash')) {
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.ACCEPTED,
-        hash: latestHash
-      })
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED,
-        hash: latestHash
-      })
+      packet.hash = latestHash
     } else if (bot.supportFeature('resourcePackUsesUUID')) {
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.ACCEPTED
-      })
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
-      })
-    } else {
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.ACCEPTED
-      })
-      bot._client.write('resource_pack_receive', {
-        result: TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED
-      })
+      packet.uuid = latestUUID
     }
+    bot._client.write('resource_pack_receive', packet)
+  }
+
+  // Results must be sent in the order ACCEPTED, DOWNLOADED (1.20.3+), SUCCESSFULLY_LOADED
+  function acceptResourcePack () {
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.ACCEPTED)
+    if (bot.supportFeature('resourcePackUsesUUID')) {
+      sendResourcePackResult(TEXTURE_PACK_RESULTS.DOWNLOADED)
+    }
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.SUCCESSFULLY_LOADED)
   }
 
   function denyResourcePack () {
-    if (bot.supportFeature('resourcePackUsesUUID')) {
-      bot._client.write('resource_pack_receive', {
-        uuid: latestUUID,
-        result: TEXTURE_PACK_RESULTS.DECLINED
-      })
-    }
-    bot._client.write('resource_pack_receive', {
-      result: TEXTURE_PACK_RESULTS.DECLINED
-    })
+    sendResourcePackResult(TEXTURE_PACK_RESULTS.DECLINED)
   }
 
   bot.acceptResourcePack = acceptResourcePack

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -532,6 +535,70 @@ for (const supportedVersion of mineflayer.testedVersions) {
         const buf = serializer.createPacketBuffer({ name: accept.name, params: accept.params })
         assert(buf.includes(expectedBytes),
           'resource_pack_receive must carry the pack UUID bytes, not a zero UUID')
+      })
+    })
+
+    describe('resource pack', () => {
+      function packetHas (name) {
+        const fields = registry.protocol?.play?.toServer?.types?.packet_resource_pack_receive?.[1] ??
+          registry.protocol?.configuration?.toServer?.types?.packet_resource_pack_receive?.[1]
+        return fields?.some(f => f.name === name)
+      }
+      const packUuid = '8ef4746b-93b7-3c32-9dcb-b375016c114d'
+
+      it('accepts with the vanilla status sequence', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          if (packetHas('uuid')) {
+            bot._client.emit('add_resource_pack', { uuid: packUuid, url: 'http://example.com/pack.zip', forced: false })
+          } else {
+            bot._client.emit('resource_pack_send', { url: 'http://example.com/pack.zip', hash: 'abc' })
+          }
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          bot.acceptResourcePack()
+          try {
+            assert.ok(writes.every(w => w.name === 'resource_pack_receive'))
+            assert.deepStrictEqual(writes.map(w => w.params.result), packetHas('uuid') ? [3, 4, 0] : [3, 0])
+            for (const { params } of writes) {
+              if (packetHas('uuid')) assert.ok(params.uuid, 'accept must carry the pack uuid')
+              else assert.strictEqual(params.uuid, undefined)
+              if (packetHas('hash')) assert.strictEqual(params.hash, 'abc')
+              else assert.strictEqual(params.hash, undefined)
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('denies with a single DECLINED', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          if (packetHas('uuid')) {
+            bot._client.emit('add_resource_pack', { uuid: packUuid, url: 'http://example.com/pack.zip', forced: false })
+          }
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          bot.denyResourcePack()
+          try {
+            assert.strictEqual(writes.length, 1)
+            assert.strictEqual(writes[0].name, 'resource_pack_receive')
+            assert.strictEqual(writes[0].params.result, 1)
+            if (packetHas('uuid')) assert.ok(writes[0].params.uuid, 'deny must carry the pack uuid')
+            else assert.strictEqual(writes[0].params.uuid, undefined)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
       })
     })
 


### PR DESCRIPTION
Vanilla (`ServerPackManager` / `DownloadedPackSource`) answers a pack with ACCEPTED, then DOWNLOADED, then SUCCESSFULLY_LOADED; DOWNLOADED and the other 1.20.3+ statuses were missing from the results table. `denyResourcePack` also sent a second DECLINED without the uuid on 1.20.3+ (after the uuid branch), which fails to serialize; accept/deny now go through one `sendResourcePackResult` sender and denial sends a single DECLINED.

Composes with #4061 (`latestUUID` stays the wire UUID string).

Tests: `accepts with the vanilla status sequence`, `denies with a single DECLINED`.

Split from #4066 (the interaction-parity audit).