### PR TITLE
Retain server-observed block inventories in bot.world

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2216,6 +2216,25 @@ Transfer some kind of item from one range to an other. `options` is an object co
 
 Open a block, for example a chest, returns a promise on the opening `Window`.
 
+After opening a chest, trapped chest, barrel, hopper, furnace, blast furnace,
+smoker, dispenser, dropper, brewing stand or shulker box, the last server-observed
+container contents are available from `bot.world.getObservedBlockInventory(block.position)`.
+This returns `null` before observation, otherwise a defensive copy with `kind`
+(block name), `slots` (item data records or `null`, excluding player slots),
+`observedAt` (local time in milliseconds), and `stale` (whether the window closed).
+Item records preserve item data, including NBT and components, but are not `Item`
+instances. Local click predictions do not change these records; only server slot
+and full-window updates do. Even an open window describes the last received data,
+not unseen server changes.
+
+These observations are held in memory separately from raw block-entity NBT.
+Block changes, raw block-entity replacements, column replacement/unload, respawn,
+login and disconnect discard them. After invalidation, opening the container again
+is required to establish a new observation. For a double chest, the complete
+window is anchored only to the clicked block; the other half is not inferred.
+Player, entity and personal ender chest inventories are excluded. Opening block
+and entity windows concurrently is rejected because their source is ambiguous.
+
  * `block` is the block the bot will open.
  * `direction` Optional defaults to `new Vec3(0, 1, 0)` (up). A vector off the direction the container block should be interacted with. Does nothing when a container entity is targeted.
  * `cursorPos` Optional defaults to `new Vec3(0.5, 0.5, 0.5)` (block center). The curos position when opening the block instance. This is send with the activate block packet. Does nothing when a container entity is targeted.

--- a/lib/observed_block_inventories.js
+++ b/lib/observed_block_inventories.js
@@ -1,0 +1,105 @@
+const blockContainers = new Set([
+  'chest', 'trapped_chest', 'barrel', 'hopper', 'furnace', 'lit_furnace',
+  'blast_furnace', 'smoker', 'dispenser', 'dropper', 'brewing_stand'
+])
+
+module.exports = function observedBlockInventories (bot) {
+  let pending = null
+  let active = null
+  const observed = new Map()
+  const snapshotItem = item => item === null ? null : structuredClone(item)
+
+  function begin (block) {
+    if (pending) throw new Error('A window is already being opened')
+    const context = block
+      ? {
+          world: bot.world,
+          position: block.position.floored(),
+          type: block.type,
+          kind: block.name,
+          column: bot.world.getColumnAt(block.position)
+        }
+      : { entity: true }
+    pending = context
+    return context
+  }
+
+  function valid (context) {
+    return context.world === bot.world &&
+      context.column === bot.world.getColumnAt(context.position) &&
+      bot.world.getBlock(context.position)?.type === context.type
+  }
+
+  function prepare (window, blockWindow) {
+    const context = pending && !pending.prepared ? pending : null
+    if (context) context.prepared = true
+    if (active) close(active.window)
+    return () => opened(window, blockWindow ? context : null)
+  }
+
+  function opened (window, context) {
+    if (!context || context.entity || window !== bot.currentWindow || !valid(context)) return
+    if (!blockContainers.has(context.kind) && !context.kind.endsWith('shulker_box')) return
+    if (window.inventoryStart <= 0) return
+    active = { ...context, window }
+    const positions = observed.get(context.world) || new Map()
+    positions.set(context.position.toString(), context.position)
+    observed.set(context.world, positions)
+    publish(window)
+  }
+
+  function publish (window) {
+    active.world.setObservedBlockInventory(active.position, {
+      kind: active.kind,
+      slots: window.slots.slice(0, window.inventoryStart).map(snapshotItem),
+      stale: false,
+      observedAt: Date.now()
+    })
+  }
+
+  function current (window) {
+    return active && active.window === window && valid(active) &&
+      active.world.getObservedBlockInventory(active.position) !== null
+  }
+
+  function updateAll (window) {
+    if (current(window)) publish(window)
+  }
+
+  function updateSlot (window, index, item) {
+    if (!current(window) || index < 0 || index >= window.inventoryStart) return
+    const observation = active.world.getObservedBlockInventory(active.position)
+    observation.slots[index] = snapshotItem(item)
+    observation.observedAt = Date.now()
+    active.world.setObservedBlockInventory(active.position, observation)
+  }
+
+  function close (window) {
+    if (!active || active.window !== window) return
+    if (current(window)) {
+      const observation = active.world.getObservedBlockInventory(active.position)
+      observation.stale = true
+      active.world.setObservedBlockInventory(active.position, observation)
+    }
+    active = null
+  }
+
+  function reset () {
+    for (const [world, positions] of observed) {
+      for (const position of positions.values()) world.removeObservedBlockInventory(position)
+    }
+    observed.clear()
+    pending = null
+    active = null
+  }
+
+  return {
+    begin,
+    cancel: context => { if (pending === context) pending = null },
+    prepare,
+    updateAll,
+    updateSlot,
+    close,
+    reset
+  }
+}

--- a/lib/observed_block_inventories.js
+++ b/lib/observed_block_inventories.js
@@ -7,7 +7,9 @@ module.exports = function observedBlockInventories (bot) {
   let pending = null
   let active = null
   const observed = new Map()
-  const snapshotItem = item => item === null ? null : structuredClone(item)
+  // The world clones nested data, preserving Buffers and component Maps.
+  // Strip only the Item prototype here so snapshots contain data records.
+  const snapshotItem = item => item === null ? null : { ...item }
 
   function begin (block) {
     if (pending) throw new Error('A window is already being opened')

--- a/lib/plugins/blocks.js
+++ b/lib/plugins/blocks.js
@@ -325,10 +325,11 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
       }
       for (const blockEntity of packet.blockEntities) {
         if (blockEntity.x !== undefined) { // 1.17+
-          column.setBlockEntity(blockEntity, blockEntity.nbtData)
+          const pos = new Vec3(packet.x * 16 + blockEntity.x, blockEntity.y, packet.z * 16 + blockEntity.z)
+          bot.world.setBlockEntity(pos, blockEntity.nbtData)
         } else {
-          const pos = new Vec3(blockEntity.value.x.value & 0xf, blockEntity.value.y.value, blockEntity.value.z.value & 0xf)
-          column.setBlockEntity(pos, blockEntity)
+          const pos = new Vec3(blockEntity.value.x.value, blockEntity.value.y.value, blockEntity.value.z.value)
+          bot.world.setBlockEntity(pos, blockEntity)
         }
       }
     }
@@ -454,16 +455,14 @@ function inject (bot, { version, storageBuilder, hideErrors }) {
     if (packet.location !== undefined) {
       const column = bot.world.getColumn(packet.location.x >> 4, packet.location.z >> 4)
       if (!column) return
-      const pos = new Vec3(packet.location.x & 0xf, packet.location.y, packet.location.z & 0xf)
-      column.setBlockEntity(pos, packet.nbtData)
       absolutePos = new Vec3(packet.location.x, packet.location.y, packet.location.z)
+      bot.world.setBlockEntity(absolutePos, packet.nbtData)
     } else {
       const tag = packet.nbtData
       const column = bot.world.getColumn(tag.value.x.value >> 4, tag.value.z.value >> 4)
       if (!column) return
-      const pos = new Vec3(tag.value.x.value & 0xf, tag.value.y.value, tag.value.z.value & 0xf)
-      column.setBlockEntity(pos, tag)
       absolutePos = new Vec3(tag.value.x.value, tag.value.y.value, tag.value.z.value)
+      bot.world.setBlockEntity(absolutePos, tag)
     }
     bot.emit('blockEntityData', bot.blockAt(absolutePos))
   })

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const { Vec3 } = require('vec3')
 const { once, sleep, createDoneTask, createTask, withTimeout } = require('../promise_utils')
 const { toNotchianYaw, toNotchianPitch } = require('../conversions')
+const observedBlockInventories = require('../observed_block_inventories')
 
 module.exports = inject
 
@@ -25,6 +26,11 @@ const ALWAYS_CONSUMABLES = [
 function inject (bot, { hideErrors }) {
   const Item = require('prismarine-item')(bot.registry)
   const windows = require('prismarine-windows')(bot.version)
+  const blockInventories = observedBlockInventories(bot)
+  bot.on('windowClose', window => blockInventories.close(window))
+  bot._client.on('respawn', blockInventories.reset)
+  bot._client.on('login', blockInventories.reset)
+  bot.on('end', blockInventories.reset)
 
   let eatingTask = createDoneTask()
   let sequence = 0
@@ -403,17 +409,27 @@ function inject (bot, { hideErrors }) {
   }
 
   async function openBlock (block, direction, cursorPos) {
-    bot.activateBlock(block, direction, cursorPos)
-    const [window] = await once(bot, 'windowOpen')
-    extendWindow(window)
-    return window
+    const context = blockInventories.begin(block)
+    try {
+      bot.activateBlock(block, direction, cursorPos)
+      const [window] = await once(bot, 'windowOpen')
+      extendWindow(window)
+      return window
+    } finally {
+      blockInventories.cancel(context)
+    }
   }
 
   async function openEntity (entity) {
-    bot.activateEntity(entity)
-    const [window] = await once(bot, 'windowOpen')
-    extendWindow(window)
-    return window
+    const context = blockInventories.begin(null)
+    try {
+      bot.activateEntity(entity)
+      const [window] = await once(bot, 'windowOpen')
+      extendWindow(window)
+      return window
+    } finally {
+      blockInventories.cancel(context)
+    }
   }
 
   function createActionNumber () {
@@ -714,11 +730,13 @@ function inject (bot, { hideErrors }) {
     bot.setQuickBarSlot(packet.slot)
   })
 
-  function prepareWindow (window) {
+  function prepareWindow (window, blockWindow = true) {
+    const observe = blockInventories.prepare(window, blockWindow)
     if (!windowItems || window.id !== windowItems.windowId) {
       // don't emit windowOpen until we have the slot data
       bot.once(`setWindowItems:${window.id}`, () => {
         extendWindow(window)
+        observe()
         bot.emit('windowOpen', window)
       })
     } else {
@@ -731,6 +749,7 @@ function inject (bot, { hideErrors }) {
       windowItems = null
       updateHeldItem()
       extendWindow(window)
+      observe()
       bot.emit('windowOpen', window)
     }
   }
@@ -746,7 +765,7 @@ function inject (bot, { hideErrors }) {
     // open window
     bot.currentWindow = windows.createWindow(packet.windowId,
       'HorseWindow', 'Horse', packet.nbSlots)
-    prepareWindow(bot.currentWindow)
+    prepareWindow(bot.currentWindow, false)
   })
   bot._client.on('close_window', (packet) => {
     // close window
@@ -796,6 +815,7 @@ function inject (bot, { hideErrors }) {
     }
     const newItem = Item.fromNotch(packet.item)
     bot._setSlot(packet.slot, newItem, window)
+    blockInventories.updateSlot(window, packet.slot, newItem)
   })
   // set_player_inventory uses vanilla Inventory indices (0-8 hotbar, 9-35 main,
   // 36-39 armor from feet to head, 40 offhand), not window 0 slot numbers
@@ -847,6 +867,7 @@ function inject (bot, { hideErrors }) {
     }
     if (packet.carriedItem !== undefined) window.selectedItem = Item.fromNotch(packet.carriedItem)
     updateHeldItem()
+    blockInventories.updateAll(window)
     bot.emit(`setWindowItems:${window.id}`)
   })
 

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "prismarine-recipe": "^1.5.0",
     "prismarine-registry": "^1.10.0",
     "prismarine-windows": "^2.9.0",
-    "prismarine-world": "^3.6.0",
+    "prismarine-world": "git+https://github.com/DragonModels/prismarine-world.git#42eea121552c01bf3b1d6b4eadd3b9dd2d7a25c1",
     "protodef": "^1.18.0",
     "typed-emitter": "^1.0.0",
     "uuid-1345": "^1.0.2",
-    "vec3": "^0.1.7"
+    "vec3": "^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^25.2.1",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "prismarine-recipe": "^1.5.0",
     "prismarine-registry": "^1.10.0",
     "prismarine-windows": "^2.9.0",
-    "prismarine-world": "git+https://github.com/DragonModels/prismarine-world.git#42eea121552c01bf3b1d6b4eadd3b9dd2d7a25c1",
+    "prismarine-world": "git+https://github.com/DragonModels/prismarine-world.git#281ebd6fae18ff0f2a93d6e3072fca133a841d5b",
     "protodef": "^1.18.0",
     "typed-emitter": "^1.0.0",
     "uuid-1345": "^1.0.2",
-    "vec3": "^0.2.0"
+    "vec3": "^0.1.7"
   },
   "devDependencies": {
     "@types/node": "^25.2.1",

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1426,6 +1426,41 @@ for (const supportedVersion of mineflayer.testedVersions) {
         carriedItem: Item.toNotch(null)
       })
 
+      it('retains server-observed block contents across window updates and close', (done) => {
+        server.on('playerJoin', (client) => {
+          bot.once('login', () => {
+            setImmediate(async () => {
+              try {
+                const position = vec3(2, 64, 3)
+                bot.world.setColumn(0, 0, bot.test.buildChunk())
+                bot.world.setBlockStateId(position, registry.blocksByName.chest.defaultState)
+                assert.strictEqual(bot.world.getObservedBlockInventory(position), null)
+                bot.activateBlock = () => {
+                  const items = emptyItems(chestData.slots)
+                  items[0] = Item.toNotch(new Item(registry.itemsByName.stone.id, 3))
+                  client.write('open_window', openWindowPacket(1, chestData))
+                  client.write('window_items', windowItemsPacket(1, items))
+                }
+                const window = await bot.openBlock(bot.blockAt(position))
+                assert.strictEqual(bot.world.getObservedBlockInventory(position).slots[0].count, 3)
+                window.updateSlot(0, new Item(registry.itemsByName.stone.id, 42))
+                assert.strictEqual(bot.world.getObservedBlockInventory(position).slots[0].count, 3)
+                const updated = once(bot, 'setWindowItems:1')
+                const items = emptyItems(chestData.slots)
+                items[0] = Item.toNotch(new Item(registry.itemsByName.stone.id, 8))
+                client.write('window_items', windowItemsPacket(1, items))
+                await updated
+                assert.strictEqual(bot.world.getObservedBlockInventory(position).slots[0].count, 8)
+                bot.closeWindow(window)
+                assert.strictEqual(bot.world.getObservedBlockInventory(position).stale, true)
+                done()
+              } catch (err) { done(err) }
+            })
+          })
+          client.write('login', bot.test.generateLoginPacket())
+        })
+      })
+
       it('opens a window whose early window_items reuses the id of a closed window', (done) => {
         const emeraldId = registry.itemsByName.emerald.id
 

--- a/test/observedBlockInventoriesTest.js
+++ b/test/observedBlockInventoriesTest.js
@@ -1,0 +1,139 @@
+/* eslint-env mocha */
+const assert = require('assert')
+const { EventEmitter } = require('events')
+const { Vec3 } = require('vec3')
+const inject = require('../lib/plugins/inventory')
+
+describe('observed block inventories', () => {
+  let bot, Item, position
+  beforeEach(() => {
+    bot = new EventEmitter()
+    bot.version = '1.21.4'
+    bot.registry = require('prismarine-registry')(bot.version)
+    bot.supportFeature = name => bot.registry.supportFeature(name)
+    bot._client = new EventEmitter()
+    bot._client.write = () => {}
+    bot.QUICK_BAR_START = 36
+    bot.entity = { id: 1 }
+    const World = require('prismarine-world')(bot.version)
+    const Chunk = require('prismarine-chunk')(bot.version)
+    bot.world = new World().sync
+    bot.world.setColumn(0, 0, new Chunk())
+    position = new Vec3(2, 64, 3)
+    bot.world.setBlockStateId(position, bot.registry.blocksByName.chest.defaultState)
+    Item = require('prismarine-item')(bot.registry)
+    inject(bot, {})
+  })
+
+  function item (count) { return new Item(bot.registry.itemsByName.stone.id, count) }
+  function contents (count = 3, size = 27) {
+    const slots = Array(size + 36).fill(null)
+    slots[0] = item(count)
+    slots[size] = item(19)
+    return slots.map(Item.toNotch)
+  }
+  function packet (name, fields) { bot._client.emit(name, fields) }
+  async function open ({ buffered = false, size = 27 } = {}) {
+    bot.activateBlock = () => setImmediate(() => {
+      const data = { windowId: 1, stateId: 1, items: contents(3, size) }
+      if (buffered) packet('window_items', data)
+      packet('open_window', { windowId: 1, inventoryType: size === 54 ? 'minecraft:generic_9x6' : 'minecraft:generic_9x3', windowTitle: 'Chest' })
+      if (!buffered) packet('window_items', data)
+    })
+    return bot.openBlock(bot.world.getBlock(position))
+  }
+  function observation () { return bot.world.getObservedBlockInventory(position) }
+
+  for (const buffered of [false, true]) {
+    it(`records server contents with buffered=${buffered}, excluding player slots`, async () => {
+      assert.strictEqual(observation(), null)
+      const raw = { value: { sentinel: { type: 'int', value: 123 } } }
+      bot.world.setBlockEntity(position, raw)
+      await open({ buffered })
+      assert.strictEqual(observation().slots.length, 27)
+      assert.strictEqual(observation().slots[0].count, 3)
+      assert.strictEqual(observation().stale, false)
+      assert.strictEqual(bot.world.getBlockEntity(position), raw)
+      const copy = observation()
+      copy.slots[0].count = 99
+      assert.strictEqual(observation().slots[0].count, 3)
+    })
+  }
+
+  it('records server slot changes but never optimistic clicks or player changes', async () => {
+    const window = await open()
+    window.updateSlot(0, item(42))
+    assert.strictEqual(observation().slots[0].count, 3)
+    packet('set_slot', { windowId: 1, stateId: 2, slot: 0, item: Item.toNotch(item(8)) })
+    assert.strictEqual(observation().slots[0].count, 8)
+    packet('set_slot', { windowId: 1, stateId: 3, slot: 27, item: Item.toNotch(item(55)) })
+    assert.strictEqual(observation().slots.length, 27)
+    window.updateSlot(0, item(44))
+    packet('close_window', { windowId: 1 })
+    assert.strictEqual(observation().slots[0].count, 8)
+    assert.strictEqual(observation().stale, true)
+    packet('set_slot', { windowId: 1, stateId: 4, slot: 0, item: Item.toNotch(item(9)) })
+    assert.strictEqual(observation().slots[0].count, 8)
+  })
+
+  it('replaces its snapshot on a full server update and retains item components', async () => {
+    await open()
+    packet('window_items', { windowId: 1, stateId: 2, items: contents(11) })
+    assert.strictEqual(observation().slots[0].count, 11)
+    assert(observation().slots[0].componentMap instanceof Map)
+    packet('set_slot', { windowId: 1, stateId: 3, slot: 0, item: Item.toNotch(null) })
+    assert.strictEqual(observation().slots[0], null)
+  })
+
+  for (const invalidate of ['unload', 'replace', 'respawn', 'login', 'end', 'nbt']) {
+    it(`forgets contents after ${invalidate} and ignores remaining packets`, async () => {
+      await open()
+      if (invalidate === 'unload') bot.world.unloadColumn(0, 0)
+      else if (invalidate === 'replace') bot.world.setBlockStateId(position, bot.registry.blocksByName.stone.defaultState)
+      else if (invalidate === 'nbt') bot.world.setBlockEntity(position, { value: {} })
+      else if (invalidate === 'end') bot.emit('end')
+      else packet(invalidate, {})
+      assert.strictEqual(observation(), null)
+      packet('window_items', { windowId: 1, stateId: 4, items: contents(12) })
+      assert.strictEqual(observation(), null)
+    })
+  }
+
+  it('stores a double chest window at the clicked position without guessing its other half', async () => {
+    await open({ size: 54 })
+    assert.strictEqual(observation().slots.length, 54)
+    assert.strictEqual(bot.world.getObservedBlockInventory(position.offset(1, 0, 0)), null)
+  })
+
+  it('does not expose personal ender chest contents as block storage', async () => {
+    bot.world.setBlockStateId(position, bot.registry.blocksByName.ender_chest.defaultState)
+    await open()
+    assert.strictEqual(observation(), null)
+  })
+
+  it('does not assign entity storage to a previously opened block', async () => {
+    await open()
+    bot.activateEntity = () => setImmediate(() => {
+      packet('open_window', { windowId: 2, inventoryType: 'minecraft:generic_9x3', windowTitle: 'Minecart' })
+      packet('window_items', { windowId: 2, stateId: 1, items: contents(22) })
+    })
+    await bot.openEntity({ id: 10 })
+    assert.strictEqual(observation().slots[0].count, 3)
+    assert.strictEqual(observation().stale, true)
+  })
+
+  it('rejects overlapping block and entity requests before attribution becomes ambiguous', async () => {
+    const opening = open()
+    await assert.rejects(bot.openEntity({ id: 10 }), /already being opened/)
+    await opening
+    assert.strictEqual(observation().slots[0].count, 3)
+  })
+
+  it('marks the previous observation stale when another window opens without a close packet', async () => {
+    await open()
+    packet('open_window', { windowId: 2, inventoryType: 'minecraft:generic_9x3', windowTitle: 'Other' })
+    packet('window_items', { windowId: 2, stateId: 1, items: contents(7) })
+    assert.strictEqual(observation().stale, true)
+    assert.strictEqual(observation().slots[0].count, 3)
+  })
+})

--- a/test/worldVectorCompatibilityTest.js
+++ b/test/worldVectorCompatibilityTest.js
@@ -1,0 +1,22 @@
+/* eslint-env mocha */
+const assert = require('assert')
+
+describe('world vector compatibility', () => {
+  it('uses compatible position objects for entity, direct block and raycast results', () => {
+    const version = '1.21.4'
+    const Entity = require('prismarine-entity')(version)
+    const registry = require('prismarine-registry')(version)
+    const Chunk = require('prismarine-chunk')(version)
+    const World = require('prismarine-world')(version)
+    const entity = new Entity(1)
+    entity.position = entity.position.offset(0.5, 65, 0.5)
+    const world = new World().sync
+    world.setColumn(0, 0, new Chunk())
+    world.setBlockStateId(entity.position.offset(0, -1, 0), registry.blocksByName.stone.defaultState)
+    const ray = world.raycast(entity.position, entity.position.scaled(0).offset(0, -1, 0), 3)
+    const direct = world.getBlock(entity.position.offset(0, -1, 0))
+    // Equal coordinates alone miss incompatible vector prototypes from mixed dependencies.
+    assert.deepStrictEqual(ray.position, direct.position)
+    assert.deepStrictEqual(entity.position, require('vec3')(0.5, 65, 0.5))
+  })
+})


### PR DESCRIPTION
Connects server-observed block-container contents to `bot.world`, advancing the block-inventory portion of #334. After `openBlock`/`openContainer`, callers can query `bot.world.getObservedBlockInventory(position)` for container slots, kind, observation time and stale status. Server packets update the snapshot; optimistic local clicks do not. Raw block-entity NBT stays separate and retains its existing storage behavior.

Unknown or invalidated contents return null. Closing/replacing the window marks the previous observation stale; block/NBT changes, column replacement/unload, respawn, login and disconnect discard it. Entity, player and personal ender-chest inventories are excluded. Double-chest windows are anchored only to the clicked position; the other half is not inferred. Overlapping block/entity open requests are rejected to avoid ambiguous attribution.

Depends on PrismarineJS/prismarine-world#164. The dependency pins the same feature patch applied to the published 3.7.0 release (commit `281ebd6fae18ff0f2a93d6e3072fca133a841d5b`). This preserves the released `vec3` 0.1 range used by entity/chunk libraries; current world master includes an unrelated, unreleased 0.2 bump that caused incompatible vector prototypes in the first CI run. The upstream world PR is unchanged. Replace the temporary pin with a compatible published upstream release before merging.

Validation:
- Upstream CI run [34277994322](https://github.com/PrismarineJS/mineflayer/actions/runs/34277994322) passed all seven Minecraft groups (all 28 supported versions), lint and version preparation on commit `a8b33d355dc6367766a55adf7685ae0896c5dca5`. This includes the repository's external-server tests.
- Final public dependency install with lifecycle scripts disabled: lint and 128 targeted tests pass. These include a regression that reproduced the initial CI vector-prototype failure, packet/lifecycle cases, and window plus absolute/relative-position protocol coverage across all 28 supported versions.
- Earlier full internal plus observation suite: 810 passing, 73 pending with one retry configured. The first broad run had five respawn timeouts; unchanged and modified code both passed all 28 respawn tests separately. The final nested-buffer-copy adjustment was followed by lint and the 99 focused tests again.
- A strict TypeScript consumer fixture passes with dependency declaration checking skipped. Unrestricted `tsc` still reports errors in dependency declarations.
- Local validation used isolated protocol fixtures; the upstream CI result above provides the external-server test evidence.


