### PR TITLE
Throw from bot.attack for targets the server kicks for

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2037,6 +2037,8 @@ Attack a player or a mob.
  * `entity` is a type of entity. To get a specific entity use [bot.nearestEntity()](#botnearestentitymatch--entity---return-true-) or [bot.entities](#botentities).
  * `swing` Default to `true`. If false the bot does not swing its arm when attacking.
 
+Throws if `entity` is the bot itself, an item or an experience orb: the server kicks a client that attacks those.
+
 #### bot.swingArm([hand], showHand)
 
 Play an arm swing animation.

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -841,6 +841,11 @@ function inject (bot) {
   }
 
   function attack (target, swing = true) {
+    // The server kicks a client that attacks itself, an item or an experience orb
+    // (multiplayer.disconnect.invalid_entity_attacked)
+    if (target.id === bot.entity.id || target.name?.toLowerCase() === 'item' || target.name === 'experience_orb') {
+      throw new Error(`attack: cannot attack ${target.name} entity ${target.id}`)
+    }
     // arm animation comes before the use_entity packet on 1.8
     if (bot.supportFeature('armAnimationBeforeUse')) {
       if (swing) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -706,6 +709,31 @@ for (const supportedVersion of mineflayer.testedVersions) {
               'height should be set from codec lookup')
             done()
           })
+        })
+      })
+    })
+
+    describe('attack', () => {
+      it('rejects targets the server kicks for and attacks the rest', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            await bot.test.pluginsLoaded
+            const loggedIn = once(bot, 'login')
+            await client.write('login', bot.test.generateLoginPacket())
+            await loggedIn
+            const writes = []
+            bot._client.write = (name, params) => { writes.push(name) }
+            assert.throws(() => bot.attack(bot.entity), /cannot attack/)
+            assert.throws(() => bot.attack({ id: 11, name: 'item' }), /cannot attack/)
+            assert.throws(() => bot.attack({ id: 12, name: 'experience_orb' }), /cannot attack/)
+            assert.deepStrictEqual(writes, [])
+            bot.attack({ id: 13, name: 'zombie' })
+            assert.strictEqual(writes.length, 2)
+            assert.ok(writes.includes('arm_animation'))
+            done()
+          } catch (err) {
+            done(err)
+          }
         })
       })
     })


### PR DESCRIPTION
The server disconnects with `multiplayer.disconnect.invalid_entity_attacked` (`ServerGamePacketListenerImpl.onAttack`) when the attacked entity is the player itself, an item or an experience orb — a vanilla client can never target those. `bot.attack` now refuses them up front.

Docs updated for `bot.attack`.

Split from #4066 (the interaction-parity audit).