### PR TITLE
Make the named scoreboard display slots non-enumerable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1150,6 +1150,8 @@ All scoreboards known to the bot in an object scoreboard displaySlot -> scoreboa
  * `list` - scoreboard placed in list
  * `0-18` - slots defined in [protocol](https://minecraft.wiki/w/Protocol#Display_Scoreboard)
 
+Only slots that currently display an objective are enumerable, so `Object.values(bot.scoreboard)` never contains `undefined`. The named slots are non-enumerable aliases of `0`, `1` and `2`.
+
 #### bot.teams
 
 All teams known to the bot

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -48,18 +48,12 @@ module.exports = (bot) => {
     }
   }
 
-  ScoreBoard.positions = {
-    get list () {
-      return this[0]
-    },
-
-    get sidebar () {
-      return this[1]
-    },
-
-    get belowName () {
-      return this[2]
-    }
-  }
+  // The named slots alias the numeric ones and stay non-enumerable, so
+  // Object.keys/values(bot.scoreboard) only ever yield displayed objectives.
+  ScoreBoard.positions = Object.defineProperties({}, {
+    list: { get () { return this[0] } },
+    sidebar: { get () { return this[1] } },
+    belowName: { get () { return this[2] } }
+  })
   return ScoreBoard
 }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1484,6 +1484,22 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('scoreboard', () => {
+      it('enumerates only the display slots that hold an objective', async () => {
+        server.on('playerJoin', (client) => client.write('login', bot.test.generateLoginPacket()))
+        await once(bot, 'login')
+        bot._client.emit('scoreboard_objective', { name: 'test1', action: 0, displayText: JSON.stringify({ text: 'Test 1' }) })
+        bot._client.emit('scoreboard_display_objective', { name: 'test1', position: 1 })
+        assert.strictEqual(bot.scoreboard.sidebar, bot.scoreboards.test1)
+        assert.strictEqual(bot.scoreboard.list, undefined)
+        assert.deepStrictEqual(Object.keys(bot.scoreboard), ['1'])
+        assert.ok(Object.values(bot.scoreboard).every(sb => sb !== undefined))
+        assert.doesNotThrow(() => { for (const sb of Object.values(bot.scoreboard)) assert.strictEqual(sb.title, 'Test 1') })
+        bot._client.emit('scoreboard_objective', { name: 'test1', action: 1 })
+        assert.deepStrictEqual(Object.keys(bot.scoreboard), [])
+        assert.strictEqual(bot.scoreboard.sidebar, undefined)
+      })
+    })
     describe('tablist', () => {
       it('handles newlines in header and footer', (done) => {
         const HEADER = 'asd\ndsa'


### PR DESCRIPTION
`bot.scoreboard` is the display-slot map: numeric slots plus `list`, `sidebar` and `belowName` getters that alias slots 0, 1 and 2. The getters were enumerable, so `Object.values(bot.scoreboard)` contained `undefined` for every named slot with no objective and a plain loop over it threw (`Cannot read properties of undefined (reading 'title')`). Observed on a 26.1 production server with keys `['1','2','list','sidebar','belowName']`.

The getters are now defined non-enumerable, so keys/values only ever yield displayed objectives while `bot.scoreboard.sidebar` keeps working. The objective-deleted loop also no longer visits the accessor keys.

Internal test added; it fails on master on all tested versions and passes here. Docs updated.

Reported in u9g/bot-harness#78.