### PR TITLE
Right-click entities through one path, so useOn and mount send the vanilla pair

### DIFF
--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -836,8 +836,7 @@ function inject (bot) {
   }
 
   function useOn (target) {
-    // TODO: check if not crouching will make make this action always use the item
-    useEntity(target, 0)
+    bot._interactEntity(target, bot._entityHitVector(target))
   }
 
   function attack (target, swing = true) {
@@ -846,9 +845,9 @@ function inject (bot) {
       if (swing) {
         swingArm()
       }
-      useEntity(target, 1)
+      attackEntity(target)
     } else {
-      useEntity(target, 1)
+      attackEntity(target)
       if (swing) {
         swingArm()
       }
@@ -856,8 +855,7 @@ function inject (bot) {
   }
 
   function mount (target) {
-    // TODO: check if crouching will make make this action always mount
-    useEntity(target, 0)
+    bot._interactEntity(target, bot._entityHitVector(target))
   }
 
   function moveVehicle (left, forward) {
@@ -902,30 +900,19 @@ function inject (bot) {
     }
   }
 
-  function useEntity (target, leftClick, x, y, z) {
-    const sneaking = bot.getControlState('sneak')
-    if (leftClick && bot.supportFeature('attackUsesOwnPacket')) {
+  // An attack carries no hit location, only the sneak state; 26.1 moved it to its own packet.
+  function attackEntity (target) {
+    if (bot.supportFeature('attackUsesOwnPacket')) {
       bot._client.write('attack', {
         entityId: target.id
       })
-    } else if (x && y && z) {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        x,
-        y,
-        z,
-        sneaking,
-        location: new Vec3(x, y, z)
-      })
-    } else {
-      bot._client.write('use_entity', {
-        target: target.id,
-        mouse: leftClick,
-        sneaking,
-        location: new Vec3(0, 0, 0)
-      })
+      return
     }
+    bot._client.write('use_entity', {
+      target: target.id,
+      mouse: 1,
+      sneaking: bot.getControlState('sneak')
+    })
   }
 
   function fetchEntity (id) {

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -823,9 +823,7 @@ function inject (bot) {
 
   bot.swingArm = swingArm
   bot.attack = attack
-  bot.mount = mount
   bot.dismount = dismount
-  bot.useOn = useOn
   bot.moveVehicle = moveVehicle
 
   function swingArm (arm = 'right', showHand = true) {
@@ -835,9 +833,10 @@ function inject (bot) {
     bot._client.write('arm_animation', packet)
   }
 
-  function useOn (target) {
-    bot._interactEntity(target, bot._entityHitVector(target))
-  }
+  // An attack carries no hit location, only the sneak state; 26.1 moved it to its own packet.
+  const attackEntity = bot.supportFeature('attackUsesOwnPacket')
+    ? (target) => bot._client.write('attack', { entityId: target.id })
+    : (target) => bot._client.write('use_entity', { target: target.id, mouse: 1, sneaking: bot.getControlState('sneak') })
 
   function attack (target, swing = true) {
     // arm animation comes before the use_entity packet on 1.8
@@ -852,10 +851,6 @@ function inject (bot) {
         swingArm()
       }
     }
-  }
-
-  function mount (target) {
-    bot._interactEntity(target, bot._entityHitVector(target))
   }
 
   function moveVehicle (left, forward) {
@@ -898,21 +893,6 @@ function inject (bot) {
     } else {
       bot.emit('error', new Error('dismount: not mounted'))
     }
-  }
-
-  // An attack carries no hit location, only the sneak state; 26.1 moved it to its own packet.
-  function attackEntity (target) {
-    if (bot.supportFeature('attackUsesOwnPacket')) {
-      bot._client.write('attack', {
-        entityId: target.id
-      })
-      return
-    }
-    bot._client.write('use_entity', {
-      target: target.id,
-      mouse: 1,
-      sneaking: bot.getControlState('sneak')
-    })
   }
 
   function fetchEntity (id) {

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -276,6 +276,14 @@ function inject (bot, { hideErrors }) {
     interactEntity(entity, position.minus(entity.position))
   }
 
+  function useOn (entity) {
+    interactEntity(entity, hitVector(entity))
+  }
+
+  function mount (entity) {
+    interactEntity(entity, hitVector(entity))
+  }
+
   // 26.1+ has a single interact packet carrying the hit point; earlier
   // versions send interact_at (hit point relative to the entity) followed by
   // interact, and both must carry the same sneak state
@@ -934,13 +942,13 @@ function inject (bot, { hideErrors }) {
   bot.activateBlock = activateBlock
   bot.activateEntity = activateEntity
   bot.activateEntityAt = activateEntityAt
+  bot.useOn = useOn
+  bot.mount = mount
   bot.consume = consume
   bot.activateItem = activateItem
   bot.deactivateItem = deactivateItem
 
   // not really in the public API
-  bot._interactEntity = interactEntity
-  bot._entityHitVector = hitVector
   bot.clickWindow = clickWindow
   bot.putSelectedItemRange = putSelectedItemRange
   bot.putAway = putAway

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -939,6 +939,8 @@ function inject (bot, { hideErrors }) {
   bot.deactivateItem = deactivateItem
 
   // not really in the public API
+  bot._interactEntity = interactEntity
+  bot._entityHitVector = hitVector
   bot.clickWindow = clickWindow
   bot.putSelectedItemRange = putSelectedItemRange
   bot.putAway = putAway

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,6 +69,9 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
+      // Plugins are injected on a timer after createBot, which can lose the
+      // race against the mock server's playerJoin
+      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -69,9 +69,6 @@ for (const supportedVersion of mineflayer.testedVersions) {
         port: PORT
       })
       bot.test = {}
-      // Plugins are injected on a timer after createBot, which can lose the
-      // race against the mock server's playerJoin
-      bot.test.pluginsLoaded = new Promise(resolve => bot.once('inject_allowed', resolve))
 
       bot.test.buildChunk = () => {
         if (bot.supportFeature('tallWorld')) {
@@ -778,6 +775,39 @@ for (const supportedVersion of mineflayer.testedVersions) {
                   { target: 7, mouse: 2, x: 0.5, y: 1, z: 0, hand: mainHand, sneaking: true },
                   { target: 7, mouse: 0, hand: mainHand, sneaking: true }
                 ])
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('useOn and mount send the same interact pair as activateEntity', (done) => {
+        server.on('playerJoin', async (client) => {
+          await bot.test.pluginsLoaded
+          const loggedIn = once(bot, 'login')
+          await client.write('login', bot.test.generateLoginPacket())
+          await loggedIn
+          const writes = []
+          bot._client.write = (name, params) => {
+            bot._client.serializer.createPacketBuffer({ name, params })
+            writes.push({ name, params })
+          }
+          bot.entity.position = vec3(0, 64, 3)
+          const entity = { id: 7, position: vec3(3, 64, 3), height: 1.8, width: 0.6 }
+          bot.useOn(entity)
+          bot.mount(entity)
+          try {
+            const useEntityHasLocation = registry.protocol.play.toServer.types.packet_use_entity[1].some(field => field.name === 'location')
+            // One right click is interact_at then interact before 26.1, and a single located
+            // interact from 26.1 on; either way both actions send the same thing.
+            const perClick = useEntityHasLocation ? 1 : 2
+            const sent = writes.filter(w => w.name === 'use_entity')
+            assert.strictEqual(sent.length, 2 * perClick)
+            assert.deepStrictEqual(sent.slice(0, perClick), sent.slice(perClick))
+            const hit = sent[0].params.location ?? vec3(sent[0].params.x, sent[0].params.y, sent[0].params.z)
+            assert.ok(Math.abs(hit.x + 0.3) < 1e-9, `hit x on the near face: ${hit}`)
+            assert.ok(sent.every(w => w.params.mouse !== 1), 'a right click never sends the attack action')
             done()
           } catch (err) {
             done(err)


### PR DESCRIPTION
`bot.useOn` and `bot.mount` sent a lone interact with the hit location fixed at the entity's feet; a right click on an entity is always interact_at then interact (vanilla `startUseItem`). Both now live next to `activateEntity` in `inventory.js` and go through the same sender, and `use_entity` no longer has a second, divergent implementation in `entities.js`. `attack` gets its own sender carrying only the sneak state (its own packet on 26.1).

**Based on #4089** (the activateEntity packet work this builds on) — the PR base is that branch; it retargets to master once #4089 merges.

Test: `useOn and mount send the same interact pair as activateEntity`.

Split from #4066 (the interaction-parity audit).
