### PR TITLE
Window state across close, re-login and respawn: stateId per window, close_window on respawn, closeWindow(null)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2196,7 +2196,7 @@ Put the item at `slot` in the inventory.
 
 This function returns a `Promise`, with `void` as its argument once the server has acknowledged the close.
 
-Close the `window`. On 1.16.5 and below the server only learns which inventory slots the window changed on its next tick, so await this before anything else (a command, another player) touches those slots.
+Close the `window`. On 1.16.5 and below the server only learns which inventory slots the window changed on its next tick, so await this before anything else (a command, another player) touches those slots. A `null` window (`bot.currentWindow` after the window closed on its own) is a no-op.
 
 #### bot.transfer(options)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1504,7 +1504,7 @@ Fires when you begin using a workbench, chest, brewing stand, etc.
 
 #### "windowClose" (window)
 
-Fires when you may no longer work with a workbench, chest, etc.
+Fires when you may no longer work with a workbench, chest, etc. Also fires when a respawn or a re-login (proxy server switch) discards the open window.
 
 #### "sleep"
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -408,7 +408,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   putAway: (slot: number) => Promise<void>
 
-  closeWindow: (window: Window) => Promise<void>
+  closeWindow: (window: Window | null) => Promise<void>
 
   transfer: (options: TransferOptions) => Promise<void>
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -30,11 +30,10 @@ function inject (bot, { hideErrors }) {
   let sequence = 0
 
   let nextActionNumber = 0 // < 1.17
-  let stateId = -1
-  if (bot.supportFeature('stateIdUsed')) {
-    const listener = packet => { stateId = packet.stateId }
-    bot._client.on('window_items', listener)
-    bot._client.on('set_slot', listener)
+  // windowId -> stateId of the last window_items or set_slot applied to that window
+  const stateIds = new Map()
+  function recordStateId (window, packet) {
+    if (packet.stateId !== undefined) stateIds.set(window.id, packet.stateId)
   }
   const windowClickQueue = []
   let windowItems
@@ -437,6 +436,7 @@ function inject (bot, { hideErrors }) {
       windowId: window.id
     })
     copyInventory(window)
+    if (window !== bot.inventory) stateIds.delete(window.id)
     lastClosedWindow = window
     dropWindow(window)
     if (bot.supportFeature('stateIdUsed')) return Promise.resolve()
@@ -636,7 +636,7 @@ function inject (bot, { hideErrors }) {
     if (bot.supportFeature('stateIdUsed')) { // 1.17.1 +
       bot._client.write('window_click', {
         windowId: window.id,
-        stateId,
+        stateId: stateIds.get(window.id) ?? -1,
         slot,
         mouseButton,
         mode,
@@ -733,6 +733,7 @@ function inject (bot, { hideErrors }) {
         const item = Item.fromNotch(windowItems.items[i])
         window.updateSlot(i, item)
       }
+      recordStateId(window, windowItems)
       // consume the buffer so a later window reusing this id cannot open
       // with stale contents
       windowItems = null
@@ -758,6 +759,7 @@ function inject (bot, { hideErrors }) {
   bot._client.on('close_window', (packet) => {
     // close window
     const oldWindow = bot.currentWindow
+    if (oldWindow) stateIds.delete(oldWindow.id)
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })
@@ -766,6 +768,7 @@ function inject (bot, { hideErrors }) {
   bot._client.on('login', () => {
     windowItems = null
     lastClosedWindow = null
+    stateIds.clear()
     if (bot.currentWindow) dropWindow(bot.currentWindow)
   })
   // Vanilla sends close_window for the open window before handling a
@@ -781,6 +784,7 @@ function inject (bot, { hideErrors }) {
     }
     windowItems = null
     lastClosedWindow = null
+    stateIds.clear()
   })
   bot._setSlot = (slotId, newItem, window = bot.inventory) => {
     // set slot
@@ -802,6 +806,7 @@ function inject (bot, { hideErrors }) {
       }
       return
     }
+    recordStateId(window, packet)
     const newItem = Item.fromNotch(packet.item)
     bot._setSlot(packet.slot, newItem, window)
   })
@@ -849,6 +854,7 @@ function inject (bot, { hideErrors }) {
     }
 
     // set window items
+    recordStateId(window, packet)
     for (let i = 0; i < packet.items.length; ++i) {
       const item = Item.fromNotch(packet.items[i])
       window.updateSlot(i, item)

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -436,10 +436,15 @@ function inject (bot, { hideErrors }) {
     })
     copyInventory(window)
     lastClosedWindow = window
-    bot.currentWindow = null
-    bot.emit('windowClose', window)
+    dropWindow(window)
     if (bot.supportFeature('stateIdUsed')) return Promise.resolve()
     return clickWindow(-999, 0, 0).catch(() => {})
+  }
+
+  // Client-side only: no close_window is sent
+  function dropWindow (window) {
+    bot.currentWindow = null
+    bot.emit('windowClose', window)
   }
 
   function copyInventory (window) {
@@ -754,23 +759,24 @@ function inject (bot, { hideErrors }) {
     bot.currentWindow = null
     bot.emit('windowClose', oldWindow)
   })
-  // Window ids restart with the player entity, so a later window can reuse
-  // the closed one's id and its early sync must not be taken for a trailing one.
-  bot._client.on('respawn', () => { lastClosedWindow = null })
+  // The server receiving a re-login has no window open; vanilla sends no
+  // close_window for the one that was open
   bot._client.on('login', () => {
-    lastClosedWindow = null
-    // close window when switch subserver
     windowItems = null
     lastClosedWindow = null
-    const oldWindow = bot.currentWindow
-    if (!oldWindow) return
-    bot.currentWindow = null
-    bot.emit('windowClose', oldWindow)
+    if (bot.currentWindow) dropWindow(bot.currentWindow)
   })
-  // A respawn (death or dimension change) replaces the server-side player
-  // entity and resets its window id counter, so pending window state can
-  // never describe a post-respawn window
+  // Vanilla sends close_window for the open window before handling a
+  // respawn. A respawn restarts the window id counter: pending window state
+  // never describes a post-respawn window, and a later window may reuse a
+  // closed one's id
   bot._client.on('respawn', () => {
+    const window = bot.currentWindow
+    if (window) {
+      bot._client.write('close_window', { windowId: window.id })
+      copyInventory(window)
+      dropWindow(window)
+    }
     windowItems = null
     lastClosedWindow = null
   })

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -431,6 +431,8 @@ function inject (bot, { hideErrors }) {
   // never sent. A rejected click already carries the full inventory, so the
   // sync click's outcome is not an error.
   function closeWindow (window) {
+    // Callers pass bot.currentWindow, which is null once the window has closed itself.
+    if (!window) return Promise.resolve()
     bot._client.write('close_window', {
       windowId: window.id
     })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1555,6 +1555,40 @@ for (const supportedVersion of mineflayer.testedVersions) {
           client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
         })
       })
+
+      it('clicks carry the stateId of the window they click, not the last one synced', function (done) {
+        if (!bot.supportFeature('stateIdUsed')) {
+          this.skip()
+          return
+        }
+        const clicks = []
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.on('window_click', (packet) => {
+            clicks.push(packet)
+            if (clicks.length < 2) return
+            try {
+              assert.deepStrictEqual(clicks.map(c => [c.windowId, c.stateId]), [[1, 5], [0, 9]])
+              done()
+            } catch (err) {
+              done(err)
+            }
+          })
+
+          bot.once('windowOpen', async () => {
+            // a player-inventory sync while the container is open
+            client.write('set_slot', { windowId: 0, stateId: 9, slot: 36, item: Item.toNotch(null) })
+            await sleep(50)
+            await bot.clickWindow(0, 0, 0)
+            bot.closeWindow(bot.currentWindow)
+            await sleep(50)
+            await bot.clickWindow(36, 0, 0)
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', { ...windowItemsPacket(1, emptyItems(chestData.slots)), stateId: 5 })
+        })
+      })
     })
 
     describe('tablist', () => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -653,6 +653,30 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('closeWindow(null) resolves without sending close_window or emitting windowClose', (done) => {
+        server.on('playerJoin', (client) => {
+          const sent = []
+          client.on('packet', (data, meta) => {
+            if (meta.name === 'close_window' || meta.name === 'window_click') sent.push(meta.name)
+          })
+          let closes = 0
+          bot.on('windowClose', () => closes++)
+          const loggedIn = once(bot, 'login')
+          client.write('login', bot.test.generateLoginPacket())
+          loggedIn
+            .then(() => {
+              assert.strictEqual(bot.currentWindow, null)
+              return bot.closeWindow(bot.currentWindow)
+            })
+            .then(() => sleep(100))
+            .then(() => {
+              assert.deepStrictEqual(sent, [])
+              assert.strictEqual(closes, 0)
+            })
+            .then(done, done)
+        })
+      })
+
       it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
         server.on('playerJoin', (client) => {
           const clicks = []

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -101,6 +101,49 @@ for (const supportedVersion of mineflayer.testedVersions) {
         }
         return loginPacket
       }
+
+      bot.test.generateRespawnPacket = () => {
+        const loginPacket = bot.test.generateLoginPacket()
+        let respawnPacket
+        if (bot.supportFeature('usesLoginPacket')) {
+          loginPacket.worldName = 'minecraft:overworld'
+          loginPacket.hashedSeed = [0, 0]
+          respawnPacket = {
+            // 1.19+ the `dimension` filed is a string in respawn packet and undefined in login packet, in previous versions it's same NBT data in login/respawn
+            dimension: bot.supportFeature('dimensionDataInCodec') ? 'minecraft:overworld' : loginPacket.dimension,
+            worldName: loginPacket.worldName,
+            hashedSeed: loginPacket.hashedSeed,
+            gamemode: 0,
+            previousGamemode: 255,
+            isDebug: false,
+            isFlat: false,
+            copyMetadata: true,
+            death: {
+              dimensionName: '',
+              location: {
+                x: 0,
+                y: 0,
+                z: 0
+              }
+            }
+          }
+          if (bot.supportFeature('spawnRespawnWorldDataField')) {
+            respawnPacket = {
+              worldState: respawnPacket
+            }
+            respawnPacket.worldState.name = loginPacket.worldName
+            respawnPacket.worldState.dimension = loginPacket.dimension
+          }
+        } else {
+          respawnPacket = {
+            dimension: 0,
+            hashedSeed: [0, 0],
+            gamemode: 0,
+            levelType: 'default'
+          }
+        }
+        return respawnPacket
+      }
     })
     afterEach((done) => {
       bot.on('end', () => {
@@ -540,45 +583,7 @@ for (const supportedVersion of mineflayer.testedVersions) {
       const goldId = 41
       it('switchWorld respawn', (done) => {
         const loginPacket = bot.test.generateLoginPacket()
-        let respawnPacket
-        if (bot.supportFeature('usesLoginPacket')) {
-          loginPacket.worldName = 'minecraft:overworld'
-          loginPacket.hashedSeed = [0, 0]
-          loginPacket.entityId = 0
-          respawnPacket = {
-            // 1.19+ the `dimension` filed is a string in respawn packet and undefined in login packet, in previous versions it's same NBT data in login/respawn
-            dimension: bot.supportFeature('dimensionDataInCodec') ? 'minecraft:overworld' : loginPacket.dimension,
-            worldName: loginPacket.worldName,
-            hashedSeed: loginPacket.hashedSeed,
-            gamemode: 0,
-            previousGamemode: 255,
-            isDebug: false,
-            isFlat: false,
-            copyMetadata: true,
-            death: {
-              dimensionName: '',
-              location: {
-                x: 0,
-                y: 0,
-                z: 0
-              }
-            }
-          }
-          if (bot.supportFeature('spawnRespawnWorldDataField')) {
-            respawnPacket = {
-              worldState: respawnPacket
-            }
-            respawnPacket.worldState.name = loginPacket.worldName
-            respawnPacket.worldState.dimension = loginPacket.dimension
-          }
-        } else {
-          respawnPacket = {
-            dimension: 0,
-            hashedSeed: [0, 0],
-            gamemode: 0,
-            levelType: 'default'
-          }
-        }
+        const respawnPacket = bot.test.generateRespawnPacket()
         const chunk = bot.test.buildChunk()
         chunk.setBlockType(pos, goldId)
         const chunkPacket = generateChunkPacket(chunk)
@@ -1476,6 +1481,50 @@ for (const supportedVersion of mineflayer.testedVersions) {
             const items = emptyItems(chestData.slots)
             items[chestSlot] = Item.toNotch(new Item(stoneId, 5))
             client.write('window_items', windowItemsPacket(1, items))
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
+        })
+      })
+
+      it('drops the open window on a re-login without telling the server', (done) => {
+        // Vanilla sends no close_window for the window open before a re-login
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.on('close_window', () => {
+            done(new Error('close_window was sent to the new server'))
+          })
+
+          bot.once('windowOpen', (window) => {
+            bot.once('windowClose', (closed) => {
+              assert.strictEqual(closed, window)
+              assert.strictEqual(bot.currentWindow, null)
+              setTimeout(done, 100)
+            })
+            client.write('login', bot.test.generateLoginPacket())
+          })
+
+          client.write('open_window', openWindowPacket(1, chestData))
+          client.write('window_items', windowItemsPacket(1, emptyItems(chestData.slots)))
+        })
+      })
+
+      it('closes the open window on respawn like vanilla', (done) => {
+        // Vanilla sends close_window for the open window before handling a respawn
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+
+          bot.once('windowOpen', (window) => {
+            let closed = null
+            bot.once('windowClose', (w) => { closed = w })
+            client.once('close_window', (packet) => {
+              assert.strictEqual(packet.windowId, window.id)
+              assert.strictEqual(closed, window)
+              assert.strictEqual(bot.currentWindow, null)
+              done()
+            })
+            client.write('respawn', bot.test.generateRespawnPacket())
           })
 
           client.write('open_window', openWindowPacket(1, chestData))


### PR DESCRIPTION
Invariants of a window across close, re-login and respawn:

- Each window keeps the stateId of the last `window_items` or `set_slot` applied to it. A `window_click` carries the stateId of the window it clicks; a window never synced sends -1. A packet routed to the player inventory updates the player inventory's id, never an open container's. `_syncWindow` still sends -1 on purpose. Vanilla: `AbstractContainerMenu` holds its own `stateId`; `ClientPacketListener.handleContainerContent` / `handleContainerSetSlot` apply containerId 0 to `player.inventoryMenu` and anything else to the open `containerMenu`; `MultiPlayerGameMode.handleInventoryMouseClick` sends the clicked menu's `getStateId()`.
- On `respawn` with a window open, a `close_window` with that window's id goes to the server, its player-inventory region is copied into `bot.inventory`, `bot.currentWindow` is null and `windowClose` fires. Vanilla: `ClientPacketListener.handleRespawn` calls `closeContainer()` on the old player before replacing it.
- A re-login (proxy server switch) drops the window with no packet and `windowClose` fires. Vanilla: `handleConfigurationStart` → `Minecraft.clearClientLevel` sends nothing, and the server receiving the login has no window open.
- Per-window stateIds, `lastClosedWindow` and buffered `window_items` are cleared when a window closes and on every `login` and `respawn`; the window id counter restarts with the player.
- `closeWindow(null)` resolves without a `close_window`, a `windowClose` or the inventory sync click. `bot.currentWindow` is null whenever the window closed on its own between a caller's check and the call, so `bot.closeWindow(bot.currentWindow)` no longer races into `TypeError: Cannot read properties of null (reading 'id')`. `index.d.ts` takes `Window | null`; api.md notes the no-op and the `windowClose` on re-login and respawn.

Internal tests, every tested version:

- `clicks carry the stateId of the window they click, not the last one synced`: a container syncs with stateId 5, a player-inventory `set_slot` with stateId 9 arrives while it is open, the click on the container carries 5 and a later click on the player inventory carries 9. Fails on master.
- `closes the open window on respawn like vanilla`: the server receives `close_window` with the window's id, `windowClose` fired with that window, `bot.currentWindow` is null. Fails on master.
- `drops the open window on a re-login without telling the server`: `windowClose` fires, `bot.currentWindow` is null, the server receives no `close_window`. Passes on master.
- `closeWindow(null) resolves without sending close_window or emitting windowClose`: fails on master with the TypeError above.
- `switchWorld respawn` builds its packet through the new shared `bot.test.generateRespawnPacket()`.

Carries the commits of #4072 and #4106, which touched the same listeners and conflicted with this branch. Reported in u9g/bot-harness#29 and #77.
