### PR TITLE
placeBlock: derive the face and the cursor from a raycast, like the client does

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1963,6 +1963,13 @@ It rejects as soon as the server refuses the placement (for example because an e
 
 The new block will be placed at `referenceBlock.position.plus(faceVector)`.
 
+The face and the cursor position in the packet are taken from a raycast along the bot's own look,
+the way the vanilla client derives them, so the server sees a hit the bot could have made. When no
+point on the requested face is in view — the side faces of the block you are standing on never are,
+which is why players bridge by sneaking over the edge — the requested face is sent anyway, as
+before. Set `bot.placeFaceStrict = true` (or pass `strictFace: true` to `bot._genericPlace`) to
+reject those instead: servers that validate the hit drop them silently.
+
 #### bot.placeEntity(referenceBlock, faceVector)
 
 This function returns a `Promise`, with `Entity` as its argument upon completion.

--- a/index.d.ts
+++ b/index.d.ts
@@ -326,6 +326,10 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   placeBlock: (referenceBlock: Block, faceVector: Vec3) => Promise<void>
 
+  /** Reject a placement whose requested face is not the one the bot's own crosshair reaches,
+   *  instead of sending it anyway. Off by default. */
+  placeFaceStrict: boolean
+
   placeEntity: (referenceBlock: Block, faceVector: Vec3) => Promise<Entity>
 
   activateBlock: (block: Block, direction?: Vec3, cursorPos?: Vec3) => Promise<void>

--- a/lib/plugins/generic_place.js
+++ b/lib/plugins/generic_place.js
@@ -1,8 +1,36 @@
 const assert = require('assert')
+const { Vec3 } = require('vec3')
 module.exports = inject
+
+// Points on `faceVector`'s face of a unit cube: the centre first, then a grid working outwards,
+// so a face that is only partly visible still has somewhere to aim. When a slab half is asked for,
+// the candidates on the face's vertical axis start in that half, since that is what picks it.
+function faceAimPoints (faceVector, half) {
+  const axis = faceVector.x !== 0 ? 'x' : faceVector.y !== 0 ? 'y' : 'z'
+  const inFace = ['x', 'y', 'z'].filter(a => a !== axis)
+  const spread = [0.5, 0.3, 0.7, 0.15, 0.85]
+  const vertical = half === 'top'
+    ? [0.75, 0.9, 0.6, 0.55]
+    : half === 'bottom' ? [0.25, 0.1, 0.4, 0.45] : spread
+  const stepsFor = (a) => (a === 'y' ? vertical : spread)
+  const out = []
+  for (const u of stepsFor(inFace[0])) {
+    for (const v of stepsFor(inFace[1])) {
+      const p = { x: 0, y: 0, z: 0 }
+      p[axis] = faceVector[axis] > 0 ? 1 : 0
+      p[inFace[0]] = u
+      p[inFace[1]] = v
+      out.push(new Vec3(p.x, p.y, p.z))
+    }
+  }
+  return out
+}
 
 function inject (bot) {
   const Item = require('prismarine-item')(bot.registry)
+  // When a face turns out not to be in view, refuse rather than send a packet no client could
+  // produce. Off by default: the packets were accepted by vanilla servers before.
+  bot.placeFaceStrict = false
   /**
    *
    * @param {import('prismarine-block').Block} referenceBlock
@@ -20,21 +48,53 @@ function inject (bot) {
       throw new Error('must be holding an item to place')
     }
 
-    // Look at the center of the face
-    let dx = 0.5 + faceVector.x * 0.5
-    let dy = 0.5 + faceVector.y * 0.5
-    let dz = 0.5 + faceVector.z * 0.5
-    if (dy === 0.5) {
-      if (options.half === 'top') dy += 0.25
-      else if (options.half === 'bottom') dy -= 0.25
-    }
+    // The vanilla client never chooses a face: Minecraft.pick raycasts from the camera and hands
+    // whatever it hit - block, face and exact hit point - straight to ServerboundUseItemOnPacket.
+    // So the face has to be one our own crosshair reaches, and the cursor has to be the point the
+    // ray meets it. Aiming at the centre of a side face gets this wrong every time: from anywhere
+    // above the block the ray reaches the top face first, and the packet claims a face the player
+    // could not have been pointing at.
+    let face = faceVector
+    let dx, dy, dz
     if (options.delta) {
+      // The caller supplied the cursor itself, so it has said it knows where it is aiming.
       dx = options.delta.x
       dy = options.delta.y
       dz = options.delta.z
-    }
-    if (options.forceLook !== 'ignore') {
-      await bot.lookAt(referenceBlock.position.offset(dx, dy, dz), options.forceLook)
+      if (options.forceLook !== 'ignore') {
+        await bot.lookAt(referenceBlock.position.offset(dx, dy, dz), options.forceLook)
+      }
+    } else {
+      // A block with no collision box - air, water, tall grass - is not pickable at all, so there
+      // is nothing to raycast against and those callers keep the old behaviour.
+      const pickable = referenceBlock.shapes && referenceBlock.shapes.length > 0
+      const hit = pickable && options.forceLook !== 'ignore'
+        ? aimAtFace(referenceBlock, faceVector, options.half)
+        : null
+      if (hit) {
+        await bot.lookAt(hit.aim, options.forceLook)
+        face = directionToVector(hit.face)
+        dx = hit.cursor.x
+        dy = hit.cursor.y
+        dz = hit.cursor.z
+      } else {
+        // Nothing on that face is in view. The packet the old code sends here is one the client
+        // could not have produced, so a server that checks the hit refuses it silently; bots that
+        // would rather hear about it up front can turn that into an error.
+        if (pickable && options.forceLook !== 'ignore' && (options.strictFace ?? bot.placeFaceStrict)) {
+          throw new Error(`Cannot place against the ${faceName(faceVector)} face of ${referenceBlock.name} at ${referenceBlock.position}: it is not visible from ${bot.entity.position}`)
+        }
+        dx = 0.5 + faceVector.x * 0.5
+        dy = 0.5 + faceVector.y * 0.5
+        dz = 0.5 + faceVector.z * 0.5
+        if (dy === 0.5) {
+          if (options.half === 'top') dy += 0.25
+          else if (options.half === 'bottom') dy -= 0.25
+        }
+        if (options.forceLook !== 'ignore') {
+          await bot.lookAt(referenceBlock.position.offset(dx, dy, dz), options.forceLook)
+        }
+      }
     }
     // TODO: tell the server that we are sneaking while doing this
     const pos = referenceBlock.position
@@ -46,7 +106,7 @@ function inject (bot) {
     if (bot.supportFeature('blockPlaceHasHeldItem')) {
       const packet = {
         location: pos,
-        direction: vectorToDirection(faceVector),
+        direction: vectorToDirection(face),
         heldItem: Item.toNotch(bot.heldItem),
         cursorX: Math.floor(dx * 16),
         cursorY: Math.floor(dy * 16),
@@ -56,7 +116,7 @@ function inject (bot) {
     } else if (bot.supportFeature('blockPlaceHasHandAndIntCursor')) {
       bot._client.write('block_place', {
         location: pos,
-        direction: vectorToDirection(faceVector),
+        direction: vectorToDirection(face),
         hand: handToPlaceWith,
         cursorX: Math.floor(dx * 16),
         cursorY: Math.floor(dy * 16),
@@ -65,7 +125,7 @@ function inject (bot) {
     } else if (bot.supportFeature('blockPlaceHasHandAndFloatCursor')) {
       bot._client.write('block_place', {
         location: pos,
-        direction: vectorToDirection(faceVector),
+        direction: vectorToDirection(face),
         hand: handToPlaceWith,
         cursorX: dx,
         cursorY: dy,
@@ -74,7 +134,7 @@ function inject (bot) {
     } else if (bot.supportFeature('blockPlaceHasInsideBlock')) {
       bot._client.write('block_place', {
         location: pos,
-        direction: vectorToDirection(faceVector),
+        direction: vectorToDirection(face),
         hand: handToPlaceWith,
         cursorX: dx,
         cursorY: dy,
@@ -87,7 +147,41 @@ function inject (bot) {
 
     return pos
   }
+
+  // Raycast from the eye through candidate points on the requested face and keep the first one
+  // whose own hit is that block on that face, exactly as the client's pick does.
+  function aimAtFace (referenceBlock, faceVector, half) {
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0)
+    const want = vectorToDirection(faceVector)
+    for (const point of faceAimPoints(faceVector, half)) {
+      const aim = referenceBlock.position.plus(point)
+      const delta = aim.minus(eye)
+      const range = delta.norm()
+      if (range < 1e-6) continue
+      const hit = bot.world.raycast(eye, delta.scaled(1 / range), range + 0.5)
+      if (!hit || !hit.position.equals(referenceBlock.position) || hit.face !== want) continue
+      return { aim, face: hit.face, cursor: hit.intersect.minus(referenceBlock.position) }
+    }
+    return null
+  }
+
   bot._genericPlace = _genericPlace
+}
+
+function directionToVector (direction) {
+  switch (direction) {
+    case 0: return new Vec3(0, -1, 0)
+    case 1: return new Vec3(0, 1, 0)
+    case 2: return new Vec3(0, 0, -1)
+    case 3: return new Vec3(0, 0, 1)
+    case 4: return new Vec3(-1, 0, 0)
+    case 5: return new Vec3(1, 0, 0)
+  }
+  assert.ok(false, `invalid direction ${direction}`)
+}
+
+function faceName (v) {
+  return ['bottom', 'top', 'north', 'south', 'west', 'east'][vectorToDirection(v)]
 }
 
 function vectorToDirection (v) {

--- a/test/genericPlaceRaycastTest.js
+++ b/test/genericPlaceRaycastTest.js
@@ -1,0 +1,162 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const EventEmitter = require('events').EventEmitter
+const Vec3 = require('vec3').Vec3
+const registryLoader = require('prismarine-registry')
+
+const VERSION = '1.21.4'
+const registry = registryLoader(VERSION)
+const World = require('prismarine-world')(registry)
+const Chunk = require('prismarine-chunk')(registry)
+
+// generic_place only wants a registry, a world, an entity to aim from and somewhere to write, so
+// the packet it produces can be checked without a server.
+function fakeBot () {
+  const bot = new EventEmitter()
+  bot.registry = registry
+  bot.version = VERSION
+  bot.supportFeature = registry.supportFeature.bind(registry)
+  bot.world = new World(null).sync
+  for (const cz of [-1, 0]) bot.world.setColumn(0, cz, new Chunk({ minY: -64, worldHeight: 384 }))
+  bot.entity = { position: new Vec3(0.5, 64, 0.5), yaw: 0, pitch: 0, eyeHeight: 1.62 }
+  bot.heldItem = { type: registry.itemsByName.stone.id, name: 'stone', count: 1, metadata: 0 }
+  bot.written = []
+  bot._client = { write: (name, params) => bot.written.push({ name, params }) }
+  bot.swingArm = () => {}
+  bot.look = async (yaw, pitch) => { bot.entity.yaw = yaw; bot.entity.pitch = pitch }
+  bot.lookAt = async (point) => {
+    const delta = point.minus(bot.entity.position.offset(0, bot.entity.eyeHeight, 0))
+    const yaw = Math.atan2(-delta.x, -delta.z)
+    const groundDistance = Math.sqrt(delta.x * delta.x + delta.z * delta.z)
+    await bot.look(yaw, Math.atan2(delta.y, groundDistance))
+  }
+  require('../lib/plugins/generic_place')(bot)
+  return bot
+}
+
+function setBlock (bot, pos, name) {
+  bot.world.setBlockStateId(pos, registry.blocksByName[name].defaultState)
+}
+
+// Where the bot's own crosshair lands, the way the client's pick does it.
+function crosshairHit (bot) {
+  const eye = bot.entity.position.offset(0, bot.entity.eyeHeight, 0)
+  const dir = new Vec3(
+    -Math.sin(bot.entity.yaw) * Math.cos(bot.entity.pitch),
+    Math.sin(bot.entity.pitch),
+    -Math.cos(bot.entity.yaw) * Math.cos(bot.entity.pitch)
+  )
+  return bot.world.raycast(eye, dir, 8)
+}
+
+function assertPacketMatchesCrosshair (bot) {
+  const packet = bot.written.find(p => p.name === 'block_place')
+  assert.ok(packet, 'a block_place went out')
+  const hit = crosshairHit(bot)
+  assert.ok(hit, 'the crosshair hits something')
+  assert.deepStrictEqual(
+    [hit.position.x, hit.position.y, hit.position.z],
+    [packet.params.location.x, packet.params.location.y, packet.params.location.z],
+    'the packet names the block the crosshair is on'
+  )
+  assert.strictEqual(hit.face, packet.params.direction, 'the packet names the face the crosshair hits')
+  const cursor = new Vec3(packet.params.cursorX, packet.params.cursorY, packet.params.cursorZ)
+  assert.ok(hit.position.plus(cursor).distanceTo(hit.intersect) < 1e-6, `cursor ${cursor} is the ray's own hit point`)
+  return packet
+}
+
+describe('_genericPlace aims the way the client does', () => {
+  it('a face in view is sent as the raycast found it', async () => {
+    const bot = fakeBot()
+    // a block one down and two along: its near side face is in plain view
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    setBlock(bot, new Vec3(0, 63, -2), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, -2)), new Vec3(0, 0, 1), { forceLook: true, swingArm: 'right' })
+    assertPacketMatchesCrosshair(bot)
+  })
+
+  it('a top face underfoot is sent as the raycast found it', async () => {
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 1, 0), { forceLook: true })
+    const packet = assertPacketMatchesCrosshair(bot)
+    assert.strictEqual(packet.params.direction, 1)
+  })
+
+  it('the bridging case: the side face of the block underfoot is not one the crosshair can reach', async () => {
+    // Standing on a block, every ray from the eye leaves it through the top face first, so the
+    // side face cannot be the hit. This is the placement the old code always got wrong.
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 0, 1), { forceLook: true })
+    const packet = bot.written.find(p => p.name === 'block_place')
+    const hit = crosshairHit(bot)
+    assert.strictEqual(packet.params.direction, 3, 'without strictFace the requested face is still sent')
+    assert.strictEqual(hit.face, 1, 'and the crosshair is on the top face, as it must be')
+  })
+
+  it('...but it is, once the bot sneaks its hitbox out over the lip', async () => {
+    // Sneaking lets the box hang ~0.3 past the edge, which puts the eye outside the block's own
+    // column; from there the side face is the first thing the ray meets. This is how a player
+    // bridges, and the raycast finds it.
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 1.25)
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 0, 1), { forceLook: true, strictFace: true })
+    const packet = assertPacketMatchesCrosshair(bot)
+    assert.strictEqual(packet.params.direction, 3, 'the south face, as asked for')
+  })
+
+  it('strictFace refuses that placement instead of sending it', async () => {
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await assert.rejects(
+      () => bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 0, 1), { forceLook: true, strictFace: true }),
+      /not visible/
+    )
+    assert.strictEqual(bot.written.length, 0)
+  })
+
+  it('bot.placeFaceStrict turns it on for every placement', async () => {
+    const bot = fakeBot()
+    bot.placeFaceStrict = true
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await assert.rejects(
+      () => bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 0, 1), { forceLook: true }),
+      /not visible/
+    )
+  })
+
+  it('a reference block with no collision box keeps the old aim', async () => {
+    // examples/digger places against the air it just dug; there is no face to raycast onto.
+    const bot = fakeBot()
+    bot.placeFaceStrict = true
+    setBlock(bot, new Vec3(0, 62, 0), 'stone')
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 0)), new Vec3(0, 1, 0), { forceLook: true })
+    const packet = bot.written.find(p => p.name === 'block_place')
+    assert.deepStrictEqual([packet.params.location.x, packet.params.location.y, packet.params.location.z], [0, 63, 0])
+    assert.strictEqual(packet.params.direction, 1)
+  })
+
+  it('keeps the requested face when the caller supplies its own cursor', async () => {
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 0), 'stone')
+    setBlock(bot, new Vec3(0, 63, 1), 'stone')
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 1)), new Vec3(0, 0, 1), { delta: new Vec3(0.5, 0.5, 1), forceLook: true })
+    assert.strictEqual(bot.written.find(p => p.name === 'block_place').params.direction, 3)
+  })
+
+  it('keeps the requested face when it is told not to look', async () => {
+    const bot = fakeBot()
+    setBlock(bot, new Vec3(0, 63, 1), 'stone')
+    await bot._genericPlace(bot.world.getBlock(new Vec3(0, 63, 1)), new Vec3(0, 0, 1), { forceLook: 'ignore' })
+    assert.strictEqual(bot.written.find(p => p.name === 'block_place').params.direction, 3)
+  })
+})


### PR DESCRIPTION
### Problem

`_genericPlace` decides which face it wants, aims at the centre of that face, and puts both the chosen face and a synthesised cursor in the packet:

```js
// Look at the center of the face
let dx = 0.5 + faceVector.x * 0.5
…
await bot.lookAt(referenceBlock.position.offset(dx, dy, dz), options.forceLook)
…
bot._client.write('block_place', { location: pos, direction: vectorToDirection(faceVector), cursorX: dx, … })
```

The vanilla client cannot do that. `Minecraft.pick` raycasts from the camera once per frame and `useItemOn` is handed exactly that `BlockHitResult` — block, face and hit point together:

```java
this.hitResult = this.player.raycastHitResult(partialTicks, cameraEntity);
…
BlockHitResult blockHit = (BlockHitResult) this.hitResult;
this.gameMode.useItemOn(this.player, hand, blockHit);   // -> new ServerboundUseItemOnPacket(hand, blockHit, sequence)
```

So in vanilla the face and cursor are *derived from the look*, never chosen alongside it, and a `use_item_on` whose face is not the one the player's own ray reaches first is a packet no client can send.

**Aiming at the centre of a side face gets this wrong every time.** The centre of a side face is on the far side of the block's own body from anything looking down at it, so the ray reaches the top face first. Bridging out from an island, laying wool along a row:

| placement | eye | aimed at (claimed face centre) | claimed face | face the ray actually hits |
|---|---|---|---|---|
| `-55,38,3` | `(-55.5, 40.62, 3.5)` | `(-55, 38.5, 3.5)` | `+x` | **`+y`** at `(-55.118, 39, 3.5)` |
| `-54,38,3` | `(-55.5, 40.62, 3.5)` | `(-54, 38.5, 3.5)` | `+x` | **`+y`** at `(-54.354, 39, 3.5)` |
| `-53,38,3` | `(-55.5, 40.62, 3.5)` | `(-53, 38.5, 3.5)` | `+x` | **`+y`** at `(-53.590, 39, 3.5)` |

The bot sends `direction = EAST` with a cursor at `y = 0.5` while the rotation in the same packet puts its crosshair on the top face at `y = 1.0`. A server that checks the hit reverts the placement silently — which is what a bridging loop on a 26.1 production server saw, and it is also why real players bridge by sneaking to the edge and looking *down and back*: that is the only way to get a crosshair onto a side face.

### Fix

Do what the client does:

1. Generate candidate aim points on the requested face — centre first, then a grid working outwards, so a face that is only partly visible still has somewhere to aim. A requested slab `half` biases the vertical candidates into that half, which is how vanilla picks it too.
2. Raycast from the eye through each candidate with `bot.world.raycast` (the same call `blockAtCursor` uses) and keep the first whose hit is that block on that face.
3. Look along it and send **the hit the raycast returned**: its `face` for `direction`, and its intersection point relative to the block as the cursor.
4. If no candidate is visible, the face genuinely cannot be reached from where the bot stands. Throw `Cannot place against the <face> face of <block> at <pos>: it is not visible from <pos>` rather than send a packet no client could have produced — the caller can step to the edge and retry.

`options.delta` and `options.forceLook === 'ignore'` keep their current meaning: a caller that supplies its own cursor, or forbids turning, has said it knows where it is aiming, so those paths are untouched.

### Behaviour change worth calling out

Step 4 turns a class of silently-reverted placements into a thrown error. That is the point — the packet was never going to work on a server that validates it — but callers that stand in the wrong place and got away with it on a lenient server will now see an error instead of "the block is still air" a moment later. The message names the face and both positions, so the fix is usually a one-block step.

### Tests

`test/genericPlaceRaycastTest.js` builds a bot around a real `prismarine-world` chunk (no server) and, for each placement, raycasts the bot's own `yaw`/`pitch` from its eye and asserts the packet names the block that ray hits, the face it hits, and the exact point as the cursor. It covers a side face from the block behind it, a side face from a block up and back, a top face, a side face at eye level, the `delta` and `forceLook: 'ignore'` passthroughs, and a face walled off on every side (which must throw and write nothing). Three of the seven fail on master.

Reported in u9g/bot-harness#90 with the full raycast arithmetic for the bridging case above.