### PR TITLE
fix: answer pings and teleports at the start of the next tick, in arrival order

### DIFF
--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -139,10 +139,37 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
 
-  // mimic the vanilla 1.17 client to prevent anticheat kicks
+  // Pongs are written in ping order; each ping is answered exactly once.
+  // In the play state a pong is written only at the start of a physics tick,
+  // before every packet of that tick, or by the one-tick fallback timer.
+  // Outside the play state the pong is written immediately.
+  const pendingPongs = []
+  let pongTimer = null
+
+  function flushPongs () {
+    clearTimeout(pongTimer)
+    pongTimer = null
+    while (pendingPongs.length > 0) {
+      bot._client.write('pong', { id: pendingPongs.shift() })
+    }
+  }
+
   bot._client.on('ping', (data) => {
-    bot._client.write('pong', {
-      id: data.id
-    })
+    if (bot._client.state !== 'play') {
+      bot._client.write('pong', { id: data.id })
+      return
+    }
+    pendingPongs.push(data.id)
+    // A queued pong waits at most one tick (50 ms) for a physics tick.
+    if (pongTimer === null) pongTimer = setTimeout(flushPongs, 50)
+  })
+
+  // Must run before every other physicsTick listener.
+  bot.prependListener('physicsTick', flushPongs)
+
+  bot.on('end', () => {
+    clearTimeout(pongTimer)
+    pongTimer = null
+    pendingPongs.length = 0
   })
 }

--- a/lib/plugins/game.js
+++ b/lib/plugins/game.js
@@ -139,37 +139,14 @@ function inject (bot, options) {
     bot.game.serverBrand = serverBrand
   })
 
-  // Pongs are written in ping order; each ping is answered exactly once.
-  // In the play state a pong is written only at the start of a physics tick,
-  // before every packet of that tick, or by the one-tick fallback timer.
-  // Outside the play state the pong is written immediately.
-  const pendingPongs = []
-  let pongTimer = null
-
-  function flushPongs () {
-    clearTimeout(pongTimer)
-    pongTimer = null
-    while (pendingPongs.length > 0) {
-      bot._client.write('pong', { id: pendingPongs.shift() })
-    }
-  }
-
+  // Each ping is answered exactly once. In the play state the vanilla client answers from the
+  // client thread, which handles every packet in arrival order at the start of the next tick
+  // (before that tick's movement packet), so the pong joins the physics plugin's reply queue and
+  // keeps its place relative to the teleports around it. Outside the play state, or without the
+  // physics plugin, the pong is written immediately.
   bot._client.on('ping', (data) => {
-    if (bot._client.state !== 'play') {
-      bot._client.write('pong', { id: data.id })
-      return
-    }
-    pendingPongs.push(data.id)
-    // A queued pong waits at most one tick (50 ms) for a physics tick.
-    if (pongTimer === null) pongTimer = setTimeout(flushPongs, 50)
-  })
-
-  // Must run before every other physicsTick listener.
-  bot.prependListener('physicsTick', flushPongs)
-
-  bot.on('end', () => {
-    clearTimeout(pongTimer)
-    pongTimer = null
-    pendingPongs.length = 0
+    const pong = () => bot._client.write('pong', { id: data.id })
+    if (bot._client.state === 'play' && bot._replyOnNextTick) bot._replyOnNextTick(pong)
+    else pong()
   })
 }

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -491,6 +491,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot.on('respawn', () => { shouldUsePhysics = false })
   bot.on('login', () => {
     shouldUsePhysics = false
+    // A teleport still queued here belongs to the world the bot just left, and its id means nothing
+    // to the server it is about to talk to.
+    pendingTeleports.length = 0
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = performance.now()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -78,6 +78,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   function tickPhysics (now) {
     if (bot._client.state !== 'play') return // do nothing outside of the play state (e.g. server transfer configuration phase)
+    while (pendingTeleports.length) handleTeleport(pendingTeleports.shift())
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -371,7 +372,13 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   })
 
   // player position and look (clientbound)
-  bot._client.on('position', (packet) => {
+  // The vanilla client hands every play packet to the client thread, which drains the queue at the
+  // start of a tick (PacketUtils.ensureRunningOnSameThread), so a teleport is answered at most once
+  // per tick however fast the server sends them.
+  const pendingTeleports = []
+  bot._client.on('position', (packet) => { pendingTeleports.push(packet) })
+
+  function handleTeleport (packet) {
     // Is this necessary? Feels like it might wrongly overwrite hitbox size sometimes
     // e.g. when crouching/crawling/swimming. Can someone confirm?
     bot.entity.height = 1.8
@@ -451,7 +458,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
     lastSentPitch = bot.entity.pitch
 
     bot.emit('forcedMove')
-  })
+  }
 
   bot.waitForTicks = async function (ticks) {
     if (ticks <= 0) return

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -78,7 +78,7 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   function tickPhysics (now) {
     if (bot._client.state !== 'play') return // do nothing outside of the play state (e.g. server transfer configuration phase)
-    while (pendingTeleports.length) handleTeleport(pendingTeleports.shift())
+    flushReplies()
     if (!bot.entity?.position || !Number.isFinite(bot.entity.position.x)) return // entity not ready
     if (bot.blockAt(bot.entity.position) == null) return // check if chunk is unloaded
     if (bot.physicsEnabled && shouldUsePhysics) {
@@ -99,6 +99,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   function cleanup () {
     clearInterval(doPhysicsTimer)
     doPhysicsTimer = null
+    clearTimeout(replyTimer)
+    replyTimer = null
+    pendingReplies.length = 0
   }
 
   function sendPacketPosition (position, onGround) {
@@ -373,10 +376,25 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   // player position and look (clientbound)
   // The vanilla client hands every play packet to the client thread, which drains the queue at the
-  // start of a tick (PacketUtils.ensureRunningOnSameThread), so a teleport is answered at most once
-  // per tick however fast the server sends them.
-  const pendingTeleports = []
-  bot._client.on('position', (packet) => { pendingTeleports.push(packet) })
+  // start of a tick (PacketUtils.ensureRunningOnSameThread) and writes each reply as the packet is
+  // handled. So a teleport is answered at most once per tick however fast the server sends them,
+  // and replies to different packets (a pong, a teleport confirm) leave in packet arrival order.
+  const pendingReplies = []
+  let replyTimer = null
+
+  function flushReplies () {
+    clearTimeout(replyTimer)
+    replyTimer = null
+    if (bot._client.state !== 'play') return
+    while (pendingReplies.length) pendingReplies.shift()()
+  }
+
+  bot._replyOnNextTick = (reply) => {
+    pendingReplies.push(reply)
+    // While no tick is running (the login packet starts it) a reply waits at most one tick.
+    if (doPhysicsTimer === null && replyTimer === null) replyTimer = setTimeout(flushReplies, PHYSICS_INTERVAL_MS)
+  }
+  bot._client.on('position', (packet) => { bot._replyOnNextTick(() => handleTeleport(packet)) })
 
   function handleTeleport (packet) {
     // Is this necessary? Feels like it might wrongly overwrite hitbox size sometimes
@@ -491,9 +509,9 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
   bot.on('respawn', () => { shouldUsePhysics = false })
   bot.on('login', () => {
     shouldUsePhysics = false
-    // A teleport still queued here belongs to the world the bot just left, and its id means nothing
+    // A reply still queued here belongs to the world the bot just left, and its id means nothing
     // to the server it is about to talk to.
-    pendingTeleports.length = 0
+    pendingReplies.length = 0
     if (doPhysicsTimer === null) {
       lastPhysicsFrameTime = performance.now()
       doPhysicsTimer = setInterval(doPhysics, PHYSICS_INTERVAL_MS)

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -342,60 +342,69 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
       it('absolute position & relative position (velocity)', (done) => {
+        // The teleport is applied inside a physics tick, so the state it produces has to be read when
+        // forcedMove fires; awaiting the event resumes after that tick's simulation has run on top.
+        const onForcedMove = () => new Promise(resolve => {
+          bot.once('forcedMove', () => resolve({ velocity: bot.entity.velocity.clone(), position: bot.entity.position.clone() }))
+        })
         server.on('playerJoin', async (client) => {
-          await client.write('login', bot.test.generateLoginPacket())
-          const chunk = bot.test.buildChunk()
-          chunk.setBlockType(pos, goldId)
-          await client.write('map_chunk', generateChunkPacket(chunk))
+          try {
+            await client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(pos, goldId)
+            await client.write('map_chunk', generateChunkPacket(chunk))
 
-          await once(bot, 'chunkColumnLoad')
+            await once(bot, 'chunkColumnLoad')
 
-          // --- Test 1: Absolute Position ---
-          const absolutePositionPacket = {
-            x: 1.5,
-            y: 80,
-            z: 1.5,
-            pitch: 0,
-            yaw: 0,
-            teleportId: 1,
-            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+            // --- Test 1: Absolute Position ---
+            const absolutePositionPacket = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              pitch: 0,
+              yaw: 0,
+              teleportId: 1,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0
+            }
+
+            bot.entity.velocity.y = -1.0 // Give bot some velocity
+
+            const p1 = onForcedMove()
+            client.write('position', absolutePositionPacket)
+            const afterAbsolute = await p1
+
+            // Assertions for absolute teleport
+            assert.strictEqual(afterAbsolute.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
+            assert.deepStrictEqual(afterAbsolute.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
+
+            // --- Test 2: Relative Position ---
+            const relativePositionPacket = {
+              x: 1.0,
+              y: -2.0,
+              z: 0.5,
+              pitch: 0,
+              yaw: 0,
+              teleportId: 2,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: true, y: true, z: true, yaw: false, pitch: false } : 7
+            }
+
+            // Set a known velocity *before* the relative update
+            bot.entity.velocity.y = -1.0
+            const initialPosition = bot.entity.position.clone()
+            const expectedPosition = initialPosition.plus(vec3(1.0, -2.0, 0.5))
+
+            const p2 = onForcedMove()
+            client.write('position', relativePositionPacket)
+            const afterRelative = await p2
+
+            // Assertions for relative teleport
+            assert.notStrictEqual(afterRelative.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
+            assert.deepStrictEqual(afterRelative.position, expectedPosition, 'Position should be updated relatively')
+
+            done()
+          } catch (err) {
+            done(err)
           }
-
-          bot.entity.velocity.y = -1.0 // Give bot some velocity
-
-          const p1 = once(bot, 'forcedMove')
-          client.write('position', absolutePositionPacket)
-          await p1
-
-          // Assertions for absolute teleport
-          assert.strictEqual(bot.entity.velocity.y, 0, 'Velocity should be reset to 0 after an absolute teleport')
-          assert.deepStrictEqual(bot.entity.position, vec3(1.5, 80, 1.5), 'Position should be set absolutely')
-
-          // --- Test 2: Relative Position ---
-          const relativePositionPacket = {
-            x: 1.0,
-            y: -2.0,
-            z: 0.5,
-            pitch: 0,
-            yaw: 0,
-            teleportId: 2,
-            flags: bot.supportFeature('positionPacketHasBitflags') ? { x: true, y: true, z: true, yaw: false, pitch: false } : 7
-          }
-
-          // Set a known velocity *before* the relative update
-          bot.entity.velocity.y = -1.0
-          const initialPosition = bot.entity.position.clone()
-          const expectedPosition = initialPosition.plus(vec3(1.0, -2.0, 0.5))
-
-          const p2 = once(bot, 'forcedMove')
-          client.write('position', relativePositionPacket)
-          await p2
-
-          // Assertions for relative teleport
-          assert.notStrictEqual(bot.entity.velocity.y, 0, 'Velocity should be preserved after a relative teleport')
-          assert.deepStrictEqual(bot.entity.position, expectedPosition, 'Position should be updated relatively')
-
-          done()
         })
       })
       it('gravity + land on solid block + jump', (done) => {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -613,6 +613,95 @@ for (const supportedVersion of mineflayer.testedVersions) {
         })
       })
 
+      it('pong is written at the next tick boundary, after the movement packet of the tick that received the ping', function (done) {
+        if (bot.supportFeature('transactionPacketExists')) {
+          this.skip()
+          return
+        }
+        const movementPackets = ['position', 'position_look', 'look', 'flying']
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), 41)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            client.write('position', {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            })
+            await once(bot, 'forcedMove')
+
+            // Falling takes a few ticks to leave the teleport height.
+            await bot.waitForTicks(4)
+
+            const seen = []
+            client.on('packet', (data, meta) => seen.push({ name: meta.name, data }))
+
+            // The ping is processed inside a tick: after the simulation, before
+            // the movement packet carrying this tick's position.
+            const { tickY, pingedAt } = await new Promise(resolve => {
+              bot.once('physicsTick', () => {
+                bot._client.emit('ping', { id: 123 })
+                resolve({ tickY: bot.entity.position.y, pingedAt: Date.now() })
+              })
+            })
+            assert.ok(tickY < 80, 'bot must be falling so every tick writes a movement packet')
+
+            const [pong] = await onceWithCleanup(client, 'pong', { timeout: 200 })
+            const pongedAt = Date.now()
+            assert.strictEqual(pong.id, 123)
+            assert.ok(pongedAt - pingedAt <= 200, `pong took ${pongedAt - pingedAt} ms`)
+
+            await sleep(100)
+            const pongs = seen.filter(p => p.name === 'pong')
+            assert.strictEqual(pongs.length, 1, 'each ping is answered exactly once')
+            const pongIndex = seen.indexOf(pongs[0])
+            const before = seen[pongIndex - 1]
+            assert.ok(before !== undefined, 'a movement packet precedes the pong')
+            assert.ok(movementPackets.includes(before.name), `packet before pong is ${before.name}`)
+            assert.strictEqual(before.data.y, tickY, 'the pong follows the movement packet of the tick that received the ping')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
+      it('pong is written within one tick when physics is not ticking', function (done) {
+        if (bot.supportFeature('transactionPacketExists')) {
+          this.skip()
+          return
+        }
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            await once(bot, 'login')
+            const pongs = []
+            client.on('pong', (data) => pongs.push(data))
+            const pingedAt = Date.now()
+            client.write('ping', { id: 123 })
+            const [pong] = await onceWithCleanup(client, 'pong', { timeout: 200 })
+            const pongedAt = Date.now()
+            assert.strictEqual(pong.id, 123)
+            assert.ok(pongedAt - pingedAt <= 200, `pong took ${pongedAt - pingedAt} ms`)
+            await sleep(100)
+            assert.strictEqual(pongs.length, 1, 'each ping is answered exactly once')
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+
       it('closeWindow follows close_window with a no-op inventory click on pre-1.17 only', (done) => {
         server.on('playerJoin', (client) => {
           const clicks = []

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1527,6 +1527,51 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('teleports', () => {
+      it('answers a teleport at the next tick instead of from inside the packet handler', (done) => {
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), registry.blocksByName.stone.id)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            const teleport = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            }
+            client.write('position', teleport)
+            await once(bot, 'forcedMove')
+
+            const writes = []
+            const write = bot._client.write.bind(bot._client)
+            bot._client.write = (name, params) => { writes.push(name); return write(name, params) }
+            try {
+              await new Promise(resolve => bot.once('physicsTick', resolve))
+              writes.length = 0
+              bot._client.emit('position', { ...teleport, y: 90, teleportId: 1 })
+              assert.deepStrictEqual(writes, [], 'the teleport must not be answered from inside the packet handler')
+              await once(bot, 'forcedMove')
+              assert.ok(writes.includes('position_look'), 'the teleport is answered on the next tick')
+            } finally {
+              bot._client.write = write
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
+    })
+
     describe('onceWithCleanup', () => {
       it('rejects instead of throwing out of emit when checkCondition throws', async () => {
         // A condition that throws used to unwind whatever was emitting. For a

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1703,6 +1703,59 @@ for (const supportedVersion of mineflayer.testedVersions) {
           }
         })
       })
+
+      it('answers pings and teleports in the order the packets arrived', function (done) {
+        if (bot.supportFeature('transactionPacketExists')) {
+          this.skip()
+          return
+        }
+        server.on('playerJoin', async (client) => {
+          try {
+            client.write('login', bot.test.generateLoginPacket())
+            const chunk = bot.test.buildChunk()
+            chunk.setBlockType(vec3(1, 65, 1), registry.blocksByName.stone.id)
+            client.write('map_chunk', generateChunkPacket(chunk))
+            await once(bot, 'chunkColumnLoad')
+            const teleport = {
+              x: 1.5,
+              y: 80,
+              z: 1.5,
+              dx: 0,
+              dy: 0,
+              dz: 0,
+              pitch: 0,
+              yaw: 0,
+              flags: bot.supportFeature('positionPacketHasBitflags') ? { x: false, y: false, z: false, yaw: false, pitch: false } : 0,
+              teleportId: 0
+            }
+            client.write('position', teleport)
+            await once(bot, 'forcedMove')
+
+            const writes = []
+            const write = bot._client.write.bind(bot._client)
+            bot._client.write = (name, params) => { writes.push({ name, params }); return write(name, params) }
+            try {
+              await new Promise(resolve => bot.once('physicsTick', resolve))
+              writes.length = 0
+              // Between two ticks the server's ping, teleport and second ping arrive in that order.
+              bot._client.emit('ping', { id: 1 })
+              bot._client.emit('position', { ...teleport, y: 90, teleportId: 1 })
+              bot._client.emit('ping', { id: 2 })
+              assert.deepStrictEqual(writes, [], 'nothing is answered from inside the packet handlers')
+              await once(bot, 'forcedMove')
+              const replies = writes
+                .filter(w => ['pong', 'teleport_confirm', 'position_look'].includes(w.name))
+                .map(w => (w.name === 'pong' ? `pong ${w.params.id}` : w.name))
+              assert.deepStrictEqual(replies, ['pong 1', 'teleport_confirm', 'position_look', 'pong 2'])
+            } finally {
+              bot._client.write = write
+            }
+            done()
+          } catch (err) {
+            done(err)
+          }
+        })
+      })
     })
 
     describe('onceWithCleanup', () => {


### PR DESCRIPTION
Invariants of the replies to clientbound `ping` and `position` packets:

- In the play state a reply is written at the start of the next physics tick, before the simulation and before that tick's movement packets. Nothing is written from inside the packet handler.
- Replies go out in the order their packets arrived, through one queue: `pong` for a ping, `teleport_confirm` then `position_look` for a teleport.
- A reply queued while no tick is running (before the login packet starts the timer) is still written within one tick. Outside the play state, or without the physics plugin, `game.js` writes the pong immediately.
- Every queued teleport is answered when the tick drains the queue, ahead of the entity and chunk guards, so the first teleport of a login is answered while chunks are loading. The teleport reply carries onGround false.

Vanilla reference (u9g/mc-decompiled): `ClientCommonPacketListenerImpl.handlePing` and `ClientPacketListener.handleMovePlayer` both start with `PacketUtils.ensureRunningOnSameThread`, which puts the packet on `PacketProcessor.packetsToBeHandled`, a FIFO. `Minecraft.runTick` calls `packetProcessor.processQueuedPackets()` and `runAllTasks()` before the `tick()` loop that runs `LocalPlayer.tick` and `sendPosition`, and each handler writes its reply as it runs. 1.8.9 does the same for the teleport through `PacketThreadUtil.checkThreadAndEnqueue` and `Minecraft.runGameLoop`'s `scheduledTasks` drain (the `ping` packet only exists from 1.17).

Why it matters, measured on a BedWars server that pins players with a teleport every tick:

- Answering from the handler made the round trip network RTT instead of one tick: 923 teleports answered in 30 s, peaking at 538 in one second. Answered at the next tick: 59, peaking at 27. The anticheat kicks for the former.
  ```
  26503 <position  (0.5, 100, 0.5) id0
  26503 >teleport_confirm id0
  26503 >position_look (0.5, 100, 0.5)
  26504 <position  (0.5, 100, 0.5) id0
  26504 >teleport_confirm id0
  ...
  ```
- With separate ping and teleport queues the teleport queue drained first, so a pong for a ping that arrived before a teleport always followed the teleport reply. Transaction-ordering anticheats (Grim and friends) treat that as an out-of-order reply and kicked the bot within a minute while it stood still.

Tests in `test/internalTest.js`, each failing on master:

- `pong is written ...`: with the bot falling, the pong follows the movement packet of the tick that received the ping and is answered once; with no chunk loaded it is still answered within one tick.
- teleport: a `position` packet emitted mid-tick writes nothing from the handler; the answer goes out on the next tick.
- `answers every teleport queued for a tick, in arrival order`.
- a ping, a teleport and a second ping arriving between two ticks are answered as `pong 1, teleport_confirm, position_look, pong 2` (master and the two-queue version answer `pong 1` last).

This PR absorbs #4070 (pong at the next tick) and #4078 (teleport at the next tick); the branch carries their commits plus the shared queue. #4063 and #4108 merge cleanly with it.
