### PR TITLE
placeEntity: write a complete use_item when placing a boat

### DIFF
--- a/lib/plugins/place_entity.js
+++ b/lib/plugins/place_entity.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const { toNotchianYaw, toNotchianPitch } = require('../conversions')
 
 module.exports = inject
 
@@ -36,8 +37,15 @@ function inject (bot) {
 
     if (type === 'boat') {
       if (bot.supportFeature('useItemWithOwnPacket')) {
+        // Same payload as bot.activateItem(): 1.19 added the prediction sequence and 1.21.2 the
+        // rotation, and leaving either out makes the serializer throw, which ends the connection.
         bot._client.write('use_item', {
-          hand: options.offhand ? 1 : 0
+          hand: options.offhand ? 1 : 0,
+          sequence: 0, // 1.19.0+, as in generic_place
+          rotation: {
+            x: toNotchianYaw(bot.entity.yaw),
+            y: toNotchianPitch(bot.entity.pitch)
+          }
         })
       } else {
         bot._client.write('block_place', {

--- a/test/placeEntityPacketTest.js
+++ b/test/placeEntityPacketTest.js
@@ -1,0 +1,59 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const EventEmitter = require('events').EventEmitter
+const Vec3 = require('vec3').Vec3
+const registryLoader = require('prismarine-registry')
+const mc = require('minecraft-protocol')
+
+// Drives bot.placeEntity far enough to see what it puts on the wire, and serializes every packet
+// with the real protocol so a missing field fails here instead of killing a live connection.
+function fakeBot (version) {
+  const registry = registryLoader(version)
+  const bot = new EventEmitter()
+  bot.registry = registry
+  bot.version = version
+  bot.supportFeature = registry.supportFeature.bind(registry)
+  bot.entity = { position: new Vec3(0, 64, 0), yaw: 0, pitch: 0 }
+  bot.written = []
+  const serializer = mc.createSerializer({ state: 'play', isServer: false, version })
+  bot._client = {
+    write (name, params) {
+      // throws exactly as the real client would on an incomplete packet
+      serializer.createPacketBuffer({ name, params })
+      bot.written.push({ name, params })
+    }
+  }
+  bot._genericPlace = async (referenceBlock) => referenceBlock.position
+  require('../lib/plugins/place_entity')(bot)
+  return bot
+}
+
+const versions = ['1.18.2', '1.19.4', '1.20.4', '1.21.4']
+
+describe('placeEntity writes a use_item the protocol accepts', () => {
+  for (const version of versions) {
+    it(version, async () => {
+      const bot = fakeBot(version)
+      const Item = require('prismarine-item')(bot.registry)
+      const boat = bot.registry.itemsByName.oak_boat || bot.registry.itemsByName.boat
+      bot.heldItem = new Item(boat.id, 1)
+      const reference = { position: new Vec3(0, 63, 0), name: 'water' }
+
+      const placed = bot.placeEntity(reference, new Vec3(0, 1, 0))
+      // the boat the server would spawn back
+      setTimeout(() => bot.emit('entitySpawn', {
+        name: bot.supportFeature('entityNameUpperCaseNoUnderscore') ? 'Boat' : 'boat',
+        position: new Vec3(0, 64, 0)
+      }), 20)
+      await placed
+
+      const useItem = bot.written.filter(p => p.name === 'use_item' || p.name === 'block_place')
+      assert.strictEqual(useItem.length, 1, 'exactly one item-use packet')
+      if (bot.supportFeature('useItemWithOwnPacket')) {
+        assert.strictEqual(useItem[0].name, 'use_item')
+        assert.strictEqual(useItem[0].params.hand, 0)
+      }
+    })
+  }
+})


### PR DESCRIPTION
### Problem

`lib/plugins/place_entity.js` finishes a boat placement with

```js
bot._client.write('use_item', {
  hand: options.offhand ? 1 : 0
})
```

`use_item` grew a `sequence` field in 1.19 and a `rotation` field in 1.21.2. Every other `use_item` in the codebase sends both — see `activateItem` in `plugins/inventory.js`.

So on 1.19 – 1.21.1 the packet carries a garbage sequence, and on **1.21.2 and newer the serializer throws** on the absent rotation:

```
$ node -e "…createSerializer({state:'play',isServer:false,version:'1.21.4'})
           .createPacketBuffer({name:'use_item',params:{hand:0}})"
in packet use_item: SizeOf error for undefined : Cannot read properties of undefined (reading 'x')
```

A throw out of `client.write` takes the connection down with it, so `bot.placeEntity(…)` with a boat in hand disconnects the bot on every current version.

Nothing caught this because `placeEntity` is listed in `excludedTests` in `test/externalTest.js`.

### Fix

Send the same payload `activateItem` does: `hand`, `sequence` and `rotation` from the bot's current yaw/pitch. `sequence: 0` matches what `generic_place.js` already writes; PR #4085 replaces both with a real shared counter, and this change is written so that rebases cleanly.

### Test

`test/placeEntityPacketTest.js` drives `bot.placeEntity` with a stub for `_genericPlace` and a `_client.write` that runs the real `minecraft-protocol` serializer, so an incomplete packet fails the test instead of a live connection. It covers 1.18.2 (which takes the old `block_place` path), 1.19.4, 1.20.4 and 1.21.4, and asserts exactly one item-use packet goes out. The 1.21.4 case fails on master with the `SizeOf error` above.

Found while running a bot on a 26.1 production server, where a throw from `client.write` is not recoverable.