### PR TITLE
Read the scoreboard objective title as a chat component

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -678,7 +678,7 @@ Name of the scoreboard.
 
 #### ScoreBoard.title
 
-The title of the scoreboard (does not always equal the name)
+The title of the scoreboard as a [ChatMessage](https://github.com/PrismarineJS/prismarine-chat) (does not always equal the name). Servers send it as a chat component, so `title.toString()` for the plain text and `title.toAnsi()` to keep its colours.
 
 #### ScoreBoard.itemsMap
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -789,13 +789,13 @@ export interface VillagerTrade {
 
 export class ScoreBoard {
   name: string
-  title: string
+  title: ChatMessage
   itemsMap: { [name: string]: ScoreBoardItem }
   items: ScoreBoardItem[]
 
   constructor (packet: object);
 
-  setTitle (title: string): void;
+  setTitle (title: string | object): void;
 
   add(name: string, value: number): ScoreBoardItem;
 

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -14,12 +14,13 @@ module.exports = (bot) => {
       this.itemsMap = {}
     }
 
+    // The wire shape of a title changes with the version: a plain string before 1.13, a JSON
+    // component string up to 1.20.2, an NBT component after that. JSON.parse().text read only
+    // the first of those correctly - it dropped everything a component kept in `extra`, and on
+    // 1.20.3+ it threw on the NBT object and left the raw object as the title, so printing one
+    // gave '[object Object]'. ChatMessage reads all three.
     setTitle (title) {
-      try {
-        this.title = JSON.parse(title).text // version>1.13
-      } catch {
-        this.title = title
-      }
+      this.title = ChatMessage.fromNotch(title)
     }
 
     add (name, value) {

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1514,6 +1514,67 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('scoreboard', () => {
+      // An objective title is a plain string before 1.13, a JSON component string up to 1.20.2
+      // and an NBT component after that - and servers build it out of `extra` far more often
+      // than they put the text at the top level.
+      function objectiveTitle (parts) {
+        if (registry.supportFeature('chatPacketsUseNbtComponents')) {
+          return nbt.comp({
+            text: nbt.string(''),
+            extra: nbt.list(nbt.comp(parts.map(part => {
+              const c = { text: nbt.string(part.text) }
+              if (part.color) c.color = nbt.string(part.color)
+              return c
+            })))
+          })
+        }
+        if (registry.version['>=']('1.13')) return JSON.stringify({ text: '', extra: parts })
+        return parts.map(part => part.text).join('')
+      }
+
+      it('reads a component objective title', async () => {
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.write('scoreboard_objective', {
+            name: 'obj',
+            action: 0,
+            displayText: objectiveTitle([{ text: 'Bed', color: 'yellow' }, { text: 'Wars' }]),
+            type: 'integer'
+          })
+          client.write('scoreboard_display_objective', { position: 1, name: 'obj' })
+        })
+
+        const [, scoreboard] = await onceWithCleanup(bot, 'scoreboardPosition', { timeout: 5000 })
+        assert.strictEqual(scoreboard.title.toString(), 'BedWars')
+        assert.strictEqual(bot.scoreboard.sidebar.title.toString(), 'BedWars')
+        assert.strictEqual(bot.scoreboards.obj.title.toString(), 'BedWars')
+      })
+
+      it('reads a component title sent as an objective update', async () => {
+        server.on('playerJoin', (client) => {
+          client.write('login', bot.test.generateLoginPacket())
+          client.write('scoreboard_objective', {
+            name: 'obj',
+            action: 0,
+            displayText: objectiveTitle([{ text: 'first' }]),
+            type: 'integer'
+          })
+          setTimeout(() => {
+            client.write('scoreboard_objective', {
+              name: 'obj',
+              action: 2,
+              displayText: objectiveTitle([{ text: 'sec', color: 'red' }, { text: 'ond' }]),
+              type: 'integer'
+            })
+          }, 100)
+        })
+
+        const [scoreboard] = await onceWithCleanup(bot, 'scoreboardTitleChanged', { timeout: 5000 })
+        assert.strictEqual(scoreboard.title.toString(), 'second')
+      })
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1


### PR DESCRIPTION
`ScoreBoard.setTitle` reads the title with `JSON.parse(title).text`, which is correct for exactly
one of the three shapes a title arrives in:

| version | `displayText` on the wire | what `JSON.parse(title).text` does |
|---|---|---|
| < 1.13 | plain string | parse throws, the string is kept — fine |
| 1.13 – 1.20.2 | JSON component string | reads only the top-level `text`, **drops everything in `extra`** |
| ≥ 1.20.3 | NBT component | parse throws on the object, **the raw NBT compound becomes the title** |

Both failures are the common case rather than an edge one. A coloured sidebar title is normally
built as `{"text":"","extra":[…]}`, so on 1.13–1.20.2 `scoreboard.title` is the empty string; on
1.20.3+ printing it gives `[object Object]`.

Measured against a live 26.1 network (Jartex BedWars), sidebar objective, same payload both ways:

```
bot.scoreboard.sidebar.title                       -> [object Object]
ChatMessage.fromNotch(bot.scoreboard.sidebar.title) -> BedWars
```

and the 1.13–1.20.2 shape, `{"text":"","extra":[{"text":"Bed","color":"yellow"},{"text":"Wars"}]}`:

```
JSON.parse(title).text  -> ""
ChatMessage.fromNotch   -> BedWars
```

`ChatMessage.fromNotch` reads all three, so `setTitle` becomes one line. The class already hands
out a `ChatMessage` from `items[].displayName`, and `BossBar.title` is one too, so this is the
shape the rest of the API already uses. Same treatment #4102 gave window titles.

`examples/scoreboard.js` interpolates `${scoreboard.title}` and keeps working — that calls
`toString()`. Callers that want the colours now can have them (`title.toAnsi()`), which was not
possible before.

**Breaking**: `ScoreBoard.title` is a `ChatMessage`, not a `string`. `index.d.ts` and `docs/api.md`
updated to say so.

### Test

`test/internalTest.js` gains a `scoreboard` block that sends a title built from `extra` in the
shape each tested version actually uses — plain string, JSON component, or NBT component — once
as a new objective (`action: 0`) and once as an update (`action: 2`), and asserts the title reads
back as `BedWars` / `second` from `scoreboardPosition`, `bot.scoreboard.sidebar`, `bot.scoreboards`
and `scoreboardTitleChanged`.

Before: **10 passing, 46 failing** — the 10 are the five pre-1.13 versions, where the title is a
plain string and the old code already worked.

```
AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ '[object Object]'
- 'second'
```

After: **56 passing**, every tested version from 1.8.8 to 26.1.
