### PR TITLE
physics: a teleport leaves the standing flag alone

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -908,7 +908,7 @@ world height
 
 #### bot.physicsEnabled
 
-Enable physics, default true.
+Enable physics, default true. While it is false the position reminder still goes out every second and carries `bot.entity.onGround` as it was left: a teleport does not change it, and nothing simulates it.
 
 #### bot.player
 

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -110,6 +110,9 @@ function inject (bot) {
     bot.entity.height = PLAYER_HEIGHT
     bot.entity.width = PLAYER_WIDTH
     bot.entity.eyeHeight = PLAYER_EYEHEIGHT
+    // A player that has just been added to the world is airborne until a tick of physics
+    // says otherwise (Entity.onGround starts false); prismarine-entity defaults it to true.
+    bot.entity.onGround = false
   })
 
   bot._client.on('entity_equipment', (packet) => {

--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -417,7 +417,6 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
     bot.entity.yaw = conv.fromNotchianYaw(newYaw)
     bot.entity.pitch = conv.fromNotchianPitch(newPitch)
-    bot.entity.onGround = false
 
     if (bot.supportFeature('teleportUsesOwnPacket')) {
       bot._client.write('teleport_confirm', { teleportId: packet.teleportId })

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -432,6 +432,35 @@ for (const supportedVersion of mineflayer.testedVersions) {
           })
         })
       })
+      it('reports the standing flag it had before a teleport while physics is disabled', async function () {
+        const client = (await once(server, 'playerJoin'))[0]
+        await client.write('login', bot.test.generateLoginPacket())
+        const chunk = bot.test.buildChunk()
+        chunk.setBlockType(pos, goldId)
+        await client.write('map_chunk', generateChunkPacket(chunk))
+        await once(bot, 'chunkColumnLoad')
+        const onBlock = { x: pos.x + 0.5, y: pos.y + 1, z: pos.z + 0.5, dx: 0, dy: 0, dz: 0, pitch: 0, yaw: 0, teleportId: 1, flags: bot.supportFeature('positionPacketHasBitflags') ? {} : 0 }
+        const landed = once(bot, 'forcedMove')
+        await client.write('position', onBlock)
+        await landed
+        await bot.waitForTicks(5)
+        assert.strictEqual(bot.entity.onGround, true, 'standing on the block')
+        bot.physicsEnabled = false
+        const pinned = once(bot, 'forcedMove')
+        await client.write('position', { ...onBlock, teleportId: 2 })
+        await pinned
+        await sleep(200)
+        const grounded = []
+        const onPacket = (data, meta) => {
+          if (!['position', 'position_look', 'look', 'flying'].includes(meta.name)) return
+          grounded.push(data.onGround ?? data.flags?.onGround)
+        }
+        client.on('packet', onPacket)
+        await sleep(1300)
+        client.off('packet', onPacket)
+        assert.ok(grounded.length > 0, 'the position reminder goes out with physics disabled')
+        assert.ok(grounded.every(g => g === true), `every movement packet reports standing: ${JSON.stringify(grounded)}`)
+      })
       it('no movement packets during a server transfer configuration phase', function (done) {
         // Regression test for https://github.com/PrismarineJS/mineflayer/issues/3776
         // While the client is in the configuration phase (Velocity/BungeeCord server


### PR DESCRIPTION
Invariants:

- A clientbound `position` packet sets the bot's position, velocity and rotation and nothing else, as `ClientPacketListener.handleMovePlayer` does. Whether the bot stands is decided by the physics tick.
- The bot's own entity starts airborne on login (`Entity.onGround` starts false); prismarine-entity defaults it to true.
- With `bot.physicsEnabled = false` nothing simulates `bot.entity.onGround`, so it reads as it was last left; the position reminder still goes out every second and carries that value. `docs/api.md` states this under `bot.physicsEnabled`.

- The reply to a teleport carries `onGround: false` and no collision, whatever the standing flag holds, and leaves the last-sent record alone (the same `sendTeleportReply` as #4063).

Test (`physics › answers a teleport airborne and then reports the standing flag it had while physics is disabled`): the bot lands on a block, physics is disabled, and capture starts before the server teleports it to the same spot. Over the next 1.5 s the reply is the only movement packet with `onGround: false`, and the reminders after it carry `true`. Fails on master for all tested versions (every packet carries `false`).

These are the teleport changes from #4063, on their own.
