### PR TITLE
Normalize open_window titles to ChatMessage

### DIFF
--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -25,6 +25,7 @@ const ALWAYS_CONSUMABLES = [
 function inject (bot, { hideErrors }) {
   const Item = require('prismarine-item')(bot.registry)
   const windows = require('prismarine-windows')(bot.version)
+  const ChatMessage = require('prismarine-chat')(bot.registry)
 
   let eatingTask = createDoneTask()
   let sequence = 0
@@ -738,8 +739,10 @@ function inject (bot, { hideErrors }) {
   bot._client.on('open_window', (packet) => {
     // open window
     lastClosedWindow = null
+    // The title is a chat component whose wire shape depends on the version
+    // (JSON string, or an NBT string/compound); window.title is always a ChatMessage.
     bot.currentWindow = windows.createWindow(packet.windowId,
-      packet.inventoryType, packet.windowTitle, packet.slotCount)
+      packet.inventoryType, ChatMessage.fromNotch(packet.windowTitle), packet.slotCount)
     prepareWindow(bot.currentWindow)
   })
   bot._client.on('open_horse_window', (packet) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -648,6 +648,28 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('window titles are ChatMessages whatever shape the server sends', async () => {
+        const Item = require('prismarine-item')(registry)
+        // A component title plus the bare-string form third-party servers send.
+        const titles = registry.supportFeature('chatPacketsUseNbtComponents')
+          ? [nbt.comp({ text: nbt.string('Test Chest') }), nbt.string('Test Chest')]
+          : [JSON.stringify({ text: 'Test Chest' }), 'Test Chest']
+        const chest = registry.supportFeature('village&pillageInventoryWindows')
+          ? { inventoryType: 2 }
+          : { inventoryType: 'minecraft:chest', slotCount: 27 }
+        const [client] = await once(server, 'playerJoin')
+        client.write('login', bot.test.generateLoginPacket())
+        for (const [i, windowTitle] of titles.entries()) {
+          const windowId = i + 1
+          client.write('open_window', { windowId, windowTitle, ...chest })
+          client.write('window_items', { windowId, stateId: 0, items: [], carriedItem: Item.toNotch(null) })
+          const [window] = await once(bot, 'windowOpen')
+          assert.strictEqual(window.id, windowId)
+          assert.strictEqual(window.title.constructor.name, 'ChatMessage')
+          assert.strictEqual(window.title.toString(), 'Test Chest')
+        }
+      })
+
       it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
         server.on('playerJoin', (client) => {
           const clicks = []


### PR DESCRIPTION
`window.title` had no stable type. The `open_window` title is a chat component on every version mineflayer supports (1.8.9 `S2DPacketOpenWindow.readPacketData` reads it with `readChatComponent`; 26.1 `ClientboundOpenScreenPacket` carries a `Component`) and reaches the client as a JSON string, an NBT string or an NBT compound depending on the version and on what the server put in the packet. On a 26.1 proxy network the same menu arrived as a bare `§`-string from one backend and as a component from another, so `String(window.title)` was `"[object Object]"` and scripts that pick GUI items by title had to guess the shape.

The `open_window` handler now runs the field through `ChatMessage.fromNotch`, the same normalization every other chat field gets. `window.title` is always a `ChatMessage`: `String(title)` is the rendered text, `.json` keeps the structure, and callers that already did `ChatMessage.fromNotch(window.title)` still get the text.

The internal test opens a chest with a component title and with the bare-string form on every tested version and asserts the rendered title.

Follow-up: `prismarine-windows` still declares `Window.title` as `string` in its typings.
