### PR TITLE
Dismount by holding sneak for one tick on 1.21.3+

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2050,7 +2050,9 @@ Mount a vehicle. To get back out, use `bot.dismount`.
 
 #### bot.dismount()
 
-Dismounts from the vehicle you are in.
+This function returns a `Promise`, with `void` as its argument once the dismount has been sent.
+
+Dismounts from the vehicle you are in. On 1.21.3+ this holds the sneak control for one physics tick, which is how vanilla leaves a vehicle.
 
 #### bot.moveVehicle(left,forward)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,7 +350,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   mount: (entity: Entity) => void
 
-  dismount: () => void
+  dismount: () => Promise<void>
 
   moveVehicle: (left: number, forward: number) => void
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -882,23 +882,26 @@ function inject (bot) {
     }
   }
 
-  function dismount () {
-    if (bot.vehicle) {
-      if (bot.supportFeature('newPlayerInputPacket')) {
-        bot._client.write('player_input', {
-          inputs: {
-            jump: true
-          }
-        })
-      } else {
-        bot._client.write('steer_vehicle', {
-          sideways: 0.0,
-          forward: 0.0,
-          jump: 0x02
-        })
+  async function dismount () {
+    if (!bot.vehicle) {
+      bot.emit('error', new Error('dismount: not mounted'))
+      return
+    }
+    if (bot.supportFeature('newPlayerInputPacket')) {
+      // Only the shift key in player_input dismounts (Player.rideTick); the jump
+      // flag is never read for this
+      bot.setControlState('sneak', true)
+      try {
+        await bot.waitForTicks(1)
+      } finally {
+        bot.setControlState('sneak', false)
       }
     } else {
-      bot.emit('error', new Error('dismount: not mounted'))
+      bot._client.write('steer_vehicle', {
+        sideways: 0.0,
+        forward: 0.0,
+        jump: 0x02 // unmount flag
+      })
     }
   }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -298,6 +301,33 @@ for (const supportedVersion of mineflayer.testedVersions) {
           // Place water only at the second eye-level position
           chunk.setBlockType(eyeLevelBlockPos2, waterId)
           client.write('map_chunk', generateChunkPacket(chunk))
+        })
+      })
+    })
+
+    describe('dismount', () => {
+      it('holds sneak for one tick on 1.21.3+ and sends the steer_vehicle unmount flag before', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            await bot.test.pluginsLoaded
+            const loggedIn = once(bot, 'login')
+            await client.write('login', bot.test.generateLoginPacket())
+            await loggedIn
+            const events = []
+            bot.setControlState = (control, state) => { events.push([control, state]) }
+            bot.waitForTicks = async (ticks) => { events.push(['tick', ticks]) }
+            bot._client.write = (name, params) => { events.push([name, params]) }
+            bot.vehicle = { id: 21 }
+            await bot.dismount()
+            if (bot.supportFeature('newPlayerInputPacket')) {
+              assert.deepStrictEqual(events, [['sneak', true], ['tick', 1], ['sneak', false]])
+            } else {
+              assert.deepStrictEqual(events, [['steer_vehicle', { sideways: 0, forward: 0, jump: 2 }]])
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
         })
       })
     })


### PR DESCRIPTION
The server only leaves a vehicle when the player's shift key is down (`Player.rideTick` → `wantsToStopRiding`); the `player_input { jump }` that was sent before is never read for this. `bot.dismount` now holds the sneak control for one physics tick and returns a `Promise` (`void` once the dismount has been sent); older versions keep the `steer_vehicle` unmount flag, which the server reads directly.

Docs and `index.d.ts` updated (`dismount` returns `Promise<void>`).

Test: `holds sneak for one tick on 1.21.3+ and sends the steer_vehicle unmount flag before`.

Split from #4066 (the interaction-parity audit).