### PR TITLE
Right-click entities like the vanilla client: interact pair, real sneak state, hit point; useOn and mount share the path

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -823,9 +823,7 @@ function inject (bot) {
 
   bot.swingArm = swingArm
   bot.attack = attack
-  bot.mount = mount
   bot.dismount = dismount
-  bot.useOn = useOn
   bot.moveVehicle = moveVehicle
 
   function swingArm (arm = 'right', showHand = true) {
@@ -835,10 +833,10 @@ function inject (bot) {
     bot._client.write('arm_animation', packet)
   }
 
-  function useOn (target) {
-    // TODO: check if not crouching will make make this action always use the item
-    useEntity(target, 0)
-  }
+  // An attack carries no hit location, only the sneak state; 26.1 moved it to its own packet.
+  const attackEntity = bot.supportFeature('attackUsesOwnPacket')
+    ? (target) => bot._client.write('attack', { entityId: target.id })
+    : (target) => bot._client.write('use_entity', { target: target.id, mouse: 1, sneaking: bot.getControlState('sneak') })
 
   function attack (target, swing = true) {
     // arm animation comes before the use_entity packet on 1.8
@@ -846,18 +844,13 @@ function inject (bot) {
       if (swing) {
         swingArm()
       }
-      useEntity(target, 1)
+      attackEntity(target)
     } else {
-      useEntity(target, 1)
+      attackEntity(target)
       if (swing) {
         swingArm()
       }
     }
-  }
-
-  function mount (target) {
-    // TODO: check if crouching will make make this action always mount
-    useEntity(target, 0)
   }
 
   function moveVehicle (left, forward) {
@@ -899,32 +892,6 @@ function inject (bot) {
       }
     } else {
       bot.emit('error', new Error('dismount: not mounted'))
-    }
-  }
-
-  function useEntity (target, leftClick, x, y, z) {
-    const sneaking = bot.getControlState('sneak')
-    if (leftClick && bot.supportFeature('attackUsesOwnPacket')) {
-      bot._client.write('attack', {
-        entityId: target.id
-      })
-    } else if (x && y && z) {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        x,
-        y,
-        z,
-        sneaking,
-        location: new Vec3(x, y, z)
-      })
-    } else {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        sneaking,
-        location: new Vec3(0, 0, 0)
-      })
     }
   }
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -245,71 +245,67 @@ function inject (bot, { hideErrors }) {
     bot.swingArm()
   }
 
-  // Where the line from the eye to the entity's middle enters its bounding box, relative to the
-  // entity. Falls back to the middle itself for an entity of unknown size.
+  // Where the line from the eye to the middle of the entity's bounding box enters the box, relative
+  // to the entity: the hit vanilla reports for a player looking at the entity's middle.
   function hitVector (entity) {
-    const middle = new Vec3(0, (entity.height ?? 0) / 2, 0)
-    const width = entity.width ?? 0
-    const height = entity.height ?? 0
-    if (width <= 0 || height <= 0) return middle
+    // An entity type minecraft-data does not know has no size, so its position stands in.
+    if (entity.width == null || entity.height == null) return new Vec3(0, 0, 0)
+    const middle = new Vec3(0, entity.height / 2, 0)
     const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0).minus(entity.position)
-    const dir = middle.minus(eye)
-    const half = width / 2
-    let near = 0
-    for (const [from, to, o, d] of [[-half, half, eye.x, dir.x], [0, height, eye.y, dir.y], [-half, half, eye.z, dir.z]]) {
-      if (d === 0) continue
-      const t1 = (from - o) / d
-      const t2 = (to - o) / d
-      near = Math.max(near, Math.min(t1, t2))
+    const toMiddle = middle.minus(eye)
+    // Slab test: parameters along the line run from 0 at the eye to 1 at the middle, each axis bounds
+    // the box to a parameter interval, and the line enters the box at the latest interval start. An
+    // axis the line does not move along already has the middle's coordinate, inside the box.
+    const half = entity.width / 2
+    let entry = 0
+    for (const [min, max, at, step] of [[-half, half, eye.x, toMiddle.x], [0, entity.height, eye.y, toMiddle.y], [-half, half, eye.z, toMiddle.z]]) {
+      if (step === 0) continue
+      entry = Math.max(entry, Math.min((min - at) / step, (max - at) / step))
     }
-    if (!(near > 0) || near > 1) return middle
-    return eye.plus(dir.scaled(near))
+    // Every interval starts behind the eye: the eye is inside the box.
+    if (entry === 0) return middle
+    return eye.plus(toMiddle.scaled(entry))
   }
 
+  // 26.1 folded interact_at into interact: one use_entity carries the hit point. Earlier versions send
+  // interact_at, then interact. The server applies the packet's sneak flag as the player's shift state.
+  const interactEntity = bot.supportFeature('useEntityHasLocation')
+    ? (entity, hit) => {
+        bot._client.write('use_entity', {
+          target: entity.id,
+          hand: 0, // main hand
+          location: hit,
+          sneaking: bot.getControlState('sneak')
+        })
+      }
+    : (entity, hit) => {
+        const sneaking = bot.getControlState('sneak')
+        bot._client.write('use_entity', {
+          target: entity.id,
+          mouse: 2, // interact at
+          x: hit.x,
+          y: hit.y,
+          z: hit.z,
+          hand: 0, // main hand
+          sneaking
+        })
+        bot._client.write('use_entity', {
+          target: entity.id,
+          mouse: 0, // interact
+          hand: 0, // main hand
+          sneaking
+        })
+      }
+
   async function activateEntity (entity) {
-    await bot.lookAt(entity.position.offset(0, (entity.height ?? 0) / 2, 0), false)
-    interactEntity(entity, hitVector(entity))
+    const hit = hitVector(entity)
+    await bot.lookAt(entity.position.plus(hit), false)
+    interactEntity(entity, hit)
   }
 
   async function activateEntityAt (entity, position) {
     await bot.lookAt(position, false)
     interactEntity(entity, position.minus(entity.position))
-  }
-
-  // 26.1+ has a single interact packet carrying the hit point; earlier
-  // versions send interact_at (hit point relative to the entity) followed by
-  // interact, and both must carry the same sneak state
-  const useEntityFields = bot.registry.protocol.play.toServer.types.packet_use_entity[1]
-  const useEntityHasLocation = useEntityFields.some(field => field.name === 'location')
-  // 26.1 declares the hand as a mapper; every earlier version takes the id.
-  const handType = useEntityFields.find(field => field.name === 'hand')?.type
-  const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
-  function interactEntity (entity, hit) {
-    const sneaking = bot.getControlState('sneak')
-    if (useEntityHasLocation) {
-      bot._client.write('use_entity', {
-        target: entity.id,
-        hand: mainHand,
-        location: hit,
-        sneaking
-      })
-      return
-    }
-    bot._client.write('use_entity', {
-      target: entity.id,
-      mouse: 2, // interact at
-      x: hit.x,
-      y: hit.y,
-      z: hit.z,
-      hand: mainHand,
-      sneaking
-    })
-    bot._client.write('use_entity', {
-      target: entity.id,
-      mouse: 0, // interact
-      hand: mainHand,
-      sneaking
-    })
   }
 
   async function transfer (options) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -248,8 +248,9 @@ function inject (bot, { hideErrors }) {
   // Where the line from the eye to the middle of the entity's bounding box enters the box, relative
   // to the entity: the hit vanilla reports for a player looking at the entity's middle.
   function hitVector (entity) {
-    // An entity type minecraft-data does not know has no size, so its position stands in.
-    if (entity.width == null || entity.height == null) return new Vec3(0, 0, 0)
+    // prismarine-entity starts every entity at a zero size and only a type minecraft-data knows is
+    // given one, so a flat box means the bot does not know the size: the entity position stands in.
+    if (!entity.width || !entity.height) return new Vec3(0, 0, 0)
     const middle = new Vec3(0, entity.height / 2, 0)
     const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0).minus(entity.position)
     const toMiddle = middle.minus(eye)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -308,6 +308,14 @@ function inject (bot, { hideErrors }) {
     interactEntity(entity, position.minus(entity.position))
   }
 
+  function useOn (entity) {
+    interactEntity(entity, hitVector(entity))
+  }
+
+  function mount (entity) {
+    interactEntity(entity, hitVector(entity))
+  }
+
   async function transfer (options) {
     const window = options.window || bot.currentWindow || bot.inventory
     const itemType = options.itemType
@@ -930,6 +938,8 @@ function inject (bot, { hideErrors }) {
   bot.activateBlock = activateBlock
   bot.activateEntity = activateEntity
   bot.activateEntityAt = activateEntityAt
+  bot.useOn = useOn
+  bot.mount = mount
   bot.consume = consume
   bot.activateItem = activateItem
   bot.deactivateItem = deactivateItem

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -245,30 +245,70 @@ function inject (bot, { hideErrors }) {
     bot.swingArm()
   }
 
+  // Where the line from the eye to the entity's middle enters its bounding box, relative to the
+  // entity. Falls back to the middle itself for an entity of unknown size.
+  function hitVector (entity) {
+    const middle = new Vec3(0, (entity.height ?? 0) / 2, 0)
+    const width = entity.width ?? 0
+    const height = entity.height ?? 0
+    if (width <= 0 || height <= 0) return middle
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0).minus(entity.position)
+    const dir = middle.minus(eye)
+    const half = width / 2
+    let near = 0
+    for (const [from, to, o, d] of [[-half, half, eye.x, dir.x], [0, height, eye.y, dir.y], [-half, half, eye.z, dir.z]]) {
+      if (d === 0) continue
+      const t1 = (from - o) / d
+      const t2 = (to - o) / d
+      near = Math.max(near, Math.min(t1, t2))
+    }
+    if (!(near > 0) || near > 1) return middle
+    return eye.plus(dir.scaled(near))
+  }
+
   async function activateEntity (entity) {
-    // TODO: tell the server that we are not sneaking while doing this
-    await bot.lookAt(entity.position.offset(0, 1, 0), false)
-    bot._client.write('use_entity', {
-      target: entity.id,
-      mouse: 0, // interact with entity
-      sneaking: false,
-      hand: 0, // interact with the main hand
-      location: new Vec3(0, 0, 0)
-    })
+    await bot.lookAt(entity.position.offset(0, (entity.height ?? 0) / 2, 0), false)
+    interactEntity(entity, hitVector(entity))
   }
 
   async function activateEntityAt (entity, position) {
-    // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(position, false)
+    interactEntity(entity, position.minus(entity.position))
+  }
+
+  // 26.1+ has a single interact packet carrying the hit point; earlier
+  // versions send interact_at (hit point relative to the entity) followed by
+  // interact, and both must carry the same sneak state
+  const useEntityFields = bot.registry.protocol.play.toServer.types.packet_use_entity[1]
+  const useEntityHasLocation = useEntityFields.some(field => field.name === 'location')
+  // 26.1 declares the hand as a mapper; every earlier version takes the id.
+  const handType = useEntityFields.find(field => field.name === 'hand')?.type
+  const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
+  function interactEntity (entity, hit) {
+    const sneaking = bot.getControlState('sneak')
+    if (useEntityHasLocation) {
+      bot._client.write('use_entity', {
+        target: entity.id,
+        hand: mainHand,
+        location: hit,
+        sneaking
+      })
+      return
+    }
     bot._client.write('use_entity', {
       target: entity.id,
-      mouse: 2, // interact with entity at
-      sneaking: false,
-      hand: 0, // interact with the main hand
-      x: position.x - entity.position.x,
-      y: position.y - entity.position.y,
-      z: position.z - entity.position.z,
-      location: position.subtract(entity.position)
+      mouse: 2, // interact at
+      x: hit.x,
+      y: hit.y,
+      z: hit.z,
+      hand: mainHand,
+      sneaking
+    })
+    bot._client.write('use_entity', {
+      target: entity.id,
+      mouse: 0, // interact
+      hand: mainHand,
+      sneaking
     })
   }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -779,18 +779,36 @@ for (const supportedVersion of mineflayer.testedVersions) {
         return p
       }
 
-      it('activateEntity sends the vanilla interact packets with the sneak state', (done) => {
+      // Before 26.1 one right click is interact_at then interact; from 26.1 on it is a single
+      // located interact.
+      const perClick = () => (registry.supportFeature('useEntityHasLocation') ? 1 : 2)
+      const hitOf = ({ location, x, y, z }) => location ?? vec3(x, y, z)
+
+      // Logs in, then runs the body, handing it a reader for the use_entity packets sent so far.
+      // Every write goes through the real serializer first, so a packet this version cannot carry
+      // fails the test where it is sent instead of leaving done() uncalled and the test timing out.
+      const afterLogin = (done, body) => {
         server.on('playerJoin', async (client) => {
-          const loggedIn = once(bot, 'login')
-          await client.write('login', bot.test.generateLoginPacket())
-          await loggedIn
-          bot.lookAt = async () => {}
-          const writes = []
-          // Every write must match this version's packet shape.
-          bot._client.write = (name, params) => {
-            bot._client.serializer.createPacketBuffer({ name, params })
-            writes.push({ name, params })
+          try {
+            const loggedIn = once(bot, 'login')
+            await client.write('login', bot.test.generateLoginPacket())
+            await loggedIn
+            const writes = []
+            bot._client.write = (name, params) => {
+              bot._client.serializer.createPacketBuffer({ name, params })
+              writes.push({ name, params })
+            }
+            await body(() => writes.filter(w => w.name === 'use_entity'))
+            done()
+          } catch (err) {
+            done(err)
           }
+        })
+      }
+
+      it('activateEntity sends the vanilla interact packets with the sneak state', (done) => {
+        afterLogin(done, async (sent) => {
+          bot.lookAt = async () => {}
           bot.setControlState('sneak', true)
           // Eye at (0, 1.62, -4) relative to the entity, so the line to its middle enters the box
           // through the face at z = -0.5.
@@ -798,109 +816,64 @@ for (const supportedVersion of mineflayer.testedVersions) {
           const entity = { id: 7, position: vec3(3, 64, 3), width: 1, height: 1.95 }
           await bot.activateEntity(entity)
           await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
-          try {
-            const params = writes.filter(w => w.name === 'use_entity').map(w => rounded(w.params))
-            assert.deepStrictEqual(params, registry.supportFeature('useEntityHasLocation')
-              ? [
-                  { target: 7, hand: 0, location: vec3(0, 1.055625, -0.5), sneaking: true },
-                  { target: 7, hand: 0, location: vec3(0.5, 1, 0), sneaking: true }
-                ]
-              : [
-                  { target: 7, mouse: 2, x: 0, y: 1.055625, z: -0.5, hand: 0, sneaking: true },
-                  { target: 7, mouse: 0, hand: 0, sneaking: true },
-                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
-                  { target: 7, mouse: 0, hand: 0, sneaking: true }
-                ])
-            done()
-          } catch (err) {
-            done(err)
-          }
+          assert.deepStrictEqual(sent().map(w => rounded(w.params)), registry.supportFeature('useEntityHasLocation')
+            ? [
+                { target: 7, hand: 0, location: vec3(0, 1.055625, -0.5), sneaking: true },
+                { target: 7, hand: 0, location: vec3(0.5, 1, 0), sneaking: true }
+              ]
+            : [
+                { target: 7, mouse: 2, x: 0, y: 1.055625, z: -0.5, hand: 0, sneaking: true },
+                { target: 7, mouse: 0, hand: 0, sneaking: true },
+                { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
+                { target: 7, mouse: 0, hand: 0, sneaking: true }
+              ])
         })
       })
 
       it('useOn and mount send the same interact pair as activateEntity', (done) => {
-        server.on('playerJoin', async (client) => {
-          const loggedIn = once(bot, 'login')
-          await client.write('login', bot.test.generateLoginPacket())
-          await loggedIn
-          const writes = []
-          bot._client.write = (name, params) => {
-            bot._client.serializer.createPacketBuffer({ name, params })
-            writes.push({ name, params })
-          }
+        afterLogin(done, async (sent) => {
           bot.entity.position = vec3(0, 64, 3)
           const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
           bot.useOn(entity)
           bot.mount(entity)
-          try {
-            // One right click is interact_at then interact before 26.1, and a single located
-            // interact from 26.1 on; either way both actions send the same thing.
-            const perClick = registry.supportFeature('useEntityHasLocation') ? 1 : 2
-            const sent = writes.filter(w => w.name === 'use_entity')
-            assert.strictEqual(sent.length, 2 * perClick)
-            assert.deepStrictEqual(sent.slice(0, perClick), sent.slice(perClick))
-            const hit = sent[0].params.location ?? vec3(sent[0].params.x, sent[0].params.y, sent[0].params.z)
-            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
-            assert.ok(sent.every(w => w.params.mouse !== 1), 'a right click never sends the attack action')
-            done()
-          } catch (err) {
-            done(err)
-          }
+          // Both actions are one right click, so both send what activateEntity sends.
+          assert.strictEqual(sent().length, 2 * perClick())
+          assert.deepStrictEqual(sent().slice(0, perClick()), sent().slice(perClick()))
+          const hit = hitOf(sent()[0].params)
+          assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+          assert.ok(sent().every(w => w.params.mouse !== 1), 'a right click never sends the attack action')
         })
       })
 
       it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
-        server.on('playerJoin', async (client) => {
-          const loggedIn = once(bot, 'login')
-          await client.write('login', bot.test.generateLoginPacket())
-          await loggedIn
+        afterLogin(done, async (sent) => {
           const looks = []
           bot.lookAt = async (point) => { looks.push(point) }
-          const writes = []
-          bot._client.write = (name, params) => {
-            bot._client.serializer.createPacketBuffer({ name, params })
-            writes.push({ name, params })
-          }
           bot.entity.position = vec3(0, 64, 3)
           // Straight along +x, so the line enters the box at half its width on the near side.
           const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
           await bot.activateEntity(entity)
-          try {
-            const first = writes.find(w => w.name === 'use_entity').params
-            const hit = first.location ?? vec3(first.x, first.y, first.z)
-            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
-            assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
-            assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
-            assert.deepStrictEqual(looks, [entity.position.plus(hit)])
-            done()
-          } catch (err) {
-            done(err)
-          }
+          const hit = hitOf(sent()[0].params)
+          assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+          assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
+          assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
+          assert.deepStrictEqual(looks, [entity.position.plus(hit)])
         })
       })
 
       it('activateEntity on an entity of unknown size hits its position', (done) => {
-        server.on('playerJoin', async (client) => {
-          const loggedIn = once(bot, 'login')
-          await client.write('login', bot.test.generateLoginPacket())
-          await loggedIn
+        afterLogin(done, async (sent) => {
           bot.lookAt = async () => {}
-          const writes = []
-          bot._client.write = (name, params) => {
-            bot._client.serializer.createPacketBuffer({ name, params })
-            writes.push({ name, params })
-          }
-          // An entity type minecraft-data does not know is spawned without a width or height.
-          const entity = { id: 7, position: vec3(3, 64, 3) }
-          await bot.activateEntity(entity)
-          try {
-            const first = writes.find(w => w.name === 'use_entity').params
-            const hit = first.location ?? vec3(first.x, first.y, first.z)
-            assert.deepStrictEqual(hit, vec3(0, 0, 0))
-            done()
-          } catch (err) {
-            done(err)
-          }
+          bot.entity.position = vec3(0, 64, 3)
+          // prismarine-entity leaves an entity type minecraft-data does not know at the zero size it
+          // starts with; an entity built by hand may carry no size field at all.
+          const entities = [
+            { id: 7, position: vec3(3, 64, 3), width: 0, height: 0 },
+            { id: 7, position: vec3(3, 64, 3) }
+          ]
+          for (const entity of entities) await bot.activateEntity(entity)
+          assert.strictEqual(sent().length, entities.length * perClick())
+          for (const w of sent()) assert.deepStrictEqual(hitOf(w.params), vec3(0, 0, 0))
         })
       })
     })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -818,6 +818,37 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('useOn and mount send the same interact pair as activateEntity', (done) => {
+        server.on('playerJoin', async (client) => {
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          bot.useOn(entity)
+          bot.mount(entity)
+          try {
+            // One right click is interact_at then interact before 26.1, and a single located
+            // interact from 26.1 on; either way both actions send the same thing.
+            const perClick = registry.supportFeature('useEntityHasLocation') ? 1 : 2
+            const sent = writes.filter(w => w.name === 'use_entity')
+            assert.strictEqual(sent.length, 2 * perClick)
+            assert.deepStrictEqual(sent.slice(0, perClick), sent.slice(perClick))
+            const hit = sent[0].params.location ?? vec3(sent[0].params.x, sent[0].params.y, sent[0].params.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(sent.every(w => w.params.mouse !== 1), 'a right click never sends the attack action')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
       it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
         server.on('playerJoin', async (client) => {
           const loggedIn = once(bot, 'login')

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -767,6 +770,77 @@ for (const supportedVersion of mineflayer.testedVersions) {
         const [block, isOpen] = await reopened
         assert.ok(block.position.equals(pos))
         assert.strictEqual(isOpen, 1)
+      })
+    })
+
+    describe('entity interaction', () => {
+      it('activateEntity sends the vanilla interact packets at mid height, with the sneak state', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          // Every write must match this version's packet shape.
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.setControlState('sneak', true)
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.95 }
+          await bot.activateEntity(entity)
+          await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
+          try {
+            const fields = registry.protocol.play.toServer.types.packet_use_entity[1]
+            const useEntityHasLocation = fields.some(field => field.name === 'location')
+            const handType = fields.find(field => field.name === 'hand')?.type
+            const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
+            assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), useEntityHasLocation
+              ? [
+                  { target: 7, hand: mainHand, location: vec3(0, 0.975, 0), sneaking: true },
+                  { target: 7, hand: mainHand, location: vec3(0.5, 1, 0), sneaking: true }
+                ]
+              : [
+                  { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: mainHand, sneaking: true },
+                  { target: 7, mouse: 0, hand: mainHand, sneaking: true }
+                ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          // Straight along +x, so the ray enters the box at half its width on the near side.
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          await bot.activateEntity(entity)
+          try {
+            const first = writes.find(w => w.name === 'use_entity').params
+            const hit = first.location ?? vec3(first.x, first.y, first.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
+            assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
       })
     })
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,9 +69,6 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
-      // Plugins are injected on a timer after createBot, which can lose the
-      // race against the mock server's playerJoin
-      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -774,9 +771,16 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
 
     describe('entity interaction', () => {
-      it('activateEntity sends the vanilla interact packets at mid height, with the sneak state', (done) => {
+      // Hit points are on the box surface; the packet carries whatever float the geometry produced.
+      const rounded = (params) => {
+        const p = { ...params }
+        for (const k of ['x', 'y', 'z']) if (k in p) p[k] = Math.round(p[k] * 1e6) / 1e6
+        if (p.location) p.location = vec3(rounded({ x: p.location.x, y: p.location.y, z: p.location.z }))
+        return p
+      }
+
+      it('activateEntity sends the vanilla interact packets with the sneak state', (done) => {
         server.on('playerJoin', async (client) => {
-          await bot.test.pluginsLoaded
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -788,24 +792,24 @@ for (const supportedVersion of mineflayer.testedVersions) {
             writes.push({ name, params })
           }
           bot.setControlState('sneak', true)
-          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.95 }
+          // Eye at (0, 1.62, -4) relative to the entity, so the line to its middle enters the box
+          // through the face at z = -0.5.
+          bot.entity.position = vec3(3, 64, -1)
+          const entity = { id: 7, position: vec3(3, 64, 3), width: 1, height: 1.95 }
           await bot.activateEntity(entity)
           await bot.activateEntityAt(entity, vec3(3.5, 65, 3))
           try {
-            const fields = registry.protocol.play.toServer.types.packet_use_entity[1]
-            const useEntityHasLocation = fields.some(field => field.name === 'location')
-            const handType = fields.find(field => field.name === 'hand')?.type
-            const mainHand = Array.isArray(handType) && handType[0] === 'mapper' ? 'main_hand' : 0
-            assert.deepStrictEqual(writes.filter(w => w.name === 'use_entity').map(w => w.params), useEntityHasLocation
+            const params = writes.filter(w => w.name === 'use_entity').map(w => rounded(w.params))
+            assert.deepStrictEqual(params, registry.supportFeature('useEntityHasLocation')
               ? [
-                  { target: 7, hand: mainHand, location: vec3(0, 0.975, 0), sneaking: true },
-                  { target: 7, hand: mainHand, location: vec3(0.5, 1, 0), sneaking: true }
+                  { target: 7, hand: 0, location: vec3(0, 1.055625, -0.5), sneaking: true },
+                  { target: 7, hand: 0, location: vec3(0.5, 1, 0), sneaking: true }
                 ]
               : [
-                  { target: 7, mouse: 2, x: 0, y: 0.975, z: 0, hand: mainHand, sneaking: true },
-                  { target: 7, mouse: 0, hand: mainHand, sneaking: true },
-                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: mainHand, sneaking: true },
-                  { target: 7, mouse: 0, hand: mainHand, sneaking: true }
+                  { target: 7, mouse: 2, x: 0, y: 1.055625, z: -0.5, hand: 0, sneaking: true },
+                  { target: 7, mouse: 0, hand: 0, sneaking: true },
+                  { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: 0, sneaking: true },
+                  { target: 7, mouse: 0, hand: 0, sneaking: true }
                 ])
             done()
           } catch (err) {
@@ -816,7 +820,36 @@ for (const supportedVersion of mineflayer.testedVersions) {
 
       it('aims activateEntity at the face of the hitbox the bot looks at', (done) => {
         server.on('playerJoin', async (client) => {
-          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const looks = []
+          bot.lookAt = async (point) => { looks.push(point) }
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          // Straight along +x, so the line enters the box at half its width on the near side.
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          await bot.activateEntity(entity)
+          try {
+            const first = writes.find(w => w.name === 'use_entity').params
+            const hit = first.location ?? vec3(first.x, first.y, first.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
+            assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
+            assert.deepStrictEqual(looks, [entity.position.plus(hit)])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('activateEntity on an entity of unknown size hits its position', (done) => {
+        server.on('playerJoin', async (client) => {
           const loggedIn = once(bot, 'login')
           await client.write('login', bot.test.generateLoginPacket())
           await loggedIn
@@ -826,16 +859,13 @@ for (const supportedVersion of mineflayer.testedVersions) {
             bot._client.serializer.createPacketBuffer({ name, params })
             writes.push({ name, params })
           }
-          bot.entity.position = vec3(0, 64, 3)
-          // Straight along +x, so the ray enters the box at half its width on the near side.
-          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          // An entity type minecraft-data does not know is spawned without a width or height.
+          const entity = { id: 7, position: vec3(3, 64, 3) }
           await bot.activateEntity(entity)
           try {
             const first = writes.find(w => w.name === 'use_entity').params
             const hit = first.location ?? vec3(first.x, first.y, first.z)
-            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
-            assert.ok(Math.abs(hit.z) < 1e-9, `hit z centred: ${hit}`)
-            assert.ok(hit.y > 0 && hit.y < entity.height, `hit y inside the box: ${hit}`)
+            assert.deepStrictEqual(hit, vec3(0, 0, 0))
             done()
           } catch (err) {
             done(err)


### PR DESCRIPTION
`activateEntity` / `activateEntityAt` / `useOn` / `mount` send what the vanilla client sends on a right click (`MultiPlayerGameMode`, `Minecraft.startUseItem`):

- Before 26.1: `use_entity` interact_at with the hit point relative to the entity, then interact. Both carry the bot's **real** sneak state, since the server applies the packet's secondary-action flag as the player's shift state.
- 26.1+: one `use_entity` carrying the `lpVec3 location`, chosen once at inject through `supportFeature('useEntityHasLocation')` (PrismarineJS/minecraft-data#1282). The hand is the numeric id on every version; the compiled 26.1 codec already accepts it.
- The hit vector is where the line from the eye to the entity's middle enters its bounding box (`interactAt` sends `entityHitResult.getLocation()` minus the entity position, a point on the box surface). An entity type minecraft-data has no size for gets its position. `activateEntity` looks at the hit point it sends.
- `activateEntityAt` no longer mutates the caller's position vector.
- `bot.useOn` and `bot.mount` used to send a lone interact with the hit location fixed at the entity's feet. They now live beside `activateEntity` in `inventory.js` and go through the same sender, so `entities.js` no longer has a second, divergent `use_entity` writer. `attack` gets its own sender carrying only the sneak state (its own packet on 26.1), chosen once at inject from `attackUsesOwnPacket`.

Tests run the recorded params through the real serializer, so a version's packet shape is checked: `activateEntity sends the vanilla interact packets with the sneak state`, `useOn and mount send the same interact pair as activateEntity`, the hitbox-face and unknown-size cases.

Depends on minecraft-data#1282 (merged): 26.1 fails until a minecraft-data release carries it.

Split from #4066 (the interaction-parity audit); absorbs #4095.

