### PR TITLE
Expose the interaction ranges the server sends, and the reach check vanilla makes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -308,6 +308,10 @@
       - [bot.acceptResourcePack()](#botacceptresourcepack)
       - [bot.denyResourcePack()](#botdenyresourcepack)
       - [bot.placeBlock(referenceBlock, faceVector)](#botplaceblockreferenceblock-facevector)
+      - [bot.entityInteractionRange()](#botentityinteractionrange)
+      - [bot.blockInteractionRange()](#botblockinteractionrange)
+      - [bot.canInteractWithEntity(entity, buffer)](#botcaninteractwithentityentity-buffer--0)
+      - [bot.canInteractWithBlock(block, buffer)](#botcaninteractwithblockblock-buffer--0)
       - [bot.placeEntity(referenceBlock, faceVector)](#botplaceentityreferenceblock-facevector)
       - [bot.activateBlock(block, direction?: Vec3, cursorPos?: Vec3)](#botactivateblockblock-direction-vec3-cursorpos-vec3)
       - [bot.activateEntity(entity)](#botactivateentityentity)
@@ -1962,6 +1966,27 @@ It rejects as soon as the server refuses the placement (for example because an e
    indicating which face of the `referenceBlock` to place the block against.
 
 The new block will be placed at `referenceBlock.position.plus(faceVector)`.
+
+#### bot.entityInteractionRange()
+
+The distance the server lets the bot reach entities at, read from the `entity_interaction_range`
+attribute the server sends (1.20.5+) and falling back to vanilla's 3.0. Creative mode adds to it.
+
+#### bot.blockInteractionRange()
+
+The same for blocks: the `block_interaction_range` attribute, or vanilla's 4.5.
+
+#### bot.canInteractWithEntity(entity, buffer = 0)
+
+Whether `entity`'s hitbox is inside `bot.entityInteractionRange() + buffer` of the bot's eye. This
+is the check vanilla makes, and the one the server repeats when an interact arrives, so it answers
+"could a player standing here have clicked that?". Interactions sent from further away are dropped
+without a reply. The server gives itself 3.0 of slack, so `buffer` is the knob for asking which of
+the two questions you mean.
+
+#### bot.canInteractWithBlock(block, buffer = 0)
+
+The same for a block, measured against its own cube.
 
 #### bot.placeEntity(referenceBlock, faceVector)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -326,6 +326,21 @@ export interface Bot extends TypedEmitter<BotEvents> {
 
   placeBlock: (referenceBlock: Block, faceVector: Vec3) => Promise<void>
 
+  /** The reach the server grants for entities, from the `entity_interaction_range` attribute
+   *  (1.20.5+), or vanilla's 3.0 default. */
+  entityInteractionRange (): number
+
+  /** The reach the server grants for blocks, from the `block_interaction_range` attribute
+   *  (1.20.5+), or vanilla's 4.5 default. */
+  blockInteractionRange (): number
+
+  /** Whether the entity's hitbox is within `entityInteractionRange() + buffer` of the bot's eye,
+   *  the way the server checks an interact packet. */
+  canInteractWithEntity (entity: Entity, buffer?: number): boolean
+
+  /** Whether the block's cube is within `blockInteractionRange() + buffer` of the bot's eye. */
+  canInteractWithBlock (block: Block, buffer?: number): boolean
+
   placeEntity: (referenceBlock: Block, faceVector: Vec3) => Promise<Entity>
 
   activateBlock: (block: Block, direction?: Vec3, cursorPos?: Vec3) => Promise<void>

--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -1,0 +1,38 @@
+// https://minecraft.wiki/w/Attribute#Operations
+function getAttributeValue (prop) {
+  let X = prop.value
+  for (const mod of prop.modifiers) {
+    if (mod.operation !== 0) continue
+    X += mod.amount
+  }
+  let Y = X
+  for (const mod of prop.modifiers) {
+    if (mod.operation !== 1) continue
+    Y += X * mod.amount
+  }
+  for (const mod of prop.modifiers) {
+    if (mod.operation !== 2) continue
+    Y += Y * mod.amount
+  }
+  return Y
+}
+
+// The key an attribute arrives under is not stable across versions or protocol builds - the same
+// attribute shows up as `generic.armor`, `minecraft:armor` or `armor`, and the interaction ranges
+// as `player.entity_interaction_range` - so match on the last segment, which is.
+function findAttribute (entity, name) {
+  const attributes = entity && entity.attributes
+  if (!attributes) return null
+  if (attributes[name]) return attributes[name]
+  for (const key of Object.keys(attributes)) {
+    if (key.split(/[:.]/).pop() === name) return attributes[key]
+  }
+  return null
+}
+
+function attributeValue (entity, name, fallback) {
+  const attribute = findAttribute(entity, name)
+  return attribute ? getAttributeValue(attribute) : fallback
+}
+
+module.exports = { getAttributeValue, findAttribute, attributeValue }

--- a/lib/plugins/entities.js
+++ b/lib/plugins/entities.js
@@ -1,6 +1,7 @@
 const { Vec3 } = require('vec3')
 const conv = require('../conversions')
 const mojangson = require('mojangson')
+const { attributeValue } = require('../attributes')
 // These values are only accurate for versions 1.14 and above (crouch hitbox changes)
 // Todo: hitbox sizes for sleeping, swimming/crawling, and flying with elytra
 const PLAYER_HEIGHT = 1.8
@@ -926,6 +927,43 @@ function inject (bot) {
         location: new Vec3(0, 0, 0)
       })
     }
+  }
+
+  // Vanilla Player.DEFAULT_ENTITY_INTERACTION_RANGE / DEFAULT_BLOCK_INTERACTION_RANGE. From
+  // 1.20.5 the server sends the live values as attributes (creative adds to both), and mineflayer
+  // already folds entity_update_attributes into entity.attributes.
+  const DEFAULT_ENTITY_INTERACTION_RANGE = 3.0
+  const DEFAULT_BLOCK_INTERACTION_RANGE = 4.5
+
+  bot.entityInteractionRange = () => attributeValue(bot.entity, 'entity_interaction_range', DEFAULT_ENTITY_INTERACTION_RANGE)
+  bot.blockInteractionRange = () => attributeValue(bot.entity, 'block_interaction_range', DEFAULT_BLOCK_INTERACTION_RANGE)
+
+  // Player.isWithinEntityInteractionRange: the squared distance from the eye to the target's
+  // bounding box, not centre to centre. `buffer` is the slack the server allows itself (3.0 in
+  // ServerGamePacketListenerImpl); leave it at 0 to ask what the client could have aimed at.
+  function distanceToBoxSq (eye, min, max) {
+    const dx = Math.max(min.x - eye.x, 0, eye.x - max.x)
+    const dy = Math.max(min.y - eye.y, 0, eye.y - max.y)
+    const dz = Math.max(min.z - eye.z, 0, eye.z - max.z)
+    return dx * dx + dy * dy + dz * dz
+  }
+
+  bot.canInteractWithEntity = (entity, buffer = 0) => {
+    if (!entity || !bot.entity) return false
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight ?? 1.62, 0)
+    const halfWidth = (entity.width ?? 0.6) / 2
+    const min = entity.position.offset(-halfWidth, 0, -halfWidth)
+    const max = entity.position.offset(halfWidth, entity.height ?? 1.8, halfWidth)
+    const range = bot.entityInteractionRange() + buffer
+    return distanceToBoxSq(eye, min, max) < range * range
+  }
+
+  // Player.isWithinBlockInteractionRange: the eye against the block's own unit cube.
+  bot.canInteractWithBlock = (block, buffer = 0) => {
+    if (!block || !bot.entity) return false
+    const eye = bot.entity.position.offset(0, bot.entity.eyeHeight ?? 1.62, 0)
+    const range = bot.blockInteractionRange() + buffer
+    return distanceToBoxSq(eye, block.position, block.position.offset(1, 1, 1)) < range * range
   }
 
   function fetchEntity (id) {

--- a/lib/plugins/explosion.js
+++ b/lib/plugins/explosion.js
@@ -1,4 +1,5 @@
 const { Vec3 } = require('vec3')
+const { getAttributeValue } = require('../attributes')
 
 module.exports = inject
 
@@ -34,25 +35,6 @@ function getDamageAfterAbsorb (damages, armorValue, toughness) {
   const var3 = 2 + toughness / 4
   const var4 = Math.min(Math.max(armorValue - damages / var3, armorValue * 0.2), 20)
   return damages * (1 - var4 / 25)
-}
-
-// https://minecraft.wiki/w/Attribute#Operations
-function getAttributeValue (prop) {
-  let X = prop.value
-  for (const mod of prop.modifiers) {
-    if (mod.operation !== 0) continue
-    X += mod.amount
-  }
-  let Y = X
-  for (const mod of prop.modifiers) {
-    if (mod.operation !== 1) continue
-    Y += X * mod.amount
-  }
-  for (const mod of prop.modifiers) {
-    if (mod.operation !== 2) continue
-    Y += Y * mod.amount
-  }
-  return Y
 }
 
 function inject (bot) {

--- a/test/interactionRangeTest.js
+++ b/test/interactionRangeTest.js
@@ -1,0 +1,74 @@
+/* eslint-env mocha */
+
+const assert = require('assert')
+const EventEmitter = require('events')
+const Vec3 = require('vec3').Vec3
+const registryLoader = require('prismarine-registry')
+
+// entities.js only needs a registry, a packet source and an entity to hang the helpers off.
+function fakeBot (version = '1.21.4') {
+  const registry = registryLoader(version)
+  const bot = new EventEmitter()
+  bot.registry = registry
+  bot.version = version
+  bot.supportFeature = registry.supportFeature.bind(registry)
+  bot._client = new EventEmitter()
+  bot._client.write = () => {}
+  bot.entities = {}
+  bot.players = {}
+  bot.entity = { id: 1, position: new Vec3(0.5, 64, 0.5), eyeHeight: 1.62, width: 0.6, height: 1.8 }
+  require('../lib/plugins/entities')(bot, {})
+  bot.entity = bot.entities[1] ?? bot.entity
+  bot.entity.position = new Vec3(0.5, 64, 0.5)
+  bot.entity.eyeHeight = 1.62
+  return bot
+}
+
+const villagerAt = (x, y, z) => ({ position: new Vec3(x, y, z), width: 0.6, height: 1.95, name: 'villager' })
+
+describe('interaction range', () => {
+  it('falls back to the vanilla defaults when the server sends no attributes', () => {
+    const bot = fakeBot()
+    assert.strictEqual(bot.entityInteractionRange(), 3.0)
+    assert.strictEqual(bot.blockInteractionRange(), 4.5)
+  })
+
+  it('reads the values the server sends, whatever key they arrive under', () => {
+    const bot = fakeBot()
+    bot.entity.attributes = {
+      'player.entity_interaction_range': { value: 6, modifiers: [] },
+      'minecraft:block_interaction_range': { value: 9.5, modifiers: [] }
+    }
+    assert.strictEqual(bot.entityInteractionRange(), 6)
+    assert.strictEqual(bot.blockInteractionRange(), 9.5)
+  })
+
+  it('applies attribute modifiers', () => {
+    const bot = fakeBot()
+    bot.entity.attributes = { 'player.entity_interaction_range': { value: 3, modifiers: [{ operation: 0, amount: 2 }] } }
+    assert.strictEqual(bot.entityInteractionRange(), 5)
+  })
+
+  it('measures from the eye to the target hitbox, as vanilla does', () => {
+    // The live measurement this came from: a shopkeeper this bot could not open at 3.15 blocks of
+    // feet-to-feet distance, and could at 2.80.
+    const bot = fakeBot()
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    assert.strictEqual(bot.canInteractWithEntity(villagerAt(0.5, 64, 3.65)), true, '3.15 feet-to-feet is 2.85 eye-to-box')
+    assert.strictEqual(bot.canInteractWithEntity(villagerAt(0.5, 64, 4.06)), false, '3.56 feet-to-feet is out of reach')
+  })
+
+  it('lets the caller ask with the slack the server allows itself', () => {
+    const bot = fakeBot()
+    const far = villagerAt(0.5, 64, 5.5)
+    assert.strictEqual(bot.canInteractWithEntity(far), false)
+    assert.strictEqual(bot.canInteractWithEntity(far, 3.0), true)
+  })
+
+  it('measures a block against its own cube', () => {
+    const bot = fakeBot()
+    bot.entity.position = new Vec3(0.5, 64, 0.5)
+    assert.strictEqual(bot.canInteractWithBlock({ position: new Vec3(0, 64, 4) }), true)
+    assert.strictEqual(bot.canInteractWithBlock({ position: new Vec3(0, 64, 7) }), false)
+  })
+})


### PR DESCRIPTION
### Problem

An interact packet sent from out of reach is dropped by the server without a reply. So a bot 20 cm too far from a shopkeeper gets no window, no error, and no chat line — and nothing in the API mentions a range, so working out what happened takes a while. Two dead ends in one session came down to this:

```js
// a walled-in BedWars shopkeeper; feet-to-feet distance in the comment
d = 3.15  ->  bot.activateEntity(shop)   // no windowOpen in 6 s, no error
d = 2.80  ->  bot.activateEntity(shop)   // 'Shop - Quickbuy'

d = 3.56  ->  bot.attack(npc)            // nothing
d = 2.84  ->  bot.attack(npc)            // the NPC's menu opens
```

The server has been sending the exact numbers since 1.20.5, and mineflayer already folds them into `bot.entity.attributes` and then never reads them:

```js
bot.entity.attributes['player.entity_interaction_range']  // { value: 3, modifiers: [] }
bot.entity.attributes['player.block_interaction_range']   // { value: 4.5, modifiers: [] }
```

### What this adds

```js
bot.entityInteractionRange()                    // the attribute, else vanilla's 3.0
bot.blockInteractionRange()                     // the attribute, else vanilla's 4.5
bot.canInteractWithEntity(entity, buffer = 0)
bot.canInteractWithBlock(block, buffer = 0)
```

The predicates follow vanilla exactly (26.1 `Player.java`):

```java
public boolean isWithinEntityInteractionRange(final AABB aabb, final double buffer) {
    double maxRange = this.entityInteractionRange() + buffer;
    double distanceToSq = aabb.distanceToSqr(this.getEyePosition());
    return distanceToSq < maxRange * maxRange;
}
```

— squared distance from the **eye** to the target's **bounding box**, not centre to centre, which is a real difference for a 1.95-tall villager you are standing next to. `buffer` is the slack the server gives itself (`isWithinEntityInteractionRange(targetBounds, 3.0)` in `ServerGamePacketListenerImpl`), so a caller can ask either "could a player standing here have clicked that?" (`0`) or "will this particular server accept it?" (`3.0`).

The attribute lookup matches on the last segment of the key, because the same attribute arrives as `generic.armor`, `minecraft:armor` or `armor` depending on the version and protocol build, and the ranges as `player.entity_interaction_range`. `getAttributeValue` moves out of `plugins/explosion.js` into `lib/attributes.js` with it, unchanged, rather than existing twice.

### No behaviour change

Nothing calls the predicates. They are what an out-of-reach check inside `attack`/`activateEntity` would be built on, but making those throw is a breaking change for every combat plugin that swings in a loop, so it belongs in its own PR (and probably behind a flag). This PR is just the numbers and the geometry, so that a caller can do the check today:

```js
if (!bot.canInteractWithEntity(villager)) await bot.pathfinder.goto(new goals.GoalNear(...))
bot.activateEntity(villager)
```

### Tests

`test/interactionRangeTest.js` injects the entities plugin against a stub bot — no server — and pins the vanilla defaults, both attribute spellings, the modifier arithmetic, the `buffer` argument, the block cube, and the eye-to-hitbox geometry against the two live measurements above (3.15 feet-to-feet is 2.85 eye-to-box and reachable; 3.56 is not).

Reported with the full session context in u9g/bot-harness#92.
