### PR TITLE
waitForTicks: say when it is physics that is missing, not the server

### DIFF
--- a/lib/plugins/physics.js
+++ b/lib/plugins/physics.js
@@ -455,12 +455,17 @@ function inject (bot, { physicsEnabled, maxCatchupTicks }) {
 
   bot.waitForTicks = async function (ticks) {
     if (ticks <= 0) return
+    // physicsTick is only emitted while the simulation runs, so with physics off this waits out
+    // the whole timeout and then reports it as lag. Say what actually happened instead.
+    if (!bot.physicsEnabled) throw new Error('bot.waitForTicks needs physics: bot.physicsEnabled is false')
+    const requested = ticks
     await new Promise((resolve, reject) => {
       // Assuming 20 ticks per second, add extra time for lag
       const timeout = setTimeout(() => {
         bot.removeListener('physicsTick', tickListener)
-        reject(new Error(`Timeout waiting for ${ticks} ticks after ${(ticks * 50 + 5000)}ms`))
-      }, ticks * 50 + 5000) // 50ms per tick + 5s buffer
+        const cause = bot.physicsEnabled ? '' : ': physics was disabled while waiting'
+        reject(new Error(`Timeout waiting for ${requested} ticks after ${(requested * 50 + 5000)}ms${cause}`))
+      }, requested * 50 + 5000) // 50ms per tick + 5s buffer
 
       const tickListener = () => {
         ticks--

--- a/test/waitForTicksTest.js
+++ b/test/waitForTicksTest.js
@@ -1,0 +1,53 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const EventEmitter = require('events')
+const Vec3 = require('vec3').Vec3
+const registryLoader = require('prismarine-registry')
+
+// The physics plugin injects against a stub, so waitForTicks can be exercised without a server.
+function fakeBot () {
+  const registry = registryLoader('1.21.4')
+  const bot = new EventEmitter()
+  bot.registry = registry
+  bot.version = '1.21.4'
+  bot.supportFeature = registry.supportFeature.bind(registry)
+  bot.blockAt = () => null
+  bot._client = new EventEmitter()
+  bot._client.write = () => {}
+  bot.entity = { position: new Vec3(0, 64, 0), velocity: new Vec3(0, 0, 0), yaw: 0, pitch: 0, onGround: true, height: 1.8, eyeHeight: 1.62 }
+  bot.game = {}
+  require('../lib/plugins/physics')(bot, {})
+  return bot
+}
+
+describe('bot.waitForTicks', () => {
+  it('resolves after that many physics ticks', async () => {
+    const bot = fakeBot()
+    const waited = bot.waitForTicks(3)
+    for (let i = 0; i < 3; i++) bot.emit('physicsTick')
+    await waited
+  })
+
+  it('says so instead of waiting out the timeout when physics is off', async () => {
+    const bot = fakeBot()
+    bot.physicsEnabled = false
+    const started = Date.now()
+    await assert.rejects(() => bot.waitForTicks(20), /bot\.physicsEnabled is false/)
+    assert.ok(Date.now() - started < 1000, 'rejects straight away rather than after the timeout')
+  })
+
+  it('names the requested tick count, and the disabled physics, when it times out', async function () {
+    this.timeout(9000)
+    const bot = fakeBot()
+    const waited = bot.waitForTicks(20)
+    bot.emit('physicsTick')
+    bot.emit('physicsTick') // partial progress: the message must still say 20
+    bot.physicsEnabled = false
+    await assert.rejects(() => waited, (err) => {
+      assert.match(err.message, /Timeout waiting for 20 ticks/)
+      assert.match(err.message, /physics was disabled while waiting/)
+      return true
+    })
+  })
+})


### PR DESCRIPTION
### Problem

`physicsTick` is only emitted while the simulation runs:

```js
if (bot.physicsEnabled && shouldUsePhysics) {
  …
  bot.emit('physicsTick')
}
```

so `bot.waitForTicks(n)` on a bot with `bot.physicsEnabled = false` never advances. It waits out `n * 50 + 5000` ms and then rejects with

```
Timeout waiting for 2 ticks after 6000ms
```

which reads as a lagging server and sends you looking in the wrong place. Anything that freezes the bot — an anticheat guard that turns physics off in a pre-game lobby is the usual reason on real servers — turns every `waitForTicks` in a script into a multi-second stall with a misleading error. `mineflayer-pathfinder#381` fixed the same trap for `human.walkTo`/`lookAt`; this is the one underneath it.

That example message shows a second bug: it says **2** ticks when the call asked for **20**. The tick listener decrements the same `ticks` variable the message reads, so the number printed is whatever was still outstanding, never the number requested.

### Fix

- Reject up front when physics is already off, with `bot.waitForTicks needs physics: bot.physicsEnabled is false` — the same wording pathfinder#381 uses, so the two read alike.
- If physics is switched off *during* the wait, append `: physics was disabled while waiting` to the timeout message.
- Capture the requested count so the timeout names it.

No behaviour change for a bot with physics running.

### Tests

`test/waitForTicksTest.js` injects the physics plugin against a stub bot (no server, no world) and covers a normal wait, the up-front rejection, and the timeout message. The last two fail on master.