### PR TITLE
Default activateBlock's cursor to the clicked face and skip activateItem with an empty hand

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -118,6 +118,8 @@ function inject (bot, { hideErrors }) {
   }
 
   function activateItem (offHand = false) {
+    // use_item must not be sent for an empty hand
+    if (!(offHand ? bot.inventory.slots[45] : bot.heldItem)) return
     bot.usingHeldItem = true
     sequence++
 
@@ -195,7 +197,8 @@ function inject (bot, { hideErrors }) {
   async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
-    cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
+    // The cursor must lie on the clicked face
+    cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
     // place block message

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -1347,6 +1350,61 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock', () => {
+      it('defaults the cursor to the centre of the clicked face and swings after use_item_on', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          const block = { position: vec3(1, 65, 1) }
+          await bot.activateBlock(block)
+          await bot.activateBlock(block, vec3(-1, 0, 0))
+          try {
+            const scale = bot.supportFeature('blockPlaceHasHandAndFloatCursor') || bot.supportFeature('blockPlaceHasInsideBlock') ? 1 : 16
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_place', 'arm_animation', 'block_place', 'arm_animation'])
+            const cursor = ({ params }) => [params.cursorX / scale, params.cursorY / scale, params.cursorZ / scale, params.direction]
+            assert.deepStrictEqual(cursor(writes[0]), [0.5, 1, 0.5, 1])
+            assert.deepStrictEqual(cursor(writes[2]), [0, 0.5, 0.5, 4])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
+    describe('activateItem', () => {
+      it('does nothing with an empty hand', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.activateItem()
+          bot.activateItem(true)
+          try {
+            assert.deepStrictEqual(writes, [])
+            assert.strictEqual(bot.usingHeldItem, false)
+            bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+            bot.activateItem()
+            assert.deepStrictEqual(writes, [bot.supportFeature('useItemWithOwnPacket') ? 'use_item' : 'block_place'])
+            assert.strictEqual(bot.usingHeldItem, true)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('heldItemChanged', () => {
       it('emits heldItemChanged when the held slot is updated via set_slot', (done) => {
         const Item = require('prismarine-item')(supportedVersion)
@@ -1557,6 +1615,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await sleep(100)
           bot.entity.yaw = testYaw
           bot.entity.pitch = testPitch
+          const Item = require('prismarine-item')(registry)
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
           bot.activateItem()
         })
       })


### PR DESCRIPTION
- `activateBlock`'s cursor defaults to the centre of the **clicked face** (`0.5 + face * 0.5` per axis): the cursor is where the crosshair hits the block, and the old `(0.5, 0.5, 0.5)` is inside the block, impossible for a real client.
- `activateItem` no-ops with an empty hand, like vanilla `startUseItem` (`!itemStack.isEmpty()`). The pre-existing `activateItem rotation` test now holds an item, since the no-op would otherwise skip its `use_item`.

Tests: `defaults the cursor to the centre of the clicked face and swings after use_item_on`, `does nothing with an empty hand`.

Split from #4066 (the interaction-parity audit).