### PR TITLE
closeWindow(null) is a no-op instead of throwing

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2196,7 +2196,7 @@ Put the item at `slot` in the inventory.
 
 This function returns a `Promise`, with `void` as its argument once the server has acknowledged the close.
 
-Close the `window`. On 1.16.5 and below the server only learns which inventory slots the window changed on its next tick, so await this before anything else (a command, another player) touches those slots.
+Close the `window`. On 1.16.5 and below the server only learns which inventory slots the window changed on its next tick, so await this before anything else (a command, another player) touches those slots. A `null` window (`bot.currentWindow` after the window closed on its own) is a no-op.
 
 #### bot.transfer(options)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -408,7 +408,7 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   putAway: (slot: number) => Promise<void>
 
-  closeWindow: (window: Window) => Promise<void>
+  closeWindow: (window: Window | null) => Promise<void>
 
   transfer: (options: TransferOptions) => Promise<void>
 

--- a/lib/plugins/inventory.js
+++ b/lib/plugins/inventory.js
@@ -431,6 +431,8 @@ function inject (bot, { hideErrors }) {
   // never sent. A rejected click already carries the full inventory, so the
   // sync click's outcome is not an error.
   function closeWindow (window) {
+    // Callers pass bot.currentWindow, which is null once the window has closed itself.
+    if (!window) return Promise.resolve()
     bot._client.write('close_window', {
       windowId: window.id
     })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -648,6 +648,30 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('closeWindow(null) resolves without sending close_window or emitting windowClose', (done) => {
+        server.on('playerJoin', (client) => {
+          const sent = []
+          client.on('packet', (data, meta) => {
+            if (meta.name === 'close_window' || meta.name === 'window_click') sent.push(meta.name)
+          })
+          let closes = 0
+          bot.on('windowClose', () => closes++)
+          const loggedIn = once(bot, 'login')
+          client.write('login', bot.test.generateLoginPacket())
+          loggedIn
+            .then(() => {
+              assert.strictEqual(bot.currentWindow, null)
+              return bot.closeWindow(bot.currentWindow)
+            })
+            .then(() => sleep(100))
+            .then(() => {
+              assert.deepStrictEqual(sent, [])
+              assert.strictEqual(closes, 0)
+            })
+            .then(done, done)
+        })
+      })
+
       it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
         server.on('playerJoin', (client) => {
           const clicks = []


### PR DESCRIPTION
\`bot.closeWindow(bot.currentWindow)\` is the usual way to close whatever is open, and \`bot.currentWindow\` is null whenever the window closed on its own between the check and the call. \`closeWindow\` read \`window.id\` first, so that raced into:

\`\`\`
TypeError: Cannot read properties of null (reading 'id')
    at EventEmitter.closeWindow (mineflayer/lib/plugins/inventory.js:485:24)
\`\`\`

A null window now resolves immediately: no \`close_window\` packet, no \`windowClose\` event, no inventory sync click. Closing a real window is unchanged. The typing accepts \`Window | null\` to match \`bot.currentWindow\`, and the doc notes the no-op.

Test: \`closeWindow(null) resolves without sending close_window or emitting windowClose\` in the internal suite, which fails with the TypeError above on master.

Reported in u9g/bot-harness#29.