### PR TITLE
Accept play-phase resource packs when no resourcePack listener answers them

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1248,6 +1248,8 @@ Emitted when the server changes any of the game properties.
 
 Emitted when the server sends a resource pack.
 
+The pack is accepted automatically when nobody listens to this event, or when it arrives during the configuration phase (a proxy server transfer), which the server holds open until the pack is answered. With a listener attached, a play-phase pack waits for `bot.acceptResourcePack()` or `bot.denyResourcePack()`.
+
 #### "title" (title, type)
 
 Emitted when the server sends a title

--- a/lib/plugins/resource_pack.js
+++ b/lib/plugins/resource_pack.js
@@ -17,9 +17,7 @@ function inject (bot) {
     activeResourcePacks[data.uuid] = data.url
 
     bot.emit('resourcePack', data.url, data.uuid)
-    // The server holds the configuration phase (e.g. a Velocity server transfer)
-    // open until the pack is answered, so accept it there to let it complete
-    if (bot._client.state === 'configuration') acceptResourcePack()
+    autoAcceptResourcePack()
   })
 
   bot._client.on('remove_resource_pack', (data) => { // Doesn't emit  anything because it is removing rather than adding
@@ -44,10 +42,18 @@ function inject (bot) {
       bot.emit('resourcePack', data.url, data.hash)
       latestHash = data.hash
     }
-    // Accept during the configuration phase (e.g. a Velocity server transfer),
-    // which the server holds open until the pack is answered
-    if (bot._client.state === 'configuration') acceptResourcePack()
+    autoAcceptResourcePack()
   })
+
+  // A pack must be answered: the server holds the configuration phase (e.g. a Velocity
+  // transfer) open until it is, and proxies that move players through a play-phase pack
+  // drop an unanswered connection. Play-phase packs are left to a resourcePack listener
+  // when one exists so it can still deny.
+  function autoAcceptResourcePack () {
+    if (bot._client.state === 'configuration' || bot.listenerCount('resourcePack') === 0) {
+      acceptResourcePack()
+    }
+  }
 
   function acceptResourcePack () {
     if (bot.supportFeature('resourcePackUsesHash')) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -533,6 +533,38 @@ for (const supportedVersion of mineflayer.testedVersions) {
         assert(buf.includes(expectedBytes),
           'resource_pack_receive must carry the pack UUID bytes, not a zero UUID')
       })
+
+      // Some proxies move players through a play-phase pack request and drop the
+      // connection when it goes unanswered.
+      function playPhasePack (withListener) {
+        // The mock server never sends a pack, so the plugin is driven directly.
+        const client = new EventEmitter()
+        client.state = 'play'
+        const writes = []
+        client.write = (name, params) => { writes.push({ name, params }) }
+        const fakeBot = new EventEmitter()
+        fakeBot._client = client
+        fakeBot.supportFeature = registry.supportFeature.bind(registry)
+        require('../lib/plugins/resource_pack')(fakeBot)
+        if (withListener) fakeBot.on('resourcePack', () => {})
+
+        const pack = { url: 'https://example.invalid/pack.zip', hash: '88b406352dc8a335b1050a4bf9577a878c812012', forced: false }
+        if (registry.supportFeature('resourcePackUsesUUID')) {
+          client.emit('add_resource_pack', { uuid: '8ef4746b-93b7-3c32-9dcb-b375016c114d', ...pack })
+        } else {
+          client.emit('resource_pack_send', pack)
+        }
+        return writes.filter((w) => w.name === 'resource_pack_receive').map((w) => w.params.result)
+      }
+
+      it('accepts a play-phase resource pack when nobody listens for it', () => {
+        // ACCEPTED then SUCCESSFULLY_LOADED
+        assert.deepStrictEqual(playPhasePack(false), [3, 0])
+      })
+
+      it('leaves a play-phase resource pack to the resourcePack listener', () => {
+        assert.deepStrictEqual(playPhasePack(true), [])
+      })
     })
 
     describe('world', () => {


### PR DESCRIPTION
Resource packs were only auto-accepted in the configuration phase (#4005). A pack sent in the play phase just emitted `resourcePack` and waited for the caller. Some proxies (Jartex on 1.21.4, for one) move players between backends through a play-phase pack request and drop the connection about 20 seconds later when nothing answers it: `end socketClosed`, no kick. Vanilla players see the prompt and accept.

Both pack handlers now go through one `autoAcceptResourcePack`: accept in the configuration phase (unchanged), and in play when no `resourcePack` listener exists. With a listener attached, a play-phase pack still waits for `bot.acceptResourcePack()` or `bot.denyResourcePack()`, so code that denies packs keeps working and is not answered twice.

Tests: `accepts a play-phase resource pack when nobody listens for it` and `leaves a play-phase resource pack to the resourcePack listener`; the first fails on master on every tested version. Docs updated for the `resourcePack` event.

Reported in u9g/bot-harness#65.

The tests drive a real bot against the mock server, which is how two further bugs turned up: `denyResourcePack()` wrote a packet without the version's `hash`/`uuid` field (a serialization error instead of a deny on 1.8/1.9, a stray second reply on 1.20.3+), and `resource_pack_send` recorded the hash/uuid only after emitting `resourcePack`, so a listener answering inside the emit sent an empty one. Accept and deny now share one `answerResourcePack(result)`.
