### PR TITLE
scoreboard: read the 1.20.3+ objective and score packets

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -678,7 +678,7 @@ Name of the scoreboard.
 
 #### ScoreBoard.title
 
-The title of the scoreboard (does not always equal the name)
+The title of the scoreboard (does not always equal the name), as a `ChatMessage`.
 
 #### ScoreBoard.itemsMap
 
@@ -689,6 +689,9 @@ An object with all items in the scoreboard in it
   dzikoysk: { name: 'dzikoysk', value: 6 }
 }
 ```
+
+Each item also has a `displayName` (a `ChatMessage`): the component the server sent with the score
+on 1.20.3+, otherwise the item's name formatted by its team.
 
 #### ScoreBoard.items
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -789,15 +789,15 @@ export interface VillagerTrade {
 
 export class ScoreBoard {
   name: string
-  title: string
+  title: ChatMessage
   itemsMap: { [name: string]: ScoreBoardItem }
   items: ScoreBoardItem[]
 
   constructor (packet: object);
 
-  setTitle (title: string): void;
+  setTitle (title: string | object): void;
 
-  add(name: string, value: number): ScoreBoardItem;
+  add(name: string, value: number, display?: string | object): ScoreBoardItem;
 
   remove (name: string): ScoreBoardItem;
 }

--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -38,26 +38,35 @@ function inject (bot) {
     }
   })
 
+  function removeScore (scoreboard, itemName) {
+    if (scoreboard !== undefined) {
+      if (!(itemName in scoreboard.itemsMap)) return
+      const removed = scoreboard.remove(itemName)
+      return bot.emit('scoreRemoved', scoreboard, removed)
+    }
+
+    // No objective named: the score is dropped from every objective that holds it.
+    for (const sb of Object.values(scoreboards)) {
+      if (itemName in sb.itemsMap) {
+        const removed = sb.remove(itemName)
+        bot.emit('scoreRemoved', sb, removed)
+      }
+    }
+  }
+
   bot._client.on('scoreboard_score', (packet) => {
     const scoreboard = scoreboards[packet.scoreName]
-    if (scoreboard !== undefined && packet.action === 0) {
-      const updated = scoreboard.add(packet.itemName, packet.value)
-      bot.emit('scoreUpdated', scoreboard, updated)
-    }
+    // 1.20.3 dropped the action field: the packet only ever sets a score, and a removal arrives as
+    // reset_score. Before that, action 1 meant the score was removed and carried no value.
+    if (packet.action === 1) return removeScore(scoreboard, packet.itemName)
+    if (scoreboard === undefined) return
+    const updated = scoreboard.add(packet.itemName, packet.value, packet.display_name)
+    bot.emit('scoreUpdated', scoreboard, updated)
+  })
 
-    if (packet.action === 1) {
-      if (scoreboard !== undefined) {
-        const removed = scoreboard.remove(packet.itemName)
-        return bot.emit('scoreRemoved', scoreboard, removed)
-      }
-
-      for (const sb of Object.values(scoreboards)) {
-        if (packet.itemName in sb.itemsMap) {
-          const removed = sb.remove(packet.itemName)
-          return bot.emit('scoreRemoved', sb, removed)
-        }
-      }
-    }
+  // 1.20.3+. An absent objective name means every objective.
+  bot._client.on('reset_score', (packet) => {
+    removeScore(packet.objective_name == null ? undefined : scoreboards[packet.objective_name], packet.entity_name)
   })
 
   bot._client.on('scoreboard_display_objective', (packet) => {

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -14,20 +14,22 @@ module.exports = (bot) => {
       this.itemsMap = {}
     }
 
+    // The objective's title is a plain string on 1.8, a JSON component from 1.13 and an NBT
+    // component from 1.20.3; only the middle one used to survive, and only its top-level text.
     setTitle (title) {
-      try {
-        this.title = JSON.parse(title).text // version>1.13
-      } catch {
-        this.title = title
-      }
+      this.title = ChatMessage.fromNotch(title)
     }
 
-    add (name, value) {
-      this.itemsMap[name] = { name, value }
+    add (name, value, display) {
+      // 1.20.3+ may send the component to draw in place of the entry's own name.
+      const displayed = display == null ? null : ChatMessage.fromNotch(display)
       this.itemsMap[name] = {
         name,
         value,
         get displayName () {
+          if (displayed !== null) {
+            return displayed
+          }
           if (name in bot.teamMap) {
             return bot.teamMap[name].displayName(name)
           }

--- a/test/internalTest.js
+++ b/test/internalTest.js
@@ -1514,6 +1514,105 @@ for (const supportedVersion of mineflayer.testedVersions) {
       })
     })
 
+    describe('scoreboard', () => {
+      // 1.20.3 dropped the action field from the score packet and moved removal to reset_score.
+      const objectiveFields = registry.protocol?.play?.toClient?.types?.packet_scoreboard_objective?.[1] ?? []
+      const scoreHasAction = (registry.protocol?.play?.toClient?.types?.packet_scoreboard_score?.[1] ?? [])
+        .some(field => field.name === 'action')
+      // 1.8 to 1.12 name the objective's render type; later versions send its index.
+      const objectiveType = objectiveFields.find(f => f.name === 'type')?.type?.[1]?.fields?.[0] === 'string' ? 'integer' : 0
+
+      const addObjective = (client, name, title) => client.write('scoreboard_objective', {
+        name, action: 0, displayText: chatText(title), type: objectiveType
+      })
+      const setScore = (client, objective, entity, value, display) => client.write('scoreboard_score', scoreHasAction
+        ? { itemName: entity, action: 0, scoreName: objective, value }
+        : { itemName: entity, scoreName: objective, value, display_name: display })
+
+      // Every packet the server sends on join lands in one batch, so the events they raise are all
+      // emitted before the first await returns; each test collects them instead of awaiting in turn.
+      function collect (...events) {
+        const seen = []
+        for (const name of events) bot.on(name, (...args) => seen.push([name, ...args]))
+        return seen
+      }
+      // Resolves once the bot has joined and the packets written for it have been handled.
+      function onJoin (write) {
+        return new Promise(resolve => {
+          server.on('playerJoin', (client) => {
+            write(client)
+            sleep(100).then(resolve)
+          })
+        })
+      }
+
+      it('reads the objective title, whatever shape the version sends it in', async () => {
+        const seen = collect('scoreboardCreated', 'scoreboardPosition')
+        await onJoin((client) => {
+          addObjective(client, 'kills', 'Total Kills')
+          client.write('scoreboard_display_objective', { position: 1, name: 'kills' })
+        })
+        const created = seen.find(e => e[0] === 'scoreboardCreated')
+        assert.ok(created, 'no scoreboardCreated')
+        assert.strictEqual(created[1].title.toString(), 'Total Kills')
+        assert.ok(seen.some(e => e[0] === 'scoreboardPosition'), 'no scoreboardPosition')
+        assert.strictEqual(bot.scoreboard.sidebar, bot.scoreboards.kills)
+      })
+
+      it('records a score and drops it again', async () => {
+        const seen = collect('scoreUpdated', 'scoreRemoved')
+        let client
+        await onJoin((c) => {
+          client = c
+          addObjective(c, 'kills', 'Total Kills')
+          setScore(c, 'kills', 'wvffle', 7)
+        })
+        const updated = seen.find(e => e[0] === 'scoreUpdated')
+        assert.ok(updated, 'no scoreUpdated')
+        const [, scoreboard, added] = updated
+        assert.strictEqual(added.value, 7)
+        assert.strictEqual(scoreboard.itemsMap.wvffle, added)
+        assert.strictEqual(added.displayName.toString(), 'wvffle')
+
+        if (scoreHasAction) client.write('scoreboard_score', { itemName: 'wvffle', action: 1, scoreName: 'kills' })
+        else client.write('reset_score', { entity_name: 'wvffle', objective_name: 'kills' })
+        await sleep(100)
+        const removal = seen.find(e => e[0] === 'scoreRemoved')
+        assert.ok(removal, 'no scoreRemoved')
+        assert.strictEqual(removal[2].value, 7)
+        assert.strictEqual(bot.scoreboards.kills.itemsMap.wvffle, undefined)
+      })
+
+      if (!scoreHasAction) {
+        it('draws a score with the display name the server sends for it', async () => {
+          const seen = collect('scoreUpdated')
+          await onJoin((client) => {
+            addObjective(client, 'kills', 'Total Kills')
+            setScore(client, 'kills', 'wvffle', 3, chatText('Wvffle the Great'))
+          })
+          assert.ok(seen.length, 'no scoreUpdated')
+          assert.strictEqual(seen[0][2].displayName.toString(), 'Wvffle the Great')
+        })
+
+        it('drops a score from every objective when reset_score names none', async () => {
+          let client
+          await onJoin((c) => {
+            client = c
+            addObjective(c, 'kills', 'Total Kills')
+            addObjective(c, 'deaths', 'Total Deaths')
+            setScore(c, 'kills', 'wvffle', 7)
+            setScore(c, 'deaths', 'wvffle', 2)
+          })
+          assert.strictEqual(bot.scoreboards.kills.itemsMap.wvffle.value, 7)
+          assert.strictEqual(bot.scoreboards.deaths.itemsMap.wvffle.value, 2)
+          client.write('reset_score', { entity_name: 'wvffle', objective_name: undefined })
+          await sleep(100)
+          assert.strictEqual(bot.scoreboards.kills.itemsMap.wvffle, undefined)
+          assert.strictEqual(bot.scoreboards.deaths.itemsMap.wvffle, undefined)
+        })
+      }
+    })
+
     describe('activateItem rotation', () => {
       it('should send the bot rotation in the use_item packet', function (done) {
         // The rotation field in use_item was added in 1.21.1


### PR DESCRIPTION
## Problem

1.20.3 reshaped both scoreboard packets and mineflayer still reads the pre-1.20.3 shapes, so the sidebar API is empty on every server from 1.20.3 on.

**`scoreboard_score` lost its `action` field.** The handler guards on `packet.action === 0`, which is never true:

```js
if (scoreboard !== undefined && packet.action === 0) {
  const updated = scoreboard.add(packet.itemName, packet.value)
```

so no score is ever recorded — `bot.scoreboards.<name>.itemsMap` stays `{}` and `scoreUpdated` never fires. Removal moved to its own `reset_score` packet, which nothing listens for, so `scoreRemoved` never fires either.

```js
// 26.1 production server, sidebar objective present and displayed
bot.scoreboard.sidebar.itemsMap   // {}
```

**The objective title became an NBT component** in the same release, and `setTitle` `JSON.parse`s it, so the `catch` leaves the raw prismarine-nbt tag in `scoreboard.title`:

```js
String(bot.scoreboard.sidebar.title)   // '[object Object]'
bot.scoreboard.sidebar.title           // { type: 'compound', value: { color: ..., text: ..., bold: ... } }
```

Even where the parse works (1.13–1.20.2) it keeps only the top-level `text`, dropping the `extra` array that carries most server titles.

## Fix

- `scoreboard_score`: read the score unless the packet is the old action-1 removal.
- `reset_score`: new handler. An absent `objective_name` means the score is dropped from every objective, which is what vanilla does.
- `setTitle`: `ChatMessage.fromNotch`, which already covers the plain string (1.8), the JSON string (1.13) and the NBT component (1.20.3) — the same treatment `open_window` titles get. `ScoreBoard.title` is now a `ChatMessage`; `String(title)` gives the text as before, with the extras included.
- 1.20.3+ can send a component to draw in place of a score's own name (`display_name`); it becomes that entry's `displayName` when present, otherwise the team-formatted name as before.

One small behaviour change beyond that: removing a score that the objective does not hold no longer emits `scoreRemoved` with an `undefined` item. Real 1.20.3+ servers send `reset_score` for entities that were never scored (a lobby sends a burst of them on join), so the event would otherwise fire constantly with nothing in it.

## Tests

Four cases under `describe('scoreboard')` in `internalTest.js`, driving a real server: the objective title (every version), a score recorded and then dropped (through `action: 1` before 1.20.3, through `reset_score` after), the per-score display name, and a `reset_score` with no objective name clearing the score everywhere. The last two are 1.20.3+ only. All pass across the version matrix (1.8.8 through 26.1); the first two fail on master for 1.20.3+.
