### PR TITLE
Swing the arm after use_item_on when placing, not before

### DIFF
--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -39,10 +39,6 @@ function inject (bot) {
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
 
-    if (options.swingArm) {
-      bot.swingArm(options.swingArm, options.showHand)
-    }
-
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {
         location: pos,
@@ -83,6 +79,11 @@ function inject (bot) {
         sequence: 0, // 1.19.0
         worldBorderHit: false // 1.21.3
       })
+    }
+
+    // The swing must follow use_item_on
+    if (options.swingArm) {
+      bot.swingArm(options.swingArm, options.showHand)
     }
 
     return pos

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -1400,6 +1403,29 @@ for (const supportedVersion of mineflayer.testedVersions) {
               stoneItem
             )
           }, 100)
+        })
+      })
+    })
+
+    describe('generic place', () => {
+      it('swings the arm after use_item_on', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore', swingArm: 'right' })
+          try {
+            assert.deepStrictEqual(writes, ['block_place', 'arm_animation'])
+            done()
+          } catch (err) {
+            done(err)
+          }
         })
       })
     })


### PR DESCRIPTION
Vanilla only swings once `useItemOn` returns a success, so the `arm_animation` follows the `use_item_on` packet.

Test: `swings the arm after use_item_on`.

Split from #4066 (the interaction-parity audit).