### PR TITLE
Swing every tick while digging, skip STOP on instant breaks and abort with face DOWN

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,7 +42,8 @@ const plugins = {
   anvil: require('./plugins/anvil'),
   place_entity: require('./plugins/place_entity'),
   generic_place: require('./plugins/generic_place'),
-  particle: require('./plugins/particle')
+  particle: require('./plugins/particle'),
+  sequence: require('./plugins/sequence')
 }
 
 const minecraftData = require('minecraft-data')

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -15,7 +15,8 @@ function inject (bot) {
   bot.targetDigFace = null
   bot.lastDigTime = null
 
-  // A dig in progress swings the arm once per physics tick
+  // A dig in progress swings the arm once per physics tick: vanilla Minecraft.continueAttack
+  // swings whenever continueDestroyBlock returns true, and the local player sends the packet unconditionally
   bot.on('physicsTick', () => {
     if (bot.targetDigBlock) bot.swingArm()
   })
@@ -129,7 +130,8 @@ function inject (bot) {
 
     // In vanilla the client will cancel digging the current block once the other block is at the crosshair.
     // Todo: don't wait until lookAt is at middle of the block, but at the edge of it.
-    // An abort caused by retargeting must carry the new block's face
+    // An abort caused by retargeting carries the new block's face: vanilla startDestroyBlock sends
+    // ABORT_DESTROY_BLOCK with the face it was given
     if (bot.targetDigBlock) abortDigging(targetDigFace)
 
     diggingTask = createTask()
@@ -210,7 +212,7 @@ function inject (bot) {
     await diggingTask.promise
   }
 
-  // A user abort must carry face DOWN
+  // A user abort carries face DOWN: vanilla stopDestroyBlock sends ABORT_DESTROY_BLOCK with Direction.DOWN
   function stopDigging () {
     if (bot.targetDigBlock) abortDigging(0)
   }

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -130,7 +130,8 @@ function inject (bot) {
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: bot.targetDigFace // default face is 1 (top)
+      face: bot.targetDigFace, // default face is 1 (top)
+      sequence: bot._nextSequence()
     })
     waitTimeout = setTimeout(finishDigging, waitTime)
     bot.targetDigBlock = block
@@ -149,7 +150,8 @@ function inject (bot) {
         bot._client.write('block_dig', {
           status: 2, // finish digging
           location: bot.targetDigBlock.position,
-          face: bot.targetDigFace // always the same as the start face
+          face: bot.targetDigFace, // always the same as the start face
+          sequence: bot._nextSequence()
         })
       }
       bot.targetDigBlock = null
@@ -178,7 +180,8 @@ function inject (bot) {
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
-        face: cancellationDiggingFace
+        face: cancellationDiggingFace,
+        sequence: 0
       })
       const block = bot.targetDigBlock
       bot.targetDigBlock = null

--- a/lib/plugins/digging.js
+++ b/lib/plugins/digging.js
@@ -6,14 +6,19 @@ const { Vec3 } = require('vec3')
 module.exports = inject
 
 function inject (bot) {
-  let swingInterval = null
   let waitTimeout = null
+  let abortDigging = null // closure of the dig in progress, takes the abort face
 
   let diggingTask = createDoneTask()
 
   bot.targetDigBlock = null
   bot.targetDigFace = null
   bot.lastDigTime = null
+
+  // A dig in progress swings the arm once per physics tick
+  bot.on('physicsTick', () => {
+    if (bot.targetDigBlock) bot.swingArm()
+  })
 
   async function dig (block, forceLook, digFace) {
     if (block === null || block === undefined) {
@@ -29,17 +34,17 @@ function inject (bot) {
       throw new Error(`dig time for ${block?.name ?? block} is Infinity`)
     }
 
-    bot.targetDigFace = 1 // Default (top)
+    let targetDigFace = 1 // Default (top)
 
     if (forceLook !== 'ignore') {
       if (digFace?.x || digFace?.y || digFace?.z) {
         // Determine the block face the bot should mine
         if (digFace.x) {
-          bot.targetDigFace = digFace.x > 0 ? BlockFaces.EAST : BlockFaces.WEST
+          targetDigFace = digFace.x > 0 ? BlockFaces.EAST : BlockFaces.WEST
         } else if (digFace.y) {
-          bot.targetDigFace = digFace.y > 0 ? BlockFaces.TOP : BlockFaces.BOTTOM
+          targetDigFace = digFace.y > 0 ? BlockFaces.TOP : BlockFaces.BOTTOM
         } else if (digFace.z) {
-          bot.targetDigFace = digFace.z > 0 ? BlockFaces.SOUTH : BlockFaces.NORTH
+          targetDigFace = digFace.z > 0 ? BlockFaces.SOUTH : BlockFaces.NORTH
         }
         await bot.lookAt(
           block.position.offset(0.5, 0.5, 0.5).offset(digFace.x * 0.5, digFace.y * 0.5, digFace.z * 0.5),
@@ -107,7 +112,7 @@ function inject (bot) {
             }
           }
           await bot.lookAt(closest.targetPos, forceLook)
-          bot.targetDigFace = closest.face
+          targetDigFace = closest.face
         } else if (closerBlocks.length === 0 && block.shapes.length === 0) {
           // no other blocks were detected and the block has no shapes.
           // The block in question is replaceable (like tall grass) so we can just dig it
@@ -124,27 +129,36 @@ function inject (bot) {
 
     // In vanilla the client will cancel digging the current block once the other block is at the crosshair.
     // Todo: don't wait until lookAt is at middle of the block, but at the edge of it.
-    if (bot.targetDigBlock) bot.stopDigging()
+    // An abort caused by retargeting must carry the new block's face
+    if (bot.targetDigBlock) abortDigging(targetDigFace)
 
     diggingTask = createTask()
+    bot.targetDigBlock = block
+    bot.targetDigFace = targetDigFace
     bot._client.write('block_dig', {
       status: 0, // start digging
       location: block.position,
-      face: bot.targetDigFace, // default face is 1 (top)
+      face: targetDigFace,
       sequence: bot._nextSequence()
     })
-    waitTimeout = setTimeout(finishDigging, waitTime)
-    bot.targetDigBlock = block
     bot.swingArm()
 
-    swingInterval = setInterval(() => {
-      bot.swingArm()
-    }, 350)
+    const eventName = `blockUpdate:${block.position}`
+    bot.on(eventName, onBlockUpdate)
+
+    if (waitTime === 0) {
+      // An instant break (creative or zero hardness) must not send STOP_DESTROY_BLOCK;
+      // the block is cleared locally
+      bot.targetDigBlock = null
+      bot.targetDigFace = null
+      bot.lastDigTime = performance.now()
+      bot._updateBlockState(block.position, 0)
+    } else {
+      waitTimeout = setTimeout(finishDigging, waitTime)
+    }
 
     function finishDigging () {
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       if (bot.targetDigBlock) {
         bot._client.write('block_dig', {
@@ -160,27 +174,14 @@ function inject (bot) {
       bot._updateBlockState(block.position, 0)
     }
 
-    const eventName = `blockUpdate:${block.position}`
-    bot.on(eventName, onBlockUpdate)
-
-    const currentBlock = block
-    bot.stopDigging = () => {
-      if (!bot.targetDigBlock) return
-
-      // Replicate the odd vanilla cancellation face value.
-      // When the cancellation is because of a new dig request on another block it's the same as the new dig start face. In all other cases it's 0.
-      const stoppedBecauseOfNewDigRequest = !currentBlock.position.equals(bot.targetDigBlock.position)
-      const cancellationDiggingFace = !stoppedBecauseOfNewDigRequest ? bot.targetDigFace : 0
-
+    abortDigging = (face) => {
       bot.removeListener(eventName, onBlockUpdate)
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       bot._client.write('block_dig', {
         status: 1, // cancel digging
         location: bot.targetDigBlock.position,
-        face: cancellationDiggingFace,
+        face,
         sequence: 0
       })
       const block = bot.targetDigBlock
@@ -188,7 +189,6 @@ function inject (bot) {
       bot.targetDigFace = null
       bot.lastDigTime = performance.now()
       bot.emit('diggingAborted', block)
-      bot.stopDigging = noop
       diggingTask.cancel(new Error('Digging aborted'))
     }
 
@@ -198,9 +198,7 @@ function inject (bot) {
       // All block update listeners receive (null, null) when the world is unloaded. So newBlock can be null.
       if (newBlock?.type !== 0) return
       bot.removeListener(eventName, onBlockUpdate)
-      clearInterval(swingInterval)
       clearTimeout(waitTimeout)
-      swingInterval = null
       waitTimeout = null
       bot.targetDigBlock = null
       bot.targetDigFace = null
@@ -210,6 +208,11 @@ function inject (bot) {
     }
 
     await diggingTask.promise
+  }
+
+  // A user abort must carry face DOWN
+  function stopDigging () {
+    if (bot.targetDigBlock) abortDigging(0)
   }
 
   bot.on('death', () => {
@@ -260,11 +263,7 @@ function inject (bot) {
 
   bot._getBlockAtEyeLevel = () => bot.entity.position && bot.blockAt(bot.entity.position.offset(0, bot.entity.eyeHeight, 0))
   bot.dig = dig
-  bot.stopDigging = noop
+  bot.stopDigging = stopDigging
   bot.canDigBlock = canDigBlock
   bot.digTime = digTime
-}
-
-function noop (err) {
-  if (err) throw err
 }

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -39,10 +39,6 @@ function inject (bot) {
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
 
-    if (options.swingArm) {
-      bot.swingArm(options.swingArm, options.showHand)
-    }
-
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {
         location: pos,
@@ -83,6 +79,11 @@ function inject (bot) {
         sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
+    }
+
+    // The swing must follow use_item_on
+    if (options.swingArm) {
+      bot.swingArm(options.swingArm, options.showHand)
     }
 
     return pos

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -80,7 +80,7 @@ function inject (bot) {
         cursorY: dy,
         cursorZ: dz,
         insideBlock: false,
-        sequence: 0, // 1.19.0
+        sequence: bot._nextSequence(), // 1.19.0
         worldBorderHit: false // 1.21.3
       })
     }

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -117,6 +117,8 @@ function inject (bot, { hideErrors }) {
   }
 
   function activateItem (offHand = false) {
+    // use_item must not be sent for an empty hand
+    if (!(offHand ? bot.inventory.slots[45] : bot.heldItem)) return
     bot.usingHeldItem = true
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
@@ -193,7 +195,8 @@ function inject (bot, { hideErrors }) {
   async function activateBlock (block, direction, cursorPos) {
     direction = direction ?? new Vec3(0, 1, 0)
     const directionNum = vectorToDirection(direction) // The packet needs a number as the direction
-    cursorPos = cursorPos ?? new Vec3(0.5, 0.5, 0.5)
+    // The cursor must lie on the clicked face
+    cursorPos = cursorPos ?? new Vec3(0.5 + direction.x * 0.5, 0.5 + direction.y * 0.5, 0.5 + direction.z * 0.5)
     // TODO: tell the server that we are not sneaking while doing this
     await bot.lookAt(block.position.offset(0.5, 0.5, 0.5), false)
     // place block message

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -27,7 +27,6 @@ function inject (bot, { hideErrors }) {
   const windows = require('prismarine-windows')(bot.version)
 
   let eatingTask = createDoneTask()
-  let sequence = 0
 
   let nextActionNumber = 0 // < 1.17
   let stateId = -1
@@ -119,7 +118,6 @@ function inject (bot, { hideErrors }) {
 
   function activateItem (offHand = false) {
     bot.usingHeldItem = true
-    sequence++
 
     if (bot.supportFeature('useItemWithBlockPlace')) {
       bot._client.write('block_place', {
@@ -133,7 +131,7 @@ function inject (bot, { hideErrors }) {
     } else if (bot.supportFeature('useItemWithOwnPacket')) {
       bot._client.write('use_item', {
         hand: offHand ? 1 : 0,
-        sequence,
+        sequence: bot._nextSequence(),
         rotation: {
           x: toNotchianYaw(bot.entity.yaw),
           y: toNotchianPitch(bot.entity.pitch)
@@ -236,7 +234,7 @@ function inject (bot, { hideErrors }) {
         cursorY: cursorPos.y,
         cursorZ: cursorPos.z,
         insideBlock: false,
-        sequence: 0, // 1.19.0+
+        sequence: bot._nextSequence(), // 1.19.0+
         worldBorderHit: false // 1.21.3+
       })
     }

--- a/lib/plugins/sequence.js
+++ b/lib/plugins/sequence.js
@@ -1,0 +1,14 @@
+module.exports = inject
+
+// One sequence counter for dig start/stop, use_item_on and use_item. Sent values
+// start at 1; abort, release and drop actions send 0 and must not consume a value.
+function inject (bot) {
+  const hasSequence = bot.registry.isNewerOrEqualTo('1.19')
+  let sequence = 0
+
+  bot._nextSequence = () => {
+    if (!hasSequence) return 0
+    sequence++
+    return sequence
+  }
+}

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -1347,6 +1350,61 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('activateBlock', () => {
+      it('defaults the cursor to the centre of the clicked face and swings after use_item_on', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          bot.lookAt = async () => {}
+          const writes = []
+          bot._client.write = (name, params) => { writes.push({ name, params }) }
+          const block = { position: vec3(1, 65, 1) }
+          await bot.activateBlock(block)
+          await bot.activateBlock(block, vec3(-1, 0, 0))
+          try {
+            const scale = bot.supportFeature('blockPlaceHasHandAndFloatCursor') || bot.supportFeature('blockPlaceHasInsideBlock') ? 1 : 16
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_place', 'arm_animation', 'block_place', 'arm_animation'])
+            const cursor = ({ params }) => [params.cursorX / scale, params.cursorY / scale, params.cursorZ / scale, params.direction]
+            assert.deepStrictEqual(cursor(writes[0]), [0.5, 1, 0.5, 1])
+            assert.deepStrictEqual(cursor(writes[2]), [0, 0.5, 0.5, 4])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
+    describe('activateItem', () => {
+      it('does nothing with an empty hand', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.activateItem()
+          bot.activateItem(true)
+          try {
+            assert.deepStrictEqual(writes, [])
+            assert.strictEqual(bot.usingHeldItem, false)
+            bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+            bot.activateItem()
+            assert.deepStrictEqual(writes, [bot.supportFeature('useItemWithOwnPacket') ? 'use_item' : 'block_place'])
+            assert.strictEqual(bot.usingHeldItem, true)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('heldItemChanged', () => {
       it('emits heldItemChanged when the held slot is updated via set_slot', (done) => {
         const Item = require('prismarine-item')(supportedVersion)
@@ -1595,6 +1653,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
           await sleep(100)
           bot.entity.yaw = testYaw
           bot.entity.pitch = testPitch
+          const Item = require('prismarine-item')(registry)
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
           bot.activateItem()
         })
       })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1514,6 +1514,44 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('block prediction sequence', () => {
+      it('shares one pre-incremented counter across use_item and use_item_on, 0 on release', function (done) {
+        const useItemFields = registry.protocol?.play?.toServer?.types?.packet_use_item?.[1]
+        if (!useItemFields?.some(f => f.name === 'sequence')) {
+          this.skip()
+          return
+        }
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push([name, params.sequence]) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+
+          bot.activateItem()
+          bot.deactivateItem()
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore' })
+          bot.activateItem()
+
+          try {
+            assert.deepStrictEqual(writes, [
+              ['use_item', 1],
+              ['block_dig', 0],
+              ['block_place', 2],
+              ['use_item', 3]
+            ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -247,6 +247,100 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('digging', () => {
+      const blockPos = vec3(1, 65, 1)
+      const otherPos = vec3(2, 65, 1)
+      const BlockFace = require('prismarine-world').iterators.BlockFace
+      const hasSequence = registry.protocol?.play?.toServer?.types?.packet_block_dig?.[1]?.some(f => f.name === 'sequence')
+      // Sequence value expected for the nth prediction packet
+      const seq = n => hasSequence ? n : 0
+
+      async function setup (client, gameMode) {
+        await bot.test.pluginsLoaded
+        const dirtId = registry.blocksByName.dirt.id
+        const loaded = once(bot, 'chunkColumnLoad')
+        client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(blockPos, dirtId)
+        chunk.setBlockType(otherPos, dirtId)
+        client.write('map_chunk', generateChunkPacket(chunk))
+        await loaded
+        bot.entity.position = vec3(1.5, 66, 1.5)
+        bot.entity.eyeHeight = 1.62
+        bot.entity.onGround = true
+        bot.entity.effects = {}
+        bot.game.gameMode = gameMode
+        const writes = []
+        bot._client.write = (name, params) => { writes.push({ name, params }) }
+        return writes
+      }
+      const digPackets = writes => writes.filter(w => w.name === 'block_dig').map(({ params }) => [params.status, params.face, params.sequence])
+
+      it('instant break sends only START_DESTROY_BLOCK and resolves on the block update', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'creative')
+            const block = bot.blockAt(blockPos)
+            assert.strictEqual(bot.digTime(block), 0)
+            const completed = once(bot, 'diggingCompleted')
+            await bot.dig(block, 'ignore')
+            await completed
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_dig', 'arm_animation'])
+            assert.deepStrictEqual(digPackets(writes), [[0, BlockFace.TOP, seq(1)]])
+            assert.strictEqual(bot.blockAt(blockPos).type, 0)
+            assert.strictEqual(bot.targetDigBlock, null)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('swings every physics tick while digging', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'survival')
+            const block = bot.blockAt(blockPos)
+            assert.ok(bot.digTime(block) > 0)
+            const dig = bot.dig(block, 'ignore')
+            bot.emit('physicsTick')
+            bot.emit('physicsTick')
+            assert.deepStrictEqual(writes.map(w => w.name), ['block_dig', 'arm_animation', 'arm_animation', 'arm_animation'])
+            await dig
+            writes.length = 0
+            bot.emit('physicsTick')
+            assert.deepStrictEqual(writes, [])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('aborts with face DOWN from stopDigging and with the new face on a retarget', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            const writes = await setup(client, 'survival')
+            const first = bot.dig(bot.blockAt(blockPos), true, vec3(-1, 0, 0))
+            const second = bot.dig(bot.blockAt(otherPos), true, vec3(0, 0, 1))
+            await assert.rejects(first, /Digging aborted/)
+            bot.stopDigging()
+            await assert.rejects(second, /Digging aborted/)
+            assert.deepStrictEqual(digPackets(writes), [
+              [0, BlockFace.WEST, seq(1)],
+              [1, BlockFace.SOUTH, 0],
+              [0, BlockFace.SOUTH, seq(2)],
+              [1, BlockFace.BOTTOM, 0]
+            ])
+            assert.strictEqual(bot.targetDigBlock, null)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('digTime', () => {
       it('should use eye-level water check instead of isInWater for dig speed', (done) => {
         const blockPos = vec3(1, 65, 1)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1462,6 +1462,29 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('generic place', () => {
+      it('swings the arm after use_item_on', (done) => {
+        const Item = require('prismarine-item')(registry)
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => { writes.push(name) }
+          bot.quickBarSlot = 0
+          bot.inventory.updateSlot(bot.QUICK_BAR_START, new Item(registry.itemsByName.stone.id, 1))
+          await bot._genericPlace({ position: vec3(1, 65, 1) }, vec3(0, 1, 0), { forceLook: 'ignore', swingArm: 'right' })
+          try {
+            assert.deepStrictEqual(writes, ['block_place', 'arm_animation'])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('windows', () => {
       const Item = require('prismarine-item')(supportedVersion)
       const pWindows = require('prismarine-windows')(supportedVersion)


### PR DESCRIPTION
Audit of the digging packets against vanilla `continueAttack` / `stopDestroyBlock`:

- Swing the arm once per physics tick while a dig is in progress (vanilla `continueAttack`), instead of on a 350 ms timer.
- An instant break (creative or zero hardness) must not send STOP_DESTROY_BLOCK: vanilla sends only START and predicts the break locally.
- A user abort carries face DOWN (vanilla `stopDestroyBlock`), while the abort caused by retargeting carries the **new** block's face — the old code had these two swapped, and let a new dig overwrite the face of the abort it was still sending.
- `bot.stopDigging` is a plain function again (it was being reassigned per dig).

**Based on #4085** (the use_item / use_item_on parity PR, which carries the shared block prediction sequence counter this builds on) — the PR base is that branch; it retargets to master once #4085 merges.

Tests: instant break sends only START, swings every physics tick, abort faces.

Split from #4066 (the interaction-parity audit).
