### PR TITLE
Throw a descriptive error when bot.chat is called before login

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1703,6 +1703,8 @@ Requests chat completion from the server.
 
 Sends a publicly broadcast chat message. Breaks up big messages into multiple chat messages as necessary.
 
+Throws if called before the `login` event: the server only accepts chat once the client is in the play state.
+
 #### bot.whisper(username, message)
 
 Shortcut for "/tell <username>". All split messages will be whispered to username.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1703,7 +1703,7 @@ Requests chat completion from the server.
 
 Sends a publicly broadcast chat message. Breaks up big messages into multiple chat messages as necessary.
 
-Throws if called before the `login` event: the server only accepts chat once the client is in the play state.
+Throws if called before the `login` event, or after a disconnect that happened before it: the server only accepts chat once the client is in the play state.
 
 #### bot.whisper(username, message)
 

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -166,6 +166,10 @@ function inject (bot, options) {
     if (typeof message !== 'string') {
       throw new Error('Chat message type must be a string or number: ' + typeof message)
     }
+    // minecraft-protocol only attaches client.chat once the login packet puts it in the play state.
+    if (typeof bot._client.chat !== 'function') {
+      throw new Error('bot.chat() called before the client entered the play state; wait for the "login" or "spawn" event')
+    }
 
     if (!header && message.startsWith('/')) {
       // Do not try and split a command without a header

--- a/lib/plugins/chat.js
+++ b/lib/plugins/chat.js
@@ -7,6 +7,8 @@ module.exports = inject
 
 function inject (bot, options) {
   const CHAT_LENGTH_LIMIT = options.chatLengthLimit ?? (bot.supportFeature('lessCharsInChat') ? 100 : 256)
+  let endReason
+  bot._client.once('end', (reason) => { endReason = reason })
   const defaultChatPatterns = options.defaultChatPatterns ?? true
 
   const ChatMessage = require('prismarine-chat')(bot.registry)
@@ -168,6 +170,9 @@ function inject (bot, options) {
     }
     // minecraft-protocol only attaches client.chat once the login packet puts it in the play state.
     if (typeof bot._client.chat !== 'function') {
+      if (endReason !== undefined) {
+        throw new Error(`bot.chat() called after the client disconnected before entering the play state (${endReason})`)
+      }
       throw new Error('bot.chat() called before the client entered the play state; wait for the "login" or "spawn" event')
     }
 

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -103,9 +103,8 @@ for (const supportedVersion of mineflayer.testedVersions) {
       }
     })
     afterEach((done) => {
-      bot.on('end', () => {
-        done()
-      })
+      if (bot._client.ended) done()
+      else bot.on('end', () => done())
       server.close()
     })
     it('chat', (done) => {
@@ -194,9 +193,20 @@ for (const supportedVersion of mineflayer.testedVersions) {
     })
     it('chat before login throws a descriptive error', async () => {
       await once(bot, 'inject_allowed')
-      const early = /before the client entered the play state/
+      const early = /before the client entered the play state; wait for/
       assert.throws(() => bot.chat('hi'), early)
       assert.throws(() => bot.whisper('gary', 'hi'), early)
+    })
+    it('chat after a kick during login throws a descriptive error', async () => {
+      // Replaces the server's login handler so the client is rejected while still in the login state.
+      server.on('connection', (client) => {
+        client.removeAllListeners('login_start')
+        client.once('login_start', () => client.end('kicked'))
+      })
+      const [reason] = await once(bot, 'end')
+      const kicked = new RegExp(`disconnected before entering the play state \\(${reason}\\)`)
+      assert.throws(() => bot.chat('hi'), kicked)
+      assert.throws(() => bot.whisper('gary', 'hi'), kicked)
     })
     it('entity effects', (done) => {
       bot.once('entityEffect', (entity, effect) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -192,6 +192,12 @@ for (const supportedVersion of mineflayer.testedVersions) {
         client.on('chat', onChat)
       })
     })
+    it('chat before login throws a descriptive error', async () => {
+      await once(bot, 'inject_allowed')
+      const early = /before the client entered the play state/
+      assert.throws(() => bot.chat('hi'), early)
+      assert.throws(() => bot.whisper('gary', 'hi'), early)
+    })
     it('entity effects', (done) => {
       bot.once('entityEffect', (entity, effect) => {
         assert.strictEqual(entity.id, 8)


### PR DESCRIPTION
minecraft-protocol attaches `client.chat` when the login packet moves the client into the play state. Calling `bot.chat()` or `bot.whisper()` earlier (for example right after creating a new bot, before it logged in) failed inside the chat plugin with `bot._client.chat is not a function`, which gives no hint that the call was simply too early.

`chatWithHeader` now throws:

- `bot.chat() called before the client entered the play state; wait for the "login" or "spawn" event` while the client is still connecting, and
- `bot.chat() called after the client disconnected before entering the play state (<end reason>)` when the connection was kicked or dropped during login/configuration, so callers are not told to wait for a login that will never come.

Internal tests added for both; on master they fail with the raw TypeError on all tested versions. Docs updated.

Reported in u9g/bot-harness#78 and u9g/bot-harness#47.