### PR TITLE
fix: drop the deferred respawn reply when a newer teleport arrives

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -98,6 +98,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function cleanup () {
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
+    cancelRespawnReply()
   }
 
   function sendPacketPosition (position, onGround) {
@@ -372,6 +373,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   // player position and look (clientbound)
   bot._client.on('position', (packet) => {
+    // A newer teleport supersedes the one a deferred reply would answer.
+    cancelRespawnReply()
     // Is this necessary? Feels like it might wrongly overwrite hitbox size sometimes
     // e.g. when crouching/crawling/swimming. Can someone confirm?
     bot.entity.height = 1.8
@@ -432,7 +435,8 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
       const delayedYaw = newYaw
       const delayedPitch = newPitch
       const delayedOnGround = bot.entity.onGround
-      setTimeout(() => {
+      respawnReply = setTimeout(() => {
+        respawnReply = null
         sendPacketPositionAndLook(delayedPos, delayedYaw, delayedPitch, delayedOnGround)
         shouldUsePhysics = true
         bot.jumpTicks = 0
@@ -476,6 +480,12 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   }
 
   let respawnTimer = 0
+  // The deferred reply to a respawn teleport; the server only accepts a reply to its latest teleport.
+  let respawnReply = null
+  function cancelRespawnReply () {
+    clearTimeout(respawnReply)
+    respawnReply = null
+  }
   bot.on('mount', () => { shouldUsePhysics = false })
   bot.on('death', () => {
     shouldUsePhysics = false

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -398,6 +398,50 @@ for (const supportedVersion of mineflayer.testedVersions) {
           done()
         })
       })
+      it('answers only the latest teleport when a second one lands inside the respawn reply delay', (done) => {
+        // After a death the reply to the next teleport waits 1.5 s. A teleport that arrives inside
+        // that window replaces it: the deferred reply must not go out with the older coordinates.
+        const teleport = (teleportId, x, y, z) => ({
+          x,
+          y,
+          z,
+          dx: 0,
+          dy: 0,
+          dz: 0,
+          pitch: 0,
+          yaw: 0,
+          flags: bot.registry.version['>=']('1.21.3') ? {} : 0,
+          teleportId
+        })
+        server.on('playerJoin', async (client) => {
+          try {
+            await client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(pos, goldId)
+            await client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            const replies = []
+            client.on('packet', (data, meta) => {
+              if (meta.name === 'position_look') replies.push([data.x, data.y, data.z])
+            })
+            await client.write('position', teleport(0, 1.5, 80, 1.5))
+            while (replies.length === 0) await once(client, 'packet')
+            replies.length = 0
+
+            bot.emit('death')
+            await client.write('position', teleport(1, 3.5, 80, 3.5))
+            await sleep(100)
+            await client.write('position', teleport(2, 1.5, 66, 1.5))
+            // Outlive the 1.5 s reply delay.
+            await sleep(1700)
+
+            assert.deepStrictEqual(replies, [[1.5, 66, 1.5]], `teleport replies: ${JSON.stringify(replies)}`)
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
       it('gravity + land on solid block + jump', (done) => {
         let y = 80
         let landed = false


### PR DESCRIPTION
Invariants of the respawn teleport reply:

- After a death, the reply to the next teleport is deferred by 1.5 s (unchanged).
- A clientbound `position` packet cancels a pending deferred reply before it is handled; the newer teleport is answered on its own path.
- At most one deferred reply is pending at a time, and none after `end`.

The server holds only its latest teleport, so a deferred reply with the earlier coordinates is a move away from where the server placed the player. `bot.entity` never held those coordinates at that point either: the timer sent the packet without updating the entity.

Test (`physics › answers only the latest teleport when a second one lands inside the respawn reply delay`): death, teleport A, teleport B 100 ms later, wait 1.7 s; the server receives exactly one `position_look`, with B's coordinates. Fails on master (A's reply arrives after B's) on every tested version; passes with the change. Internal suite green on all 28 tested versions.

Overlaps PrismarineJS/mineflayer#4099, which introduces the same `respawnReply` handle for the configuration-state case; the rebase is mechanical whichever lands first.