### PR TITLE
internal tests: wait for plugin injection before driving the bot from playerJoin

### DIFF
--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -592,6 +595,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
           teleportId: 0
         }
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           bot.once('respawn', () => {
             assert.ok(bot.world.getColumn(0, 0) !== undefined)
             bot.once('respawn', () => {
@@ -1527,6 +1531,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
         const testYaw = 1.5
         const testPitch = -0.3
         server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
           await client.write('login', bot.test.generateLoginPacket())
           await client.write('position', {
             x: 0,


### PR DESCRIPTION
`createBot` injects the plugins on a timer, so the mock server's `playerJoin` can fire first; the internal tests then call bot methods that do not exist yet (seen as `bot.waitForTicks is not a function` in the switch world respawn).

Adds `bot.test.pluginsLoaded` (a promise resolved on `inject_allowed`) and awaits it in the pre-existing flaky tests (switch world respawn, `activateItem rotation`). The new interaction tests from the other PRs split out of #4066 await it as well.

Split from #4066 (the interaction-parity audit).