### PR TITLE
Read the 1.20.3+ scoreboard packets: scores, resets and NBT titles

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -678,7 +678,8 @@ Name of the scoreboard.
 
 #### ScoreBoard.title
 
-The title of the scoreboard (does not always equal the name)
+The title of the scoreboard (does not always equal the name), as a `ChatMessage`. Servers send it
+as a chat component, so `.toString()` for the plain text and `.toAnsi()` for the coloured form.
 
 #### ScoreBoard.itemsMap
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -789,15 +789,15 @@ export interface VillagerTrade {
 
 export class ScoreBoard {
   name: string
-  title: string
+  title: ChatMessage
   itemsMap: { [name: string]: ScoreBoardItem }
   items: ScoreBoardItem[]
 
   constructor (packet: object);
 
-  setTitle (title: string): void;
+  setTitle (title: string | object): void;
 
-  add(name: string, value: number): ScoreBoardItem;
+  add(name: string, value: number, displayName?: string | object): ScoreBoardItem;
 
   remove (name: string): ScoreBoardItem;
 }

--- a/lib/plugins/scoreboard.js
+++ b/lib/plugins/scoreboard.js
@@ -40,9 +40,13 @@ function inject (bot) {
 
   bot._client.on('scoreboard_score', (packet) => {
     const scoreboard = scoreboards[packet.scoreName]
-    if (scoreboard !== undefined && packet.action === 0) {
-      const updated = scoreboard.add(packet.itemName, packet.value)
+    // 1.20.3 moved removal into its own reset_score packet, so this packet lost its action
+    // field and now only ever sets a score.
+    if (packet.action === undefined || packet.action === 0) {
+      if (scoreboard === undefined) return
+      const updated = scoreboard.add(packet.itemName, packet.value, packet.display_name)
       bot.emit('scoreUpdated', scoreboard, updated)
+      return
     }
 
     if (packet.action === 1) {
@@ -57,6 +61,19 @@ function inject (bot) {
           return bot.emit('scoreRemoved', sb, removed)
         }
       }
+    }
+  })
+
+  // 1.20.3+. An absent objective_name resets the entry on every objective, as vanilla does.
+  bot._client.on('reset_score', (packet) => {
+    const targets = packet.objective_name == null
+      ? Object.values(scoreboards)
+      : [scoreboards[packet.objective_name]]
+
+    for (const scoreboard of targets) {
+      if (scoreboard === undefined || !(packet.entity_name in scoreboard.itemsMap)) continue
+      const removed = scoreboard.remove(packet.entity_name)
+      bot.emit('scoreRemoved', scoreboard, removed)
     }
   })
 

--- a/lib/scoreboard.js
+++ b/lib/scoreboard.js
@@ -14,20 +14,21 @@ module.exports = (bot) => {
       this.itemsMap = {}
     }
 
+    // displayText is a plain string before 1.13, a JSON string up to 1.20.2 and an NBT
+    // component from 1.20.3 on; fromNotch reads all three.
     setTitle (title) {
-      try {
-        this.title = JSON.parse(title).text // version>1.13
-      } catch {
-        this.title = title
-      }
+      this.title = title == null ? new ChatMessage('') : ChatMessage.fromNotch(title)
     }
 
-    add (name, value) {
-      this.itemsMap[name] = { name, value }
+    // displayName, when the server sends one, is what vanilla renders for this entry instead of
+    // the team-formatted entity name (1.20.3+).
+    add (name, value, displayName) {
+      const shown = displayName == null ? null : ChatMessage.fromNotch(displayName)
       this.itemsMap[name] = {
         name,
         value,
         get displayName () {
+          if (shown !== null) return shown
           if (name in bot.teamMap) {
             return bot.teamMap[name].displayName(name)
           }

--- a/test/scoreboardTest.js
+++ b/test/scoreboardTest.js
@@ -1,0 +1,129 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const EventEmitter = require('events').EventEmitter
+const registryLoader = require('prismarine-registry')
+
+// The scoreboard plugin only needs a registry, a packet source and an event bus, so it can be
+// driven straight off the wire shapes without standing up a server.
+function fakeBot (version) {
+  const bot = new EventEmitter()
+  bot.registry = registryLoader(version)
+  bot._client = new EventEmitter()
+  bot.teamMap = {}
+  require('../lib/plugins/scoreboard')(bot)
+  return bot
+}
+
+function createObjective (bot, name, displayText) {
+  bot._client.emit('scoreboard_objective', { name, action: 0, displayText })
+  bot._client.emit('scoreboard_display_objective', { name, position: 1 })
+}
+
+describe('scoreboard', () => {
+  describe('1.20.2 and older (scoreboard_score carries an action)', () => {
+    it('tracks scores and removals, and reads a JSON title', () => {
+      const bot = fakeBot('1.20.2')
+      createObjective(bot, 'objective', '{"text":"Leaderboard"}')
+      assert.strictEqual(bot.scoreboard.sidebar.title.toString(), 'Leaderboard')
+
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'objective', action: 0, value: 3 })
+      bot._client.emit('scoreboard_score', { itemName: 'dzikoysk', scoreName: 'objective', action: 0, value: 6 })
+      assert.deepStrictEqual(bot.scoreboard.sidebar.items.map(i => [i.name, i.value]), [['dzikoysk', 6], ['wvffle', 3]])
+
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'objective', action: 1 })
+      assert.deepStrictEqual(bot.scoreboard.sidebar.items.map(i => i.name), ['dzikoysk'])
+    })
+  })
+
+  describe('1.20.3+ (scoreboard_score lost its action, reset_score took over removals)', () => {
+    it('tracks scores sent without an action', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'objective', { type: 'compound', value: { text: { type: 'string', value: 'BedWars' } } })
+      assert.strictEqual(bot.scoreboard.sidebar.title.toString(), 'BedWars')
+
+      const seen = []
+      bot.on('scoreUpdated', (sb, item) => seen.push([sb.name, item.name, item.value]))
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'objective', value: 3 })
+      bot._client.emit('scoreboard_score', { itemName: 'dzikoysk', scoreName: 'objective', value: 6 })
+
+      assert.deepStrictEqual(bot.scoreboard.sidebar.items.map(i => [i.name, i.value]), [['dzikoysk', 6], ['wvffle', 3]])
+      assert.deepStrictEqual(seen, [['objective', 'wvffle', 3], ['objective', 'dzikoysk', 6]])
+    })
+
+    it('renders the per-score display name the server sends', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'objective', { type: 'compound', value: { text: { type: 'string', value: 'BedWars' } } })
+      bot._client.emit('scoreboard_score', {
+        itemName: 'green',
+        scoreName: 'objective',
+        value: 1,
+        display_name: { type: 'compound', value: { text: { type: 'string', value: 'Green: alive' } } }
+      })
+      assert.strictEqual(bot.scoreboard.sidebar.items[0].displayName.toString(), 'Green: alive')
+    })
+
+    it('falls back to the entry name when no display name is sent', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'objective', { type: 'compound', value: { text: { type: 'string', value: 'BedWars' } } })
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'objective', value: 1 })
+      assert.strictEqual(bot.scoreboard.sidebar.items[0].displayName.toString(), 'wvffle')
+    })
+
+    it('reset_score removes the entry from one objective', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'objective', { type: 'compound', value: { text: { type: 'string', value: 'BedWars' } } })
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'objective', value: 3 })
+      bot._client.emit('scoreboard_score', { itemName: 'dzikoysk', scoreName: 'objective', value: 6 })
+
+      const removed = []
+      bot.on('scoreRemoved', (sb, item) => removed.push(item.name))
+      bot._client.emit('reset_score', { entity_name: 'wvffle', objective_name: 'objective' })
+
+      assert.deepStrictEqual(removed, ['wvffle'])
+      assert.deepStrictEqual(bot.scoreboard.sidebar.items.map(i => i.name), ['dzikoysk'])
+    })
+
+    it('reset_score without an objective clears the entry everywhere', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'a', { type: 'compound', value: { text: { type: 'string', value: 'A' } } })
+      bot._client.emit('scoreboard_objective', { name: 'b', action: 0, displayText: { type: 'compound', value: { text: { type: 'string', value: 'B' } } } })
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'a', value: 3 })
+      bot._client.emit('scoreboard_score', { itemName: 'wvffle', scoreName: 'b', value: 4 })
+
+      bot._client.emit('reset_score', { entity_name: 'wvffle', objective_name: undefined })
+
+      assert.deepStrictEqual(bot.scoreboards.a.items, [])
+      assert.deepStrictEqual(bot.scoreboards.b.items, [])
+    })
+  })
+
+  describe('titles', () => {
+    it('keeps the whole component, not just the first text run', () => {
+      const bot = fakeBot('1.21.4')
+      createObjective(bot, 'objective', {
+        type: 'compound',
+        value: {
+          text: { type: 'string', value: '' },
+          extra: {
+            type: 'list',
+            value: {
+              type: 'compound',
+              value: [
+                { text: { type: 'string', value: 'Bed' } },
+                { text: { type: 'string', value: 'Wars' } }
+              ]
+            }
+          }
+        }
+      })
+      assert.strictEqual(bot.scoreboard.sidebar.title.toString(), 'BedWars')
+    })
+
+    it('reads a plain-string title from 1.8', () => {
+      const bot = fakeBot('1.8.8')
+      createObjective(bot, 'objective', 'Leaderboard')
+      assert.strictEqual(bot.scoreboard.sidebar.title.toString(), 'Leaderboard')
+    })
+  })
+})


### PR DESCRIPTION
### Problem

1.20.3 changed three things about the scoreboard packets, and mineflayer still reads the 1.20.2 shapes. On every version from 1.20.3 on (so 1.20.3 … 1.21.x, 26.1):

| what | 1.20.2 | 1.20.3+ |
| --- | --- | --- |
| set a score | `scoreboard_score { itemName, action, scoreName, value }` | `scoreboard_score { itemName, scoreName, value, display_name?, number_format? }` — no `action` |
| remove a score | `scoreboard_score` with `action: 1` | `reset_score { entity_name, objective_name? }` |
| objective display text | JSON string | NBT component |

The consequences:

- **Every score is dropped.** The handler adds only when `packet.action === 0`; the field is gone, `undefined === 0` is false, so `bot.scoreboard.sidebar.items` stays `[]` for the life of the bot and `scoreUpdated` never fires. A server-side sidebar — the thing most minigame servers put every piece of game state into — is completely invisible to a bot.
- **No score is ever removed.** `reset_score` had no handler at all, so once the first bug is fixed, entries would accumulate forever.
- **`ScoreBoard.title` is raw NBT.** `setTitle` does `JSON.parse(title).text`, which throws on an object and falls through to keeping the object as-is, so a title prints as `[object Object]`.

Reproduced on a 26.1 production server (jartexnetwork BedWars): `bot.scoreboard.sidebar` is `{ name: 'page0', title: [object Object], items: [] }` while the client shows a full sidebar.

### Fix

- `scoreboard_score` with no `action` is always an update (`packet.action === undefined || packet.action === 0`); the pre-1.20.3 `action: 1` removal path is untouched.
- New `reset_score` handler: removes the entry from the named objective, or from every objective when the packet names none — which is what vanilla's `ResetScorePacket` with an absent objective means.
- `setTitle` goes through `ChatMessage.fromNotch`, which reads an NBT component, a JSON string and a plain string alike. That also fixes the old path silently throwing away everything but the first text run of a multi-part title (`{text:"",extra:[…]}` used to give `""`).
- 1.20.3+ also lets the server override how a single entry renders (`display_name`). `item.displayName` prefers that component when one is sent, and otherwise falls back to the team-formatted entity name exactly as before.

### Compatibility

`ScoreBoard.title` is now a `ChatMessage` instead of a string. `ScoreBoardItem.displayName` has always been a `ChatMessage`, so this makes the class consistent, and `title.toString()` gives the text the field used to hold. `index.d.ts` and `docs/api.md` are updated.

### Tests

`test/scoreboardTest.js` drives the plugin directly off the wire shapes — no server needed, the plugin only wants a registry, a packet source and an event bus. It covers the 1.20.2 action-based add/remove path, the 1.20.3+ actionless add, `reset_score` with and without an objective name, the per-score `display_name`, its fallback, an NBT title, a multi-run NBT title, and a plain-string 1.8 title. Five of the eight fail on master.

`standard` is clean.