### PR TITLE
ci: only flag tests 2x and 10s slower than master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: npm install
 
       # Per-test durations from the last master run of this version group, so a PR gets a
-      # comment listing tests it made more than 1.5x slower (test/common/compareDurations.js).
+      # comment listing tests it made more than 2x slower (test/common/compareDurations.js).
       - name: Restore duration baseline
         uses: actions/cache/restore@v4
         with:

--- a/.github/workflows/duration-comment.yml
+++ b/.github/workflows/duration-comment.yml
@@ -35,7 +35,7 @@ jobs:
             const existing = comments.find(c => c.body.startsWith(marker))
             if (lines.length === 0 && !existing) return
             const body = lines.length === 0
-              ? `${marker}\nNo tests are more than 1.5x slower than master anymore.`
-              : `${marker}\nTests more than 1.5x slower than master (durations are noisy, so this is informational):\n\`\`\`\n${lines.join('\n')}\n\`\`\``
+              ? `${marker}\nNo tests are more than 2x slower than master anymore.`
+              : `${marker}\nTests more than 2x slower than master (durations are noisy, so this is informational):\n\`\`\`\n${lines.join('\n')}\n\`\`\``
             if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body })
             else await github.rest.issues.createComment({ owner, repo, issue_number, body })

--- a/test/common/compareDurations.js
+++ b/test/common/compareDurations.js
@@ -1,13 +1,14 @@
 // Usage: node test/common/compareDurations.js <baselineDir> <currentDir> <slowerFile>
-// Writes every test that got more than 1.5x slower than master's baseline to <slowerFile>,
+// Writes every test that got more than 2x slower than master's baseline to <slowerFile>,
 // one line each, so CI can post them as a PR comment. Never fails: durations are noisy.
 const fs = require('fs')
 const path = require('path')
 
 const [baselineDir, currentDir, slowerFile] = process.argv.slice(2)
-const FACTOR = 1.5
-// Ignore tests too short for a 1.5x jump to mean anything (server/network jitter).
-const MIN_REGRESSION_MS = 5000
+const FACTOR = 2
+// Ignore jumps under 10s: master's own run-to-run spread on the world-event tests
+// (nether, fishing) is 5-10s, so anything smaller is server/network jitter.
+const MIN_REGRESSION_MS = 10000
 
 const slower = []
 for (const file of fs.readdirSync(currentDir).filter(f => f.startsWith('durations-')).sort()) {


### PR DESCRIPTION
The slower-tests comment currently fires on 69 of the 71 PRs it has ever run on, and master flags itself against its own previous run in 5 of the last 6 pushes. Every hit has been nether, fishing, spawnEvent or another world-event wait, whose run-to-run spread on master already exceeds the 5s bar (1.9.4 fishing alone ranges 2950–16697ms across six master runs).

At 2x and 10s, those same six master runs produce 2 self-flags instead of 30, so a line in the comment is far more likely to mean something.

Follow-ups worth doing separately: compare against a median of the last few master runs instead of the single latest one, and fix the bimodal spawnEvent (~0.4s vs ~15s) and creative (~0.4s vs ~6.4s) tests, which look like a timeout being hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qoS2nnjeTJNr5jR7wFpNA